### PR TITLE
Add automatic ID auto-generation attribute

### DIFF
--- a/BareMetalWeb.Host/RouteHandlers.cs
+++ b/BareMetalWeb.Host/RouteHandlers.cs
@@ -1834,6 +1834,8 @@ public sealed class RouteHandlers : IRouteHandlers
             }
 
             ApplyAuditInfo(instance, (await UserAuth.GetUserAsync(context, context.RequestAborted).ConfigureAwait(false))?.UserName ?? "system", isCreate);
+            if (isCreate)
+                await DataScaffold.ApplyAutoIdAsync(meta, instance, context.RequestAborted).ConfigureAwait(false);
             await DataScaffold.SaveAsync(meta, instance);
             if (isCreate)
                 created++;
@@ -1950,6 +1952,7 @@ public sealed class RouteHandlers : IRouteHandlers
         }
 
         ApplyAuditInfo(instance, (await UserAuth.GetUserAsync(context, context.RequestAborted).ConfigureAwait(false))?.UserName ?? "system", isCreate: true);
+        await DataScaffold.ApplyAutoIdAsync(meta, instance, context.RequestAborted).ConfigureAwait(false);
         await DataScaffold.SaveAsync(meta, instance);
         var newId = instance is BaseDataObject dataObject ? DataScaffold.GetIdValue(dataObject) : null;
         var keyQuery = string.IsNullOrWhiteSpace(newApiKey) ? string.Empty : $"&apikey={WebUtility.UrlEncode(newApiKey)}";
@@ -2240,6 +2243,7 @@ public sealed class RouteHandlers : IRouteHandlers
 
         var clone = CreateClone(meta, source);
         ApplyAuditInfo(clone, (await UserAuth.GetUserAsync(context, context.RequestAborted).ConfigureAwait(false))?.UserName ?? "system", isCreate: true);
+        await DataScaffold.ApplyAutoIdAsync(meta, clone, context.RequestAborted).ConfigureAwait(false);
         await DataScaffold.SaveAsync(meta, clone);
 
         var newId = DataScaffold.GetIdValue(clone) ?? string.Empty;
@@ -2422,6 +2426,7 @@ public sealed class RouteHandlers : IRouteHandlers
         }
 
         ApplyAuditInfo(instance, (await UserAuth.GetUserAsync(context, context.RequestAborted).ConfigureAwait(false))?.UserName ?? "system", isCreate: true);
+        await DataScaffold.ApplyAutoIdAsync(meta, instance, context.RequestAborted).ConfigureAwait(false);
         await DataScaffold.SaveAsync(meta, instance);
         context.Response.StatusCode = StatusCodes.Status201Created;
         await WriteJsonResponseAsync(context, BuildApiModel(meta, instance));


### PR DESCRIPTION
## Summary

Adds opt-in auto-ID generation for data entities via the `[DataEntity]` attribute's new `IdGeneration` property.

### Changes

**New files (already on main from prior commit):**
- `AutoIdStrategy.cs` — Enum with `Guid`, `Sequential`, `None` strategies
- `IdSequenceProvider.cs` — Thread-safe per-entity sequential counter with lazy seeding from existing records

**Modified files (already on main from prior commit):**
- `DataEntityAttribute.cs` — Added `IdGeneration` property (default: `Guid`)
- `DataScaffold.cs` — Added `IdGeneration` to `DataEntityMetadata` record and `ApplyAutoIdAsync()` method

**Modified files (this PR):**
- `RouteHandlers.cs` — Wired `ApplyAutoIdAsync` into all 4 create paths: form create, API POST, clone, and CSV import

### Usage

```csharp
// Sequential auto-incrementing IDs (1, 2, 3, ...)
[DataEntity("Products", IdGeneration = AutoIdStrategy.Sequential)]
public class Product : RenderableDataObject { ... }

// Explicit GUID (default, existing behavior)
[DataEntity("Customers", IdGeneration = AutoIdStrategy.Guid)]
public class Customer : RenderableDataObject { ... }

// Caller must provide ID
[DataEntity("Settings", IdGeneration = AutoIdStrategy.None)]
public class Setting : RenderableDataObject { ... }
```

Fixes #23