### PR TITLE
Refactor startup into UseBareMetalWeb() extension method

### DIFF
--- a/BareMetalWeb.Host/BareMetalWebExtensions.cs
+++ b/BareMetalWeb.Host/BareMetalWebExtensions.cs
@@ -1,0 +1,136 @@
+using System.Reflection;
+using BareMetalWeb.Core;
+using BareMetalWeb.Core.Host;
+using BareMetalWeb.Core.Interfaces;
+using BareMetalWeb.Data;
+using BareMetalWeb.Data.Interfaces;
+using BareMetalWeb.Interfaces;
+using BareMetalWeb.Rendering;
+using BareMetalWeb.Rendering.Interfaces;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+
+namespace BareMetalWeb.Host;
+
+/// <summary>
+/// Single entry point for wiring up the full BareMetalWeb stack.
+/// Usage:
+///   var app = WebApplication.Create(args);
+///   await app.UseBareMetalWeb();
+///   app.Run();
+/// </summary>
+public static class BareMetalWebExtensions
+{
+    /// <summary>
+    /// Configures and starts the full BareMetalWeb stack: data store, rendering,
+    /// authentication, routing, static files, CORS, HTTPS, and proxy support.
+    /// Optionally pass <paramref name="configureRoutes"/> to register additional routes.
+    /// </summary>
+    public static async Task UseBareMetalWeb(
+        this WebApplication app,
+        Action<BareMetalWebServer, IRouteHandlers, IPageInfoFactory, IHtmlTemplate>? configureRoutes = null)
+    {
+        // Logger & data root
+        IBufferedLogger logger = ProgramSetup.CreateLogger(app);
+        logger.LogInfo("Starting BareMetalWeb server...");
+
+        var contentRoot = app.Environment.ContentRootPath;
+        var dataRoot = app.Configuration.GetValue("Data:Root", Path.Combine(contentRoot, "Data"));
+        ProgramSetup.ResetDataIfRequested(app, dataRoot, logger);
+        CookieProtection.ConfigureKeyRoot(dataRoot);
+
+        // Data store
+        ISchemaAwareObjectSerializer serializer = BinaryObjectSerializer.CreateDefault(dataRoot);
+        IDataQueryEvaluator queryEvaluator = new DataQueryEvaluator();
+        try { _ = Assembly.Load("BareMetalWeb.UserClasses"); } catch { }
+        DataEntityRegistry.RegisterAllEntities();
+        IDataObjectStore dataStore = ProgramSetup.CreateDataStore(app, serializer, queryEvaluator, logger);
+
+        // Permissions
+        var entityPermissions = DataScaffold.Entities
+            .SelectMany(e => (e.Permissions ?? string.Empty)
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        var rootPermissionSet = new HashSet<string>(entityPermissions, StringComparer.OrdinalIgnoreCase)
+        {
+            "admin",
+            "monitoring"
+        };
+        await ProgramSetup.EnsureRootPermissionsAsync(logger, rootPermissionSet.ToArray());
+
+        // Rendering
+        IHtmlFragmentStore fragmentStore = new HtmlFragmentStore();
+        IHtmlFragmentRenderer fragmentRenderer = new HtmlFragmentRenderer(fragmentStore);
+        IHtmlRenderer htmlRenderer = new HtmlRenderer(fragmentRenderer);
+        ITemplateStore templateStore = new TemplateStore();
+        IPageInfoFactory pageInfoFactory = new PageInfoFactory();
+        IMetricsTracker metricsTracker = new MetricsTracker();
+        IClientRequestTracker throttling = ProgramSetup.CreateClientRequestTracker(app, logger);
+
+        // Route handlers
+        bool allowAccountCreation = app.Configuration.GetValue("Auth:AllowAccountCreation", false);
+        IRouteHandlers routeHandlers = new RouteHandlers(htmlRenderer, templateStore, allowAccountCreation, dataRoot);
+        IHtmlTemplate mainTemplate = templateStore.Get("Index");
+        CancellationTokenSource cts = new CancellationTokenSource();
+
+        // App info
+        BareMetalWebServer appInfo = ProgramSetup.CreateAppInfo(
+            app, logger, htmlRenderer, pageInfoFactory, mainTemplate, metricsTracker, throttling, cts);
+
+        // Infrastructure configuration
+        ProgramSetup.ConfigureStaticFiles(app, appInfo);
+        ProgramSetup.ConfigureCors(app, appInfo);
+        ProgramSetup.ConfigureHttps(app, appInfo);
+        ProgramSetup.ConfigureProxyRoutes(app, appInfo, logger, pageInfoFactory);
+
+        // Built-in routes
+        appInfo.RegisterStaticRoutes(routeHandlers, pageInfoFactory, mainTemplate);
+        appInfo.RegisterAuthRoutes(routeHandlers, pageInfoFactory, mainTemplate, allowAccountCreation);
+        appInfo.RegisterMonitoringRoutes(routeHandlers, pageInfoFactory, mainTemplate);
+        appInfo.RegisterAdminRoutes(routeHandlers, pageInfoFactory, mainTemplate);
+        appInfo.RegisterDataRoutes(routeHandlers, pageInfoFactory, mainTemplate);
+        appInfo.RegisterApiRoutes(routeHandlers, pageInfoFactory);
+
+        // Custom routes from caller
+        configureRoutes?.Invoke(appInfo, routeHandlers, pageInfoFactory, mainTemplate);
+
+        // Finalise
+        await appInfo.BuildAppInfoMenuOptionsAsync();
+        await appInfo.WireUpRequestHandlingAndLoggerAsyncLifetime();
+
+        app.Lifetime.ApplicationStarted.Register(() =>
+        {
+            var addresses = app.Services.GetService(typeof(IServer)) is IServer server
+                ? server.Features.Get<IServerAddressesFeature>()?.Addresses
+                : null;
+            var list = addresses is null || addresses.Count == 0
+                ? (app.Urls ?? Array.Empty<string>())
+                : addresses;
+            var display = list.Any() ? string.Join(", ", list) : "unknown";
+            logger.LogInfo($"BareMetalWeb server is ready - listening for requests on {display}");
+            Console.WriteLine($"BareMetalWeb server is ready - listening for requests on {display}");
+
+            var httpsConfig = $"HTTPS redirect settings: mode={appInfo.HttpsRedirectMode}, trustForwardedHeaders={appInfo.TrustForwardedHeaders}, redirectHost={(string.IsNullOrWhiteSpace(appInfo.HttpsRedirectHost) ? "(auto)" : appInfo.HttpsRedirectHost)}, redirectPort={(appInfo.HttpsRedirectPort.HasValue ? appInfo.HttpsRedirectPort.Value.ToString() : "(auto)")}";
+            logger.LogInfo(httpsConfig);
+            Console.WriteLine(httpsConfig);
+
+            var httpsAddress = list.FirstOrDefault(a => a.StartsWith("https://", StringComparison.OrdinalIgnoreCase));
+            appInfo.HttpsEndpointAvailable = !string.IsNullOrWhiteSpace(httpsAddress);
+            if (appInfo.HttpsEndpointAvailable && Uri.TryCreate(httpsAddress, UriKind.Absolute, out var httpsUri))
+            {
+                if (string.IsNullOrWhiteSpace(appInfo.HttpsRedirectHost))
+                    appInfo.HttpsRedirectHost = httpsUri.Host;
+                if (!appInfo.HttpsRedirectPort.HasValue || appInfo.HttpsRedirectPort.Value <= 0)
+                    appInfo.HttpsRedirectPort = httpsUri.IsDefaultPort ? 443 : httpsUri.Port;
+            }
+
+            if (!appInfo.HttpsEndpointAvailable)
+            {
+                var warn = "HTTPS endpoint not configured. Configure HTTPS (ASPNETCORE_URLS / Kestrel) to expose an https:// address.";
+                logger.LogInfo(warn);
+                Console.WriteLine(warn);
+            }
+        });
+    }
+}

--- a/BareMetalWeb.Host/Program.cs
+++ b/BareMetalWeb.Host/Program.cs
@@ -1,441 +1,251 @@
-using System.Reflection;
 using System.Text.Json;
 using BareMetalWeb.Core;
 using BareMetalWeb.Core.Host;
-using BareMetalWeb.Core.Interfaces;
 using BareMetalWeb.Data;
 using BareMetalWeb.Data.DataObjects;
-using BareMetalWeb.Data.Interfaces;
 using BareMetalWeb.Host;
-using BareMetalWeb.Interfaces;
-using BareMetalWeb.Rendering;
-using BareMetalWeb.Rendering.Interfaces;
-using Microsoft.AspNetCore.Hosting.Server;
-using Microsoft.AspNetCore.Hosting.Server.Features;
 
-// Setup 
 WebApplication app = WebApplication.Create();
-IBufferedLogger logger = ProgramSetup.CreateLogger(app);
-logger.LogInfo("Starting BareMetalWeb server...");
 
-var contentRoot = app.Environment.ContentRootPath;
-var dataRoot = app.Configuration.GetValue("Data:Root", Path.Combine(contentRoot, "Data"));
-ProgramSetup.ResetDataIfRequested(app, dataRoot, logger);
-CookieProtection.ConfigureKeyRoot(dataRoot);
-
-ISchemaAwareObjectSerializer serializer = BinaryObjectSerializer.CreateDefault(dataRoot);
-IDataQueryEvaluator queryEvaluator = new DataQueryEvaluator();
-try
+await app.UseBareMetalWeb(configureRoutes: (appInfo, routeHandlers, pageInfoFactory, mainTemplate) =>
 {
-    _ = Assembly.Load("BareMetalWeb.UserClasses");
-}
-catch
-{
-    // Optional library; ignore if not present.
-}
-DataEntityRegistry.RegisterAllEntities();
-IDataObjectStore dataStore = ProgramSetup.CreateDataStore(app, serializer, queryEvaluator, logger);
-var entityPermissions = DataScaffold.Entities
-    .SelectMany(entity => (entity.Permissions ?? string.Empty)
-        .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-    .Distinct(StringComparer.OrdinalIgnoreCase)
-    .ToArray();
-    
-var rootPermissionSet = new HashSet<string>(entityPermissions, StringComparer.OrdinalIgnoreCase)
-{
-    "admin",
-    "monitoring"
-};
-
-await ProgramSetup.EnsureRootPermissionsAsync(logger, rootPermissionSet.ToArray());
-
-IHtmlFragmentStore fragmentStore = new HtmlFragmentStore();
-IHtmlFragmentRenderer fragmentRenderer = new HtmlFragmentRenderer(fragmentStore);
-IHtmlRenderer htmlRenderer = new HtmlRenderer(fragmentRenderer);
-ITemplateStore templateStore = new TemplateStore();
-IPageInfoFactory pageInfoFactory = new PageInfoFactory();
-IMetricsTracker metricsTracker = new MetricsTracker();
-IClientRequestTracker throttling = ProgramSetup.CreateClientRequestTracker(app, logger);
-
-bool allowAccountCreation = app.Configuration.GetValue("Auth:AllowAccountCreation", false);
-IRouteHandlers routeHandlers = new RouteHandlers(htmlRenderer, templateStore, allowAccountCreation, dataRoot);
-IHtmlTemplate mainTemplate = templateStore.Get("Index");
-IHtmlTemplate blankTemplate = templateStore.Get("Blank");
-CancellationTokenSource cts = new CancellationTokenSource();
-
-BareMetalWebServer appInfo = ProgramSetup.CreateAppInfo(app, logger, htmlRenderer, pageInfoFactory, mainTemplate, metricsTracker, throttling, cts);
-ProgramSetup.ConfigureStaticFiles(app, appInfo);
-ProgramSetup.ConfigureCors(app, appInfo);
-ProgramSetup.ConfigureHttps(app, appInfo);
-ProgramSetup.ConfigureProxyRoutes(app, appInfo, logger, pageInfoFactory);
-
-// Register routes using plugin-like extension methods
-appInfo.RegisterStaticRoutes(routeHandlers, pageInfoFactory, mainTemplate);
-appInfo.RegisterAuthRoutes(routeHandlers, pageInfoFactory, mainTemplate, allowAccountCreation);
-appInfo.RegisterMonitoringRoutes(routeHandlers, pageInfoFactory, mainTemplate);
-appInfo.RegisterAdminRoutes(routeHandlers, pageInfoFactory, mainTemplate);
-appInfo.RegisterDataRoutes(routeHandlers, pageInfoFactory, mainTemplate);
-appInfo.RegisterApiRoutes(routeHandlers, pageInfoFactory);
-// Standard render routes
-appInfo.RegisterRoute("GET /", new RouteHandlerData(pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "message" }, new[] { "Home", "<p></p>" }, "Public", false, 60), routeHandlers.DefaultPageHandler)); // new method to register routes
-// appInfo.RegisterRoute("GET /about", new RouteHandlerData(pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "message" }, new[] { "About", "<p>This is the about page.</p>" }, "Public", true, 60), routeHandlers.DefaultPageHandler));
-// appInfo.RegisterRoute("GET /about/{what}", new RouteHandlerData(pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "message" }, new[] { "About", "<p>This is the about page.</p>" }, "Public", false, 60), routeHandlers.DefaultPageHandler));
-appInfo.RegisterRoute("GET /metrics", new RouteHandlerData(pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "message" }, new[] { "Metric Viewer", "" }, "monitoring", true, 1, navGroup: "System", navAlignment: NavAlignment.Right), routeHandlers.BuildPageHandler(context =>
-{
-    var app = context.GetApp()!;
-    app.Metrics.GetMetricTable(out string[] tableColumns, out string[][] tableRows);
-    context.SetStringValue("title", "Metric Viewer");
-    context.AddTable(tableColumns, tableRows);
-})));
-appInfo.RegisterRoute("GET /metrics/json", new RouteHandlerData(pageInfoFactory.RawPage("monitoring", false), routeHandlers.MetricsJsonHandler));
-appInfo.RegisterRoute("GET /admin/logs", new RouteHandlerData(pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "message" }, new[] { "Logs", "" }, "monitoring", true, 1, navGroup: "System", navAlignment: NavAlignment.Right), routeHandlers.LogsViewerHandler));
-appInfo.RegisterRoute("GET /admin/logs/prune", new RouteHandlerData(pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "message" }, new[] { "Prune Logs", "" }, "monitoring", false, 1), routeHandlers.LogsPruneHandler));
-appInfo.RegisterRoute("POST /admin/logs/prune", new RouteHandlerData(pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "message" }, new[] { "Prune Logs", "" }, "monitoring", false, 1), routeHandlers.LogsPrunePostHandler));
-appInfo.RegisterRoute("GET /admin/logs/download", new RouteHandlerData(pageInfoFactory.RawPage("monitoring", false), routeHandlers.LogsDownloadHandler));
-appInfo.RegisterRoute("GET /admin/sample-data", new RouteHandlerData(pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "message" }, new[] { "Generate Sample Data", "" }, "admin", true, 1, navGroup: "System", navAlignment: NavAlignment.Right), routeHandlers.SampleDataHandler));
-appInfo.RegisterRoute("POST /admin/sample-data", new RouteHandlerData(pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "message" }, new[] { "Generate Sample Data", "" }, "admin", false, 1), routeHandlers.SampleDataPostHandler));
-appInfo.RegisterRoute("GET /topips", new RouteHandlerData(pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "message" }, new[] { "Top IPs", "" }, "monitoring", true, 1, navGroup: "System", navAlignment: NavAlignment.Right), routeHandlers.BuildPageHandler(context =>
-{
-    var app = context.GetApp()!;
-    app.ClientRequests.GetTopClientsTable(20, out var tableColumns, out var tableRows);
-    context.SetStringValue("title", "Top IPs");
-    context.AddTable(tableColumns, tableRows);
-})));
-appInfo.RegisterRoute("GET /suspiciousips", new RouteHandlerData(pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "message" }, new[] { "Suspicious IPs", "" }, "monitoring", true, 1, navGroup: "System", navAlignment: NavAlignment.Right), routeHandlers.BuildPageHandler(context =>
-{
-    var app = context.GetApp()!;
-    app.ClientRequests.GetSuspiciousClientsTable(20, out var tableColumns, out var tableRows);
-    context.SetStringValue("title", "Suspicious IPs");
-    context.AddTable(tableColumns, tableRows);
-})));
-appInfo.RegisterRoute("GET /login", new RouteHandlerData(pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "message" }, new[] { "Login", "" }, "AnonymousOnly", true, 1, navAlignment: NavAlignment.Right, navRenderStyle: NavRenderStyle.Button, navColorClass: "btn-success"), routeHandlers.LoginHandler));
-appInfo.RegisterRoute("POST /login", new RouteHandlerData(pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "message" }, new[] { "Login", "" }, "AnonymousOnly", false, 1), routeHandlers.LoginPostHandler));
-appInfo.RegisterRoute("GET /mfa", new RouteHandlerData(pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "message" }, new[] { "Verify MFA", "" }, "AnonymousOnly", false, 1), routeHandlers.MfaChallengeHandler));
-appInfo.RegisterRoute("POST /mfa", new RouteHandlerData(pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "message" }, new[] { "Verify MFA", "" }, "AnonymousOnly", false, 1), routeHandlers.MfaChallengePostHandler));
-if (allowAccountCreation)
-{
-    appInfo.RegisterRoute("GET /register", new RouteHandlerData(pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "message" }, new[] { "Create Account", "" }, "AnonymousOnly", false, 1, navAlignment: NavAlignment.Right), routeHandlers.RegisterHandler));
-    appInfo.RegisterRoute("POST /register", new RouteHandlerData(pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "message" }, new[] { "Create Account", "" }, "AnonymousOnly", false, 1), routeHandlers.RegisterPostHandler));
-}
-appInfo.RegisterRoute("GET /logout", new RouteHandlerData(pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "message" }, new[] { "Logout", "" }, "Authenticated", false, 1), routeHandlers.LogoutHandler));
-appInfo.RegisterRoute("POST /logout", new RouteHandlerData(pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "message" }, new[] { "Logout", "" }, "Authenticated", false, 1), routeHandlers.LogoutPostHandler));
-appInfo.RegisterRoute("GET /account", new RouteHandlerData(pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "message" }, new[] { "Account", "" }, "Authenticated", true, 1, navAlignment: NavAlignment.Right), routeHandlers.AccountHandler));
-appInfo.RegisterRoute("GET /account/mfa", new RouteHandlerData(pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "message" }, new[] { "Multi-Factor Authentication", "" }, "Authenticated", true, 1), routeHandlers.MfaStatusHandler));
-appInfo.RegisterRoute("GET /account/mfa/setup", new RouteHandlerData(pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "message" }, new[] { "Enable MFA", "" }, "Authenticated", false, 1), routeHandlers.MfaSetupHandler));
-appInfo.RegisterRoute("POST /account/mfa/setup", new RouteHandlerData(pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "message" }, new[] { "Enable MFA", "" }, "Authenticated", false, 1), routeHandlers.MfaSetupPostHandler));
-appInfo.RegisterRoute("GET /account/mfa/reset", new RouteHandlerData(pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "message" }, new[] { "Reset MFA", "" }, "Authenticated", false, 1), routeHandlers.MfaResetHandler));
-appInfo.RegisterRoute("POST /account/mfa/reset", new RouteHandlerData(pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "message" }, new[] { "Reset MFA", "" }, "Authenticated", false, 1), routeHandlers.MfaResetPostHandler));
-appInfo.RegisterRoute("GET /setup", new RouteHandlerData(pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "message" }, new[] { "Setup", "" }, "AnonymousOnly", false, 1), routeHandlers.SetupHandler));
-appInfo.RegisterRoute("POST /setup", new RouteHandlerData(pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "message" }, new[] { "Setup", "" }, "AnonymousOnly", false, 1), routeHandlers.SetupPostHandler));
-appInfo.RegisterRoute("GET /admin/data", new RouteHandlerData(pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "message" }, new[] { "Data", "" }, "Authenticated", true, 1, navGroup: "Admin", navAlignment: NavAlignment.Right), routeHandlers.DataEntitiesHandler));
-appInfo.RegisterRoute("GET /admin/data/{type}", new RouteHandlerData(pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "message" }, new[] { "Data", "" }, "Authenticated", false, 1, navGroup: "Admin", navAlignment: NavAlignment.Right), routeHandlers.DataListHandler));
-appInfo.RegisterRoute("GET /admin/data/{type}/csv", new RouteHandlerData(pageInfoFactory.RawPage("Authenticated", false), routeHandlers.DataListCsvHandler));
-appInfo.RegisterRoute("GET /admin/data/{type}/html", new RouteHandlerData(pageInfoFactory.RawPage("Authenticated", false), routeHandlers.DataListHtmlHandler));
-appInfo.RegisterRoute("GET /admin/data/{type}/import", new RouteHandlerData(pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "message" }, new[] { "Import CSV", "" }, "Authenticated", false, 1), routeHandlers.DataImportHandler));
-appInfo.RegisterRoute("POST /admin/data/{type}/import", new RouteHandlerData(pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "message" }, new[] { "Import CSV", "" }, "Authenticated", false, 1), routeHandlers.DataImportPostHandler));
-appInfo.RegisterRoute("GET /admin/data/{type}/create", new RouteHandlerData(pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "message" }, new[] { "Create", "" }, "Authenticated", false, 1), routeHandlers.DataCreateHandler));
-appInfo.RegisterRoute("POST /admin/data/{type}/create", new RouteHandlerData(pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "message" }, new[] { "Create", "" }, "Authenticated", false, 1), routeHandlers.DataCreatePostHandler));
-appInfo.RegisterRoute("GET /admin/data/{type}/{id}", new RouteHandlerData(pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "message" }, new[] { "View", "" }, "Authenticated", false, 1), routeHandlers.DataViewHandler));
-appInfo.RegisterRoute("GET /admin/data/{type}/{id}/rtf", new RouteHandlerData(pageInfoFactory.RawPage("Authenticated", false), routeHandlers.DataViewRtfHandler));
-appInfo.RegisterRoute("GET /admin/data/{type}/{id}/html", new RouteHandlerData(pageInfoFactory.RawPage("Authenticated", false), routeHandlers.DataViewHtmlHandler));
-appInfo.RegisterRoute("GET /admin/data/{type}/{id}/edit", new RouteHandlerData(pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "message" }, new[] { "Edit", "" }, "Authenticated", false, 1), routeHandlers.DataEditHandler));
-appInfo.RegisterRoute("POST /admin/data/{type}/{id}/edit", new RouteHandlerData(pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "message" }, new[] { "Edit", "" }, "Authenticated", false, 1), routeHandlers.DataEditPostHandler));
-appInfo.RegisterRoute("POST /admin/data/{type}/{id}/clone", new RouteHandlerData(pageInfoFactory.RawPage("Authenticated", false), routeHandlers.DataClonePostHandler));
-appInfo.RegisterRoute("POST /admin/data/{type}/{id}/clone-edit", new RouteHandlerData(pageInfoFactory.RawPage("Authenticated", false), routeHandlers.DataCloneEditPostHandler));
-appInfo.RegisterRoute("GET /admin/data/{type}/{id}/delete", new RouteHandlerData(pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "message" }, new[] { "Delete", "" }, "Authenticated", false, 1), routeHandlers.DataDeleteHandler));
-appInfo.RegisterRoute("POST /admin/data/{type}/{id}/delete", new RouteHandlerData(pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "message" }, new[] { "Delete", "" }, "Authenticated", false, 1), routeHandlers.DataDeletePostHandler));
-
-appInfo.RegisterRoute("POST /api/device/code", new RouteHandlerData(pageInfoFactory.RawPage("Public", false), async context =>
-{
-    var dc = new DeviceCodeAuth
+    // Device code auth flow
+    appInfo.RegisterRoute("POST /api/device/code", new RouteHandlerData(pageInfoFactory.RawPage("Public", false), async context =>
     {
-        UserCode = DeviceCodeAuth.GenerateUserCode(),
-        DeviceCode = DeviceCodeAuth.GenerateDeviceCode(),
-        ExpiresUtc = DateTime.UtcNow.AddMinutes(15),
-        Status = "pending"
-    };
-    DataStoreProvider.Current.Save(dc);
-    var baseUrl = $"{context.Request.Scheme}://{context.Request.Host}";
-    var json = JsonSerializer.Serialize(new Dictionary<string, object>
-    {
-        ["device_code"] = dc.DeviceCode,
-        ["user_code"] = dc.UserCode,
-        ["verification_url"] = $"{baseUrl}/device",
-        ["expires_in"] = 900,
-        ["interval"] = 5
-    });
-    context.Response.ContentType = "application/json";
-    await context.Response.WriteAsync(json);
-}));
-appInfo.RegisterRoute("POST /api/device/token", new RouteHandlerData(pageInfoFactory.RawPage("Public", false), async context =>
-{
-    string body;
-    using (var reader = new System.IO.StreamReader(context.Request.Body))
-        body = await reader.ReadToEndAsync();
-    var deviceCode = "";
-    try { var doc = JsonDocument.Parse(body); deviceCode = doc.RootElement.GetProperty("device_code").GetString() ?? ""; } catch { }
-    if (string.IsNullOrEmpty(deviceCode))
-    {
-        context.Response.StatusCode = 400;
-        context.Response.ContentType = "application/json";
-        await context.Response.WriteAsync("{\"error\":\"missing device_code\"}");
-        return;
-    }
-    var all = DataStoreProvider.Current.Query<DeviceCodeAuth>(null).ToList();
-    var dc = all.FirstOrDefault(d => d.DeviceCode == deviceCode);
-    if (dc == null || dc.IsExpired(DateTime.UtcNow))
-    {
-        context.Response.ContentType = "application/json";
-        await context.Response.WriteAsync("{\"status\":\"expired\"}");
-        return;
-    }
-    if (dc.Status == "approved" && !string.IsNullOrEmpty(dc.UserId))
-    {
-        var user = await DataStoreProvider.Current.LoadAsync<User>(dc.UserId);
-        if (user != null)
+        var dc = new DeviceCodeAuth
         {
-            await UserAuth.SignInAsync(context, user, false);
-            dc.Status = "consumed";
-            DataStoreProvider.Current.Save(dc);
+            UserCode = DeviceCodeAuth.GenerateUserCode(),
+            DeviceCode = DeviceCodeAuth.GenerateDeviceCode(),
+            ExpiresUtc = DateTime.UtcNow.AddMinutes(15),
+            Status = "pending"
+        };
+        DataStoreProvider.Current.Save(dc);
+        var baseUrl = $"{context.Request.Scheme}://{context.Request.Host}";
+        var json = JsonSerializer.Serialize(new Dictionary<string, object>
+        {
+            ["device_code"] = dc.DeviceCode,
+            ["user_code"] = dc.UserCode,
+            ["verification_url"] = $"{baseUrl}/device",
+            ["expires_in"] = 900,
+            ["interval"] = 5
+        });
+        context.Response.ContentType = "application/json";
+        await context.Response.WriteAsync(json);
+    }));
+    appInfo.RegisterRoute("POST /api/device/token", new RouteHandlerData(pageInfoFactory.RawPage("Public", false), async context =>
+    {
+        string body;
+        using (var reader = new System.IO.StreamReader(context.Request.Body))
+            body = await reader.ReadToEndAsync();
+        var deviceCode = "";
+        try { var doc = JsonDocument.Parse(body); deviceCode = doc.RootElement.GetProperty("device_code").GetString() ?? ""; } catch { }
+        if (string.IsNullOrEmpty(deviceCode))
+        {
+            context.Response.StatusCode = 400;
             context.Response.ContentType = "application/json";
-            await context.Response.WriteAsync(JsonSerializer.Serialize(new Dictionary<string, object>
-            {
-                ["status"] = "approved",
-                ["user"] = user.DisplayName ?? user.UserName
-            }));
+            await context.Response.WriteAsync("{\"error\":\"missing device_code\"}");
             return;
         }
-    }
-    if (dc.Status == "denied")
-    {
+        var all = DataStoreProvider.Current.Query<DeviceCodeAuth>(null).ToList();
+        var dc = all.FirstOrDefault(d => d.DeviceCode == deviceCode);
+        if (dc == null || dc.IsExpired(DateTime.UtcNow))
+        {
+            context.Response.ContentType = "application/json";
+            await context.Response.WriteAsync("{\"status\":\"expired\"}");
+            return;
+        }
+        if (dc.Status == "approved" && !string.IsNullOrEmpty(dc.UserId))
+        {
+            var user = await DataStoreProvider.Current.LoadAsync<User>(dc.UserId);
+            if (user != null)
+            {
+                await UserAuth.SignInAsync(context, user, false);
+                dc.Status = "consumed";
+                DataStoreProvider.Current.Save(dc);
+                context.Response.ContentType = "application/json";
+                await context.Response.WriteAsync(JsonSerializer.Serialize(new Dictionary<string, object>
+                {
+                    ["status"] = "approved",
+                    ["user"] = user.DisplayName ?? user.UserName
+                }));
+                return;
+            }
+        }
+        if (dc.Status == "denied")
+        {
+            context.Response.ContentType = "application/json";
+            await context.Response.WriteAsync("{\"status\":\"denied\"}");
+            return;
+        }
         context.Response.ContentType = "application/json";
-        await context.Response.WriteAsync("{\"status\":\"denied\"}");
-        return;
-    }
-    context.Response.ContentType = "application/json";
-    await context.Response.WriteAsync("{\"status\":\"authorization_pending\"}");
-}));
-appInfo.RegisterRoute("GET /device", new RouteHandlerData(pageInfoFactory.RawPage("Public", false), async context =>
-{
-    var code = context.Request.Query.ContainsKey("code") ? context.Request.Query["code"].ToString() : "";
-    var msg = context.Request.Query.ContainsKey("msg") ? context.Request.Query["msg"].ToString() : "";
-    var sb = new System.Text.StringBuilder();
-    sb.Append("<!DOCTYPE html><html><head><meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">");
-    sb.Append("<title>Device Login - BareMetalWeb</title><style>");
-    sb.Append("*{margin:0;padding:0;box-sizing:border-box}");
-    sb.Append("body{font-family:system-ui,-apple-system,sans-serif;background:#1a1a2e;color:#e0e0e0;display:flex;justify-content:center;align-items:center;min-height:100vh}");
-    sb.Append(".card{background:#16213e;border-radius:12px;padding:40px;max-width:420px;width:100%;box-shadow:0 8px 32px rgba(0,0,0,.4);text-align:center}");
-    sb.Append("h1{font-size:1.6em;margin-bottom:8px;color:#fff}");
-    sb.Append("p{color:#a0a0b0;margin-bottom:24px;font-size:.95em}");
-    sb.Append("input[type=text]{width:100%;padding:14px;font-size:1.4em;text-align:center;letter-spacing:4px;border:2px solid #4361ee;border-radius:8px;background:#0f3460;color:#fff;outline:none;text-transform:uppercase}");
-    sb.Append("input:focus{border-color:#7c8cf8;box-shadow:0 0 12px rgba(67,97,238,.4)}");
-    sb.Append("button{width:100%;margin-top:16px;padding:14px;font-size:1.1em;background:#4361ee;color:#fff;border:none;border-radius:8px;cursor:pointer;font-weight:600}");
-    sb.Append("button:hover{background:#3a56d4}");
-    sb.Append(".msg{margin-top:16px;padding:12px;border-radius:6px;font-size:.9em}");
-    sb.Append(".msg-ok{background:#1b5e20;color:#a5d6a7}.msg-err{background:#b71c1c;color:#ef9a9a}");
-    sb.Append(".logo{font-size:2.5em;margin-bottom:16px}");
-    sb.Append("</style></head><body>");
-    sb.Append("<div class=\"card\">");
-    sb.Append("<div class=\"logo\">&#128272;</div>");
-    sb.Append("<h1>Device Login</h1>");
-    sb.Append("<p>Enter the code shown in your CLI to authorize this device.</p>");
-    sb.Append("<form method=\"post\" action=\"/device\">");
-    sb.Append($"<input type=\"text\" name=\"code\" maxlength=\"9\" placeholder=\"XXXX-XXXX\" value=\"{System.Net.WebUtility.HtmlEncode(code)}\" autocomplete=\"off\" autofocus>");
-    sb.Append("<button type=\"submit\">Authorize Device</button>");
-    sb.Append("</form>");
-    if (!string.IsNullOrEmpty(msg))
+        await context.Response.WriteAsync("{\"status\":\"authorization_pending\"}");
+    }));
+    appInfo.RegisterRoute("GET /device", new RouteHandlerData(pageInfoFactory.RawPage("Public", false), async context =>
     {
-        var isErr = msg.StartsWith("Error", StringComparison.OrdinalIgnoreCase);
-        sb.Append($"<div class=\"msg {(isErr ? "msg-err" : "msg-ok")}\">{System.Net.WebUtility.HtmlEncode(msg)}</div>");
-    }
-    sb.Append("</div></body></html>");
-    context.Response.ContentType = "text/html";
-    await context.Response.WriteAsync(sb.ToString());
-}));
-appInfo.RegisterRoute("POST /device", new RouteHandlerData(pageInfoFactory.RawPage("Authenticated", false), async context =>
-{
-    var user = await UserAuth.GetRequestUserAsync(context);
-    string code = "";
-    if (context.Request.HasFormContentType)
-    {
-        var form = await context.Request.ReadFormAsync();
-        code = form["code"].ToString().Trim().ToUpperInvariant();
-    }
-    if (string.IsNullOrEmpty(code) || user == null)
-    {
-        context.Response.Redirect("/device?msg=Error:+Invalid+request");
-        return;
-    }
-    var all = DataStoreProvider.Current.Query<DeviceCodeAuth>(null).ToList();
-    var dc = all.FirstOrDefault(d => d.UserCode == code && d.Status == "pending" && !d.IsExpired(DateTime.UtcNow));
-    if (dc == null)
-    {
-        context.Response.Redirect($"/device?msg=Error:+Invalid+or+expired+code&code={System.Net.WebUtility.UrlEncode(code)}");
-        return;
-    }
-    dc.Status = "approved";
-    dc.UserId = user.Id;
-    DataStoreProvider.Current.Save(dc);
-    context.Response.Redirect("/device?msg=Device+authorized+successfully!+You+can+close+this+tab.");
-}));
-appInfo.RegisterRoute("GET /api/{type}", new RouteHandlerData(pageInfoFactory.RawPage("Authenticated", false), routeHandlers.DataApiListHandler));
-appInfo.RegisterRoute("POST /api/{type}", new RouteHandlerData(pageInfoFactory.RawPage("Authenticated", false), routeHandlers.DataApiPostHandler));
-appInfo.RegisterRoute("GET /api/{type}/{id}", new RouteHandlerData(pageInfoFactory.RawPage("Authenticated", false), routeHandlers.DataApiGetHandler));
-appInfo.RegisterRoute("PUT /api/{type}/{id}", new RouteHandlerData(pageInfoFactory.RawPage("Authenticated", false), routeHandlers.DataApiPutHandler));
-appInfo.RegisterRoute("PATCH /api/{type}/{id}", new RouteHandlerData(pageInfoFactory.RawPage("Authenticated", false), routeHandlers.DataApiPatchHandler));
-appInfo.RegisterRoute("DELETE /api/{type}/{id}", new RouteHandlerData(pageInfoFactory.RawPage("Authenticated", false), routeHandlers.DataApiDeleteHandler));
-appInfo.RegisterRoute("GET /api/_meta", new RouteHandlerData(pageInfoFactory.RawPage("Authenticated", false), async context =>
-{
-    var entities = DataScaffold.Entities;
-    var result = entities.Select(e => new Dictionary<string, object?>
-    {
-        ["name"] = e.Name,
-        ["slug"] = e.Slug,
-        ["permissions"] = e.Permissions,
-        ["showOnNav"] = e.ShowOnNav,
-        ["navGroup"] = e.NavGroup,
-        ["fields"] = e.Fields.Select(f => new Dictionary<string, object?>
+        var code = context.Request.Query.ContainsKey("code") ? context.Request.Query["code"].ToString() : "";
+        var msg = context.Request.Query.ContainsKey("msg") ? context.Request.Query["msg"].ToString() : "";
+        var sb = new System.Text.StringBuilder();
+        sb.Append("<!DOCTYPE html><html><head><meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">");
+        sb.Append("<title>Device Login - BareMetalWeb</title><style>");
+        sb.Append("*{margin:0;padding:0;box-sizing:border-box}");
+        sb.Append("body{font-family:system-ui,-apple-system,sans-serif;background:#1a1a2e;color:#e0e0e0;display:flex;justify-content:center;align-items:center;min-height:100vh}");
+        sb.Append(".card{background:#16213e;border-radius:12px;padding:40px;max-width:420px;width:100%;box-shadow:0 8px 32px rgba(0,0,0,.4);text-align:center}");
+        sb.Append("h1{font-size:1.6em;margin-bottom:8px;color:#fff}");
+        sb.Append("p{color:#a0a0b0;margin-bottom:24px;font-size:.95em}");
+        sb.Append("input[type=text]{width:100%;padding:14px;font-size:1.4em;text-align:center;letter-spacing:4px;border:2px solid #4361ee;border-radius:8px;background:#0f3460;color:#fff;outline:none;text-transform:uppercase}");
+        sb.Append("input:focus{border-color:#7c8cf8;box-shadow:0 0 12px rgba(67,97,238,.4)}");
+        sb.Append("button{width:100%;margin-top:16px;padding:14px;font-size:1.1em;background:#4361ee;color:#fff;border:none;border-radius:8px;cursor:pointer;font-weight:600}");
+        sb.Append("button:hover{background:#3a56d4}");
+        sb.Append(".msg{margin-top:16px;padding:12px;border-radius:6px;font-size:.9em}");
+        sb.Append(".msg-ok{background:#1b5e20;color:#a5d6a7}.msg-err{background:#b71c1c;color:#ef9a9a}");
+        sb.Append(".logo{font-size:2.5em;margin-bottom:16px}");
+        sb.Append("</style></head><body>");
+        sb.Append("<div class=\"card\">");
+        sb.Append("<div class=\"logo\">&#128272;</div>");
+        sb.Append("<h1>Device Login</h1>");
+        sb.Append("<p>Enter the code shown in your CLI to authorize this device.</p>");
+        sb.Append("<form method=\"post\" action=\"/device\">");
+        sb.Append($"<input type=\"text\" name=\"code\" maxlength=\"9\" placeholder=\"XXXX-XXXX\" value=\"{System.Net.WebUtility.HtmlEncode(code)}\" autocomplete=\"off\" autofocus>");
+        sb.Append("<button type=\"submit\">Authorize Device</button>");
+        sb.Append("</form>");
+        if (!string.IsNullOrEmpty(msg))
         {
-            ["name"] = f.Name,
-            ["label"] = f.Label,
-            ["type"] = f.FieldType.ToString(),
-            ["order"] = f.Order,
-            ["required"] = f.Required,
-            ["list"] = f.List,
-            ["view"] = f.View,
-            ["edit"] = f.Edit,
-            ["create"] = f.Create,
-            ["readOnly"] = f.ReadOnly
-        }).ToArray()
-    }).ToArray();
-    context.Response.ContentType = "application/json";
-    await context.Response.WriteAsync(JsonSerializer.Serialize(result, new JsonSerializerOptions { WriteIndented = true }));
-}));
-appInfo.RegisterRoute("GET /ideas/search", new RouteHandlerData(pageInfoFactory.RawPage("Public", false), async context =>
-{
-    var q = context.Request.Query.ContainsKey("q") ? context.Request.Query["q"].ToString() : null;
-    var caller = context.Request.Query.ContainsKey("caller") ? context.Request.Query["caller"].ToString() : null;
-    var source = context.Request.Query.ContainsKey("source") ? context.Request.Query["source"].ToString() : null;
-
-    // If idea text provided, create a new ToDo entry from it
-    if (!string.IsNullOrWhiteSpace(q))
-    {
-        var todo = new ToDo
-        {
-            Id = Guid.NewGuid().ToString("N"),
-            Title = q,
-            Notes = $"caller={caller ?? ""}, source={source ?? ""}",
-            Deadline = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(7)),
-            StartTime = TimeOnly.FromDateTime(DateTime.UtcNow),
-            IsCompleted = false
-        };
-        DataStoreProvider.Current.Save(todo);
-    }
-
-    // Return all ToDo entries regardless of query
-    var todos = DataStoreProvider.Current.Query<ToDo>(null);
-    var sb = new System.Text.StringBuilder();
-    sb.Append("<!DOCTYPE html><html><head><meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">");
-    sb.Append("<title>Ideas</title><style>");
-    sb.Append("*{margin:0;padding:0;box-sizing:border-box}");
-    sb.Append("body{font-family:system-ui,-apple-system,sans-serif;background:#f4f6f9;color:#333}");
-    sb.Append("header{background:#1a1a2e;color:#fff;padding:16px 24px;font-size:1.4em;font-weight:600}");
-    sb.Append(".container{max-width:900px;margin:24px auto;padding:0 16px}");
-    sb.Append("form{display:flex;gap:8px;margin-bottom:24px}");
-    sb.Append("input[type=text]{flex:1;padding:10px 14px;border:1px solid #ccc;border-radius:6px;font-size:1em}");
-    sb.Append("button{padding:10px 20px;background:#4361ee;color:#fff;border:none;border-radius:6px;font-size:1em;cursor:pointer}");
-    sb.Append("button:hover{background:#3a56d4}");
-    sb.Append("table{width:100%;border-collapse:collapse;background:#fff;border-radius:8px;overflow:hidden;box-shadow:0 1px 4px rgba(0,0,0,.1)}");
-    sb.Append("th{background:#e8eaf6;text-align:left;padding:12px 14px;font-weight:600;font-size:.9em;color:#555}");
-    sb.Append("td{padding:10px 14px;border-top:1px solid #eee;font-size:.95em}");
-    sb.Append("tr:hover{background:#f0f4ff}");
-    sb.Append(".done{text-decoration:line-through;color:#999}");
-    sb.Append(".badge{display:inline-block;padding:2px 8px;border-radius:10px;font-size:.8em;font-weight:600}");
-    sb.Append(".badge-open{background:#e3f2fd;color:#1565c0}.badge-done{background:#e8f5e9;color:#2e7d32}");
-    sb.Append(".empty{text-align:center;padding:40px;color:#999;font-size:1.1em}");
-    sb.Append("footer{text-align:center;padding:24px;color:#999;font-size:.85em}");
-    sb.Append("</style></head><body>");
-    sb.Append("<header>&#128161; Ideas</header>");
-    sb.Append("<div class=\"container\">");
-    sb.Append("<form method=\"get\" action=\"/ideas/search\">");
-    sb.Append("<input type=\"text\" name=\"q\" placeholder=\"Enter a new idea...\" value=\"\">");
-    sb.Append("<button type=\"submit\">Add &amp; Search</button>");
-    sb.Append("</form>");
-
-    var list = todos.ToList();
-    if (list.Count == 0)
-    {
-        sb.Append("<div class=\"empty\">No ideas yet. Add one above!</div>");
-    }
-    else
-    {
-        sb.Append("<table><thead><tr><th>Title</th><th>Notes</th><th>Deadline</th><th>Status</th></tr></thead><tbody>");
-        foreach (var t in list)
-        {
-            var css = t.IsCompleted ? " class=\"done\"" : "";
-            var badge = t.IsCompleted ? "<span class=\"badge badge-done\">Done</span>" : "<span class=\"badge badge-open\">Open</span>";
-            sb.Append($"<tr><td{css}>{System.Net.WebUtility.HtmlEncode(t.Title)}</td>");
-            sb.Append($"<td>{System.Net.WebUtility.HtmlEncode(t.Notes)}</td>");
-            sb.Append($"<td>{t.Deadline:yyyy-MM-dd}</td>");
-            sb.Append($"<td>{badge}</td></tr>");
+            var isErr = msg.StartsWith("Error", StringComparison.OrdinalIgnoreCase);
+            sb.Append($"<div class=\"msg {(isErr ? "msg-err" : "msg-ok")}\">{System.Net.WebUtility.HtmlEncode(msg)}</div>");
         }
-        sb.Append("</tbody></table>");
-    }
-
-    sb.Append("</div><footer>BareMetalWeb &middot; Ideas</footer></body></html>");
-
-    context.Response.ContentType = "text/html";
-    await context.Response.WriteAsync(sb.ToString());
-}));
-appInfo.RegisterRoute("GET /admin/reload-templates", new RouteHandlerData(pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "message" }, new[] { "Reload Templates", "" }, "admin", true, 1, navGroup: "System", navAlignment: NavAlignment.Right), routeHandlers.ReloadTemplatesHandler));
-appInfo.RegisterRoute("GET /status", new RouteHandlerData(pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "message" }, new[] { "" }, "Public", false, 1), routeHandlers.BuildPageHandler(context =>
-{
-    context.Response.ContentType = "text/html";
-    context.SetStringValue("title", "Server Time");
-    context.SetStringValue("message", $"Current server time is: {DateTime.UtcNow:O}");
-})));
-appInfo.RegisterRoute("GET /statusRaw", new RouteHandlerData(pageInfoFactory.RawPage("Public", false), routeHandlers.TimeRawHandler));
-
-await appInfo.BuildAppInfoMenuOptionsAsync();
-await appInfo.WireUpRequestHandlingAndLoggerAsyncLifetime();
-app.Lifetime.ApplicationStarted.Register(() =>
-{
-    var addresses = app.Services.GetService(typeof(IServer)) is IServer server
-        ? server.Features.Get<IServerAddressesFeature>()?.Addresses
-        : null;
-    var list = addresses is null || addresses.Count == 0
-        ? (app.Urls ?? Array.Empty<string>())
-        : addresses;
-    var display = list.Any() ? string.Join(", ", list) : "unknown";
-    var message = $"BareMetalWeb server is ready - listening for requests on {display}";
-    logger.LogInfo(message);
-    Console.WriteLine(message);
-
-    var httpsConfig = $"HTTPS redirect settings: mode={appInfo.HttpsRedirectMode}, trustForwardedHeaders={appInfo.TrustForwardedHeaders}, redirectHost={(string.IsNullOrWhiteSpace(appInfo.HttpsRedirectHost) ? "(auto)" : appInfo.HttpsRedirectHost)}, redirectPort={(appInfo.HttpsRedirectPort.HasValue ? appInfo.HttpsRedirectPort.Value.ToString() : "(auto)")}";
-    logger.LogInfo(httpsConfig);
-    Console.WriteLine(httpsConfig);
-
-    var httpsAddress = list.FirstOrDefault(address => address.StartsWith("https://", StringComparison.OrdinalIgnoreCase));
-    appInfo.HttpsEndpointAvailable = !string.IsNullOrWhiteSpace(httpsAddress);
-    if (appInfo.HttpsEndpointAvailable && Uri.TryCreate(httpsAddress, UriKind.Absolute, out var httpsUri))
+        sb.Append("</div></body></html>");
+        context.Response.ContentType = "text/html";
+        await context.Response.WriteAsync(sb.ToString());
+    }));
+    appInfo.RegisterRoute("POST /device", new RouteHandlerData(pageInfoFactory.RawPage("Authenticated", false), async context =>
     {
-        if (string.IsNullOrWhiteSpace(appInfo.HttpsRedirectHost))
+        var user = await UserAuth.GetRequestUserAsync(context);
+        string code = "";
+        if (context.Request.HasFormContentType)
         {
-            appInfo.HttpsRedirectHost = httpsUri.Host;
+            var form = await context.Request.ReadFormAsync();
+            code = form["code"].ToString().Trim().ToUpperInvariant();
+        }
+        if (string.IsNullOrEmpty(code) || user == null)
+        {
+            context.Response.Redirect("/device?msg=Error:+Invalid+request");
+            return;
+        }
+        var all = DataStoreProvider.Current.Query<DeviceCodeAuth>(null).ToList();
+        var dc = all.FirstOrDefault(d => d.UserCode == code && d.Status == "pending" && !d.IsExpired(DateTime.UtcNow));
+        if (dc == null)
+        {
+            context.Response.Redirect($"/device?msg=Error:+Invalid+or+expired+code&code={System.Net.WebUtility.UrlEncode(code)}");
+            return;
+        }
+        dc.Status = "approved";
+        dc.UserId = user.Id;
+        DataStoreProvider.Current.Save(dc);
+        context.Response.Redirect("/device?msg=Device+authorized+successfully!+You+can+close+this+tab.");
+    }));
+    // API metadata endpoint
+    appInfo.RegisterRoute("GET /api/_meta", new RouteHandlerData(pageInfoFactory.RawPage("Authenticated", false), async context =>
+    {
+        var entities = DataScaffold.Entities;
+        var result = entities.Select(e => new Dictionary<string, object?>
+        {
+            ["name"] = e.Name,
+            ["slug"] = e.Slug,
+            ["permissions"] = e.Permissions,
+            ["showOnNav"] = e.ShowOnNav,
+            ["navGroup"] = e.NavGroup,
+            ["fields"] = e.Fields.Select(f => new Dictionary<string, object?>
+            {
+                ["name"] = f.Name,
+                ["label"] = f.Label,
+                ["type"] = f.FieldType.ToString(),
+                ["order"] = f.Order,
+                ["required"] = f.Required,
+                ["list"] = f.List,
+                ["view"] = f.View,
+                ["edit"] = f.Edit,
+                ["create"] = f.Create,
+                ["readOnly"] = f.ReadOnly
+            }).ToArray()
+        }).ToArray();
+        context.Response.ContentType = "application/json";
+        await context.Response.WriteAsync(JsonSerializer.Serialize(result, new JsonSerializerOptions { WriteIndented = true }));
+    }));
+    // Ideas/search page
+    appInfo.RegisterRoute("GET /ideas/search", new RouteHandlerData(pageInfoFactory.RawPage("Public", false), async context =>
+    {
+        var q = context.Request.Query.ContainsKey("q") ? context.Request.Query["q"].ToString() : null;
+        var caller = context.Request.Query.ContainsKey("caller") ? context.Request.Query["caller"].ToString() : null;
+        var source = context.Request.Query.ContainsKey("source") ? context.Request.Query["source"].ToString() : null;
+
+        if (!string.IsNullOrWhiteSpace(q))
+        {
+            var todo = new ToDo
+            {
+                Id = Guid.NewGuid().ToString("N"),
+                Title = q,
+                Notes = $"caller={caller ?? ""}, source={source ?? ""}",
+                Deadline = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(7)),
+                StartTime = TimeOnly.FromDateTime(DateTime.UtcNow),
+                IsCompleted = false
+            };
+            DataStoreProvider.Current.Save(todo);
         }
 
-        if (!appInfo.HttpsRedirectPort.HasValue || appInfo.HttpsRedirectPort.Value <= 0)
-        {
-            appInfo.HttpsRedirectPort = httpsUri.IsDefaultPort ? 443 : httpsUri.Port;
-        }
-    }
+        var todos = DataStoreProvider.Current.Query<ToDo>(null);
+        var sb = new System.Text.StringBuilder();
+        sb.Append("<!DOCTYPE html><html><head><meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">");
+        sb.Append("<title>Ideas</title><style>");
+        sb.Append("*{margin:0;padding:0;box-sizing:border-box}");
+        sb.Append("body{font-family:system-ui,-apple-system,sans-serif;background:#f4f6f9;color:#333}");
+        sb.Append("header{background:#1a1a2e;color:#fff;padding:16px 24px;font-size:1.4em;font-weight:600}");
+        sb.Append(".container{max-width:900px;margin:24px auto;padding:0 16px}");
+        sb.Append("form{display:flex;gap:8px;margin-bottom:24px}");
+        sb.Append("input[type=text]{flex:1;padding:10px 14px;border:1px solid #ccc;border-radius:6px;font-size:1em}");
+        sb.Append("button{padding:10px 20px;background:#4361ee;color:#fff;border:none;border-radius:6px;font-size:1em;cursor:pointer}");
+        sb.Append("button:hover{background:#3a56d4}");
+        sb.Append("table{width:100%;border-collapse:collapse;background:#fff;border-radius:8px;overflow:hidden;box-shadow:0 1px 4px rgba(0,0,0,.1)}");
+        sb.Append("th{background:#e8eaf6;text-align:left;padding:12px 14px;font-weight:600;font-size:.9em;color:#555}");
+        sb.Append("td{padding:10px 14px;border-top:1px solid #eee;font-size:.95em}");
+        sb.Append("tr:hover{background:#f0f4ff}");
+        sb.Append(".done{text-decoration:line-through;color:#999}");
+        sb.Append(".badge{display:inline-block;padding:2px 8px;border-radius:10px;font-size:.8em;font-weight:600}");
+        sb.Append(".badge-open{background:#e3f2fd;color:#1565c0}.badge-done{background:#e8f5e9;color:#2e7d32}");
+        sb.Append(".empty{text-align:center;padding:40px;color:#999;font-size:1.1em}");
+        sb.Append("footer{text-align:center;padding:24px;color:#999;font-size:.85em}");
+        sb.Append("</style></head><body>");
+        sb.Append("<header>&#128161; Ideas</header>");
+        sb.Append("<div class=\"container\">");
+        sb.Append("<form method=\"get\" action=\"/ideas/search\">");
+        sb.Append("<input type=\"text\" name=\"q\" placeholder=\"Enter a new idea...\" value=\"\">");
+        sb.Append("<button type=\"submit\">Add &amp; Search</button>");
+        sb.Append("</form>");
 
-    if (!appInfo.HttpsEndpointAvailable)
-    {
-        var warn = "HTTPS endpoint not configured. Configure HTTPS (ASPNETCORE_URLS / Kestrel) to expose an https:// address.";
-        logger.LogInfo(warn);
-        Console.WriteLine(warn);
-    }
+        var list = todos.ToList();
+        if (list.Count == 0)
+        {
+            sb.Append("<div class=\"empty\">No ideas yet. Add one above!</div>");
+        }
+        else
+        {
+            sb.Append("<table><thead><tr><th>Title</th><th>Notes</th><th>Deadline</th><th>Status</th></tr></thead><tbody>");
+            foreach (var t in list)
+            {
+                var css = t.IsCompleted ? " class=\"done\"" : "";
+                var badge = t.IsCompleted ? "<span class=\"badge badge-done\">Done</span>" : "<span class=\"badge badge-open\">Open</span>";
+                sb.Append($"<tr><td{css}>{System.Net.WebUtility.HtmlEncode(t.Title)}</td>");
+                sb.Append($"<td>{System.Net.WebUtility.HtmlEncode(t.Notes)}</td>");
+                sb.Append($"<td>{t.Deadline:yyyy-MM-dd}</td>");
+                sb.Append($"<td>{badge}</td></tr>");
+            }
+            sb.Append("</tbody></table>");
+        }
+
+        sb.Append("</div><footer>BareMetalWeb &middot; Ideas</footer></body></html>");
+
+        context.Response.ContentType = "text/html";
+        await context.Response.WriteAsync(sb.ToString());
+    }));
 });
 
 app.Run();


### PR DESCRIPTION
## Summary

Extracts all boilerplate setup into a single `UseBareMetalWeb()` extension method, enabling the NuGet packaging workflow described in #29.

### Changes

- **New file: `BareMetalWebExtensions.cs`** — `UseBareMetalWeb()` wires up the full stack: data store, rendering, auth, routing, static files, CORS, HTTPS, and proxy support. Accepts an optional `configureRoutes` callback for app-specific routes.

- **Simplified `Program.cs`** — Top-level code reduced from ~440 lines to just:
  ```csharp
  var app = WebApplication.Create();
  await app.UseBareMetalWeb(configureRoutes: (appInfo, routeHandlers, pageInfoFactory, mainTemplate) => {
      // app-specific routes only (device code auth, ideas, API metadata)
  });
  app.Run();
  ```

- **Removed duplicate route registrations** — The inline routes that duplicated `RouteRegistrationExtensions` (static, auth, monitoring, admin, data, API CRUD) are no longer repeated in Program.cs.

### Target usage for NuGet consumers

```csharp
var app = WebApplication.Create(args);
await app.UseBareMetalWeb();
app.Run();
```

Closes #29