### PR TITLE
Fix create form 500 for entities with DataLookup fields

### DIFF
--- a/BareMetalWeb.Data.Tests/DataScaffoldLookupTests.cs
+++ b/BareMetalWeb.Data.Tests/DataScaffoldLookupTests.cs
@@ -1,0 +1,182 @@
+using System.Collections;
+using BareMetalWeb.Core;
+using BareMetalWeb.Core.Interfaces;
+using BareMetalWeb.Data;
+using BareMetalWeb.Data.DataObjects;
+using BareMetalWeb.Data.Interfaces;
+
+namespace BareMetalWeb.Data.Tests;
+
+/// <summary>
+/// Tests that BuildFormFields works for entities with [DataLookup] attributes.
+/// Regression test for the create-route 500 bug caused by QueryByType attempting
+/// an invalid cast from ValueTask&lt;IEnumerable&lt;T&gt;&gt; to ValueTask&lt;IEnumerable&gt;.
+/// </summary>
+public class DataScaffoldLookupTests : IDisposable
+{
+    private readonly IDataObjectStore _originalStore;
+
+    public DataScaffoldLookupTests()
+    {
+        _originalStore = DataStoreProvider.Current;
+        DataStoreProvider.Current = new InMemoryDataStore();
+
+        // Ensure lookup target entities are registered
+        DataEntityRegistry.RegisterAllEntities();
+    }
+
+    public void Dispose()
+    {
+        DataStoreProvider.Current = _originalStore;
+    }
+
+    [Fact]
+    public void BuildFormFields_ForCreate_WithLookupFields_DoesNotThrow()
+    {
+        // Product has [DataLookup] on UnitOfMeasureId and CurrencyId
+        var meta = DataScaffold.GetEntityByType(typeof(Product));
+        Assert.NotNull(meta);
+
+        var fields = DataScaffold.BuildFormFields(meta, null, forCreate: true);
+        Assert.NotNull(fields);
+        Assert.True(fields.Count > 0, "Expected at least one form field for Product create");
+    }
+
+    [Fact]
+    public void BuildFormFields_ForCreate_WithLookupFields_ReturnsLookupListType()
+    {
+        var meta = DataScaffold.GetEntityByType(typeof(Product));
+        Assert.NotNull(meta);
+
+        var fields = DataScaffold.BuildFormFields(meta, null, forCreate: true);
+
+        // UnitOfMeasureId and CurrencyId should be LookupList fields
+        var uomField = fields.FirstOrDefault(f => f.Name == "UnitOfMeasureId");
+        Assert.NotNull(uomField);
+        Assert.Equal(Rendering.Models.FormFieldType.LookupList, uomField.FieldType);
+
+        var currencyField = fields.FirstOrDefault(f => f.Name == "CurrencyId");
+        Assert.NotNull(currencyField);
+        Assert.Equal(Rendering.Models.FormFieldType.LookupList, currencyField.FieldType);
+    }
+
+    [Fact]
+    public void BuildFormFields_ForCreate_WithLookupFields_PopulatesLookupOptions()
+    {
+        // Seed some lookup data
+        var uom = new UnitOfMeasure { Id = "uom-1", Name = "Each" };
+        DataStoreProvider.Current.Save(uom);
+
+        var currency = new Currency { Id = "cur-1" };
+        // Set IsoCode via reflection (it's a property)
+        typeof(Currency).GetProperty("IsoCode")?.SetValue(currency, "USD");
+
+        DataStoreProvider.Current.Save(currency);
+
+        // Clear lookup cache to force re-query
+        ClearLookupCache();
+
+        var meta = DataScaffold.GetEntityByType(typeof(Product));
+        Assert.NotNull(meta);
+
+        var fields = DataScaffold.BuildFormFields(meta, null, forCreate: true);
+
+        var uomField = fields.FirstOrDefault(f => f.Name == "UnitOfMeasureId");
+        Assert.NotNull(uomField);
+        Assert.NotNull(uomField.LookupOptions);
+        Assert.Contains(uomField.LookupOptions, o => o.Key == "uom-1" && o.Value == "Each");
+    }
+
+    [Fact]
+    public void BuildFormFields_ForCreate_Order_WithCustomerLookup_DoesNotThrow()
+    {
+        // Order has [DataLookup] on CustomerId and CurrencyId
+        var meta = DataScaffold.GetEntityByType(typeof(Order));
+        Assert.NotNull(meta);
+
+        var fields = DataScaffold.BuildFormFields(meta, null, forCreate: true);
+        Assert.NotNull(fields);
+        Assert.True(fields.Count > 0);
+    }
+
+    [Fact]
+    public void BuildFormFields_ForCreate_Invoice_WithLookups_DoesNotThrow()
+    {
+        var meta = DataScaffold.GetEntityByType(typeof(Invoice));
+        Assert.NotNull(meta);
+
+        var fields = DataScaffold.BuildFormFields(meta, null, forCreate: true);
+        Assert.NotNull(fields);
+        Assert.True(fields.Count > 0);
+    }
+
+    [Fact]
+    public void BuildFormFields_ForEdit_WithLookupFields_DoesNotThrow()
+    {
+        var product = new Product
+        {
+            Id = "prod-1",
+            Name = "Widget",
+            Sku = "W001",
+            UnitOfMeasureId = "uom-1",
+            CurrencyId = "cur-1",
+            Price = 9.99m
+        };
+
+        var meta = DataScaffold.GetEntityByType(typeof(Product));
+        Assert.NotNull(meta);
+
+        var fields = DataScaffold.BuildFormFields(meta, product, forCreate: false);
+        Assert.NotNull(fields);
+        Assert.True(fields.Count > 0);
+    }
+
+    private static void ClearLookupCache()
+    {
+        // Use reflection to clear the private lookup cache
+        var cacheField = typeof(DataScaffold).GetField("LookupCache",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        if (cacheField?.GetValue(null) is IDictionary cache)
+            cache.Clear();
+    }
+
+    /// <summary>
+    /// Minimal in-memory IDataObjectStore for testing.
+    /// </summary>
+    private class InMemoryDataStore : IDataObjectStore
+    {
+        private readonly Dictionary<(Type, string), BaseDataObject> _store = new();
+
+        public IReadOnlyList<IDataProvider> Providers => Array.Empty<IDataProvider>();
+        public void RegisterProvider(IDataProvider provider, bool prepend = false) { }
+        public void RegisterFallbackProvider(IDataProvider provider) { }
+        public void ClearProviders() { }
+
+        public void Save<T>(T obj) where T : BaseDataObject
+            => _store[(typeof(T), obj.Id)] = obj;
+
+        public ValueTask SaveAsync<T>(T obj, CancellationToken cancellationToken = default) where T : BaseDataObject
+        { Save(obj); return ValueTask.CompletedTask; }
+
+        public T? Load<T>(string id) where T : BaseDataObject
+            => _store.TryGetValue((typeof(T), id), out var obj) ? obj as T : null;
+
+        public ValueTask<T?> LoadAsync<T>(string id, CancellationToken cancellationToken = default) where T : BaseDataObject
+            => ValueTask.FromResult(Load<T>(id));
+
+        public IEnumerable<T> Query<T>(QueryDefinition? query = null) where T : BaseDataObject
+            => _store.Values.OfType<T>();
+
+        public ValueTask<IEnumerable<T>> QueryAsync<T>(QueryDefinition? query = null, CancellationToken cancellationToken = default) where T : BaseDataObject
+            => ValueTask.FromResult(Query<T>(query));
+
+        public ValueTask<int> CountAsync<T>(QueryDefinition? query = null, CancellationToken cancellationToken = default) where T : BaseDataObject
+            => ValueTask.FromResult(Query<T>(query).Count());
+
+        public void Delete<T>(string id) where T : BaseDataObject
+            => _store.Remove((typeof(T), id));
+
+        public ValueTask DeleteAsync<T>(string id, CancellationToken cancellationToken = default) where T : BaseDataObject
+        { Delete<T>(id); return ValueTask.CompletedTask; }
+    }
+}

--- a/BareMetalWeb.Data/DataScaffold.cs
+++ b/BareMetalWeb.Data/DataScaffold.cs
@@ -834,15 +834,21 @@ public static class DataScaffold
     private static IEnumerable QueryByType(Type type, QueryDefinition? query)
     {
         // Note: This uses sync-over-async for scaffolding/reflection scenarios called from synchronous UI rendering.
-        // This is a pragmatic choice to avoid cascading async changes through the entire scaffolding system.
-        // CancellationToken.None is used because:
-        // 1. This is only called during UI rendering with cached results (see GetLookupOptions cache)
-        // 2. The synchronous callers (BuildEditFormHtml, BuildListRows, etc.) don't have cancellation context
-        // 3. The operations are typically fast due to caching and small data sets for lookups
+        // QueryAsync<T> returns ValueTask<IEnumerable<T>> which cannot be cast directly to
+        // ValueTask<IEnumerable> (ValueTask is not covariant). We must use reflection to
+        // extract the result from the concrete ValueTask<IEnumerable<T>>.
         var method = typeof(IDataObjectStore).GetMethod(nameof(IDataObjectStore.QueryAsync))!;
         var generic = method.MakeGenericMethod(type);
-        var task = (ValueTask<IEnumerable>)generic.Invoke(DataStoreProvider.Current, new object?[] { query, CancellationToken.None })!;
-        return task.AsTask().GetAwaiter().GetResult();
+        var result = generic.Invoke(DataStoreProvider.Current, new object?[] { query, CancellationToken.None })!;
+
+        // result is a ValueTask<IEnumerable<T>>; convert to Task then await synchronously
+        var asTaskMethod = result.GetType().GetMethod(nameof(ValueTask<int>.AsTask))!;
+        var task = (Task)asTaskMethod.Invoke(result, null)!;
+        task.GetAwaiter().GetResult();
+
+        // Get the Result property from the completed Task<IEnumerable<T>>
+        var resultProp = task.GetType().GetProperty(nameof(Task<object>.Result))!;
+        return (IEnumerable)resultProp.GetValue(task)!;
     }
 
     private static IReadOnlyList<KeyValuePair<string, string>> BuildLookupOptions(IEnumerable items, string valueField, string displayField)

--- a/BareMetalWeb.Host/Program.cs
+++ b/BareMetalWeb.Host/Program.cs
@@ -1,9 +1,14 @@
 using System.Text.Json;
 using BareMetalWeb.Core;
 using BareMetalWeb.Core.Host;
+using BareMetalWeb.Core.Interfaces;
 using BareMetalWeb.Data;
 using BareMetalWeb.Data.DataObjects;
+using BareMetalWeb.Data.Interfaces;
 using BareMetalWeb.Host;
+using BareMetalWeb.Interfaces;
+using BareMetalWeb.Rendering;
+using BareMetalWeb.Rendering.Interfaces;
 
 WebApplication app = WebApplication.Create();
 


### PR DESCRIPTION
## Bug

GET requests to `/admin/data/{type}/create` throw HTTP 500 for any entity with `[DataLookup]` attributes (Product, Order, Customer, Invoice, etc.).

## Root Cause

`DataScaffold.QueryByType()` casts the result of `QueryAsync<T>()` — which returns `ValueTask<IEnumerable<T>>` — directly to `ValueTask<IEnumerable>`. Since `ValueTask` is a struct and is **not covariant**, this throws `InvalidCastException` at runtime.

## Fix

Use reflection to properly extract the result:
1. Call `AsTask()` on the concrete `ValueTask<IEnumerable<T>>`
2. Synchronously await the `Task`
3. Read the `Result` property from the completed `Task<IEnumerable<T>>`

This avoids the invalid cast while maintaining the existing sync-over-async pattern.

## Also Fixes

Missing usings in Program.cs for the `ProgramSetup` class after the startup refactor (PR #36).

## Tests Added

- `DataScaffoldLookupTests.cs` — 6 tests covering:
  - `BuildFormFields` for create with lookup fields (Product, Order, Invoice)
  - Verifies lookup fields render as `FormFieldType.LookupList`
  - Verifies lookup options populate from data store
  - `BuildFormFields` for edit with lookup fields

Fixes #37