### PR TITLE
Set Vapor as default theme, replace switcher with footer dropdown

### DIFF
--- a/BareMetalWeb.Core/wwwroot/static/css/site.css
+++ b/BareMetalWeb.Core/wwwroot/static/css/site.css
@@ -380,39 +380,33 @@ body a:hover {
     }
 }
 
-.bm-theme-switcher {
-    display: inline-flex;
-    gap: 0.35rem;
-    padding: 0.35rem;
-    border-radius: 999px;
-    background: rgba(12, 16, 22, 0.8);
-    border: 1px solid var(--bm-border);
-    backdrop-filter: blur(8px);
-    float: right;
-}
-
-.bm-theme-switcher input {
-    position: absolute;
-    opacity: 0;
-    pointer-events: none;
-}
-
-.bm-theme-switcher label {
-    padding: 0.25rem 0.75rem;
+.bm-theme-label {
     font-size: 0.75rem;
     font-weight: 600;
-    border-radius: 999px;
+    color: var(--bm-muted);
+    margin-right: 0.4rem;
+    vertical-align: middle;
+}
+
+.bm-theme-select {
+    font-size: 0.75rem;
+    font-weight: 600;
+    padding: 0.2rem 0.5rem;
+    border-radius: 6px;
+    border: 1px solid var(--bm-border);
+    background: rgba(12, 16, 22, 0.8);
     color: var(--bm-muted);
     cursor: pointer;
-    transition: all 0.2s ease;
+    outline: none;
+    vertical-align: middle;
+    backdrop-filter: blur(8px);
 }
 
-.bm-theme-switcher input:checked + label {
-    background: var(--bm-accent-soft);
-    color: var(--bm-link-hover);
+.bm-theme-select:focus {
+    border-color: var(--bm-accent);
 }
 
-body:has(#theme-contrast:checked) {
+body.bm-theme-contrast {
     --bm-surface: #000000;
     --bm-surface-elevated: #0a0a0a;
     --bm-surface-soft: #111111;
@@ -439,7 +433,7 @@ body:has(#theme-contrast:checked) {
     --bm-input-border: #ffffff;
 }
 
-body:has(#theme-muted:checked) {
+body.bm-theme-muted {
     --bm-surface: #1a1d22;
     --bm-surface-elevated: #20242b;
     --bm-surface-soft: #252b34;

--- a/BareMetalWeb.Core/wwwroot/static/js/theme-switcher.js
+++ b/BareMetalWeb.Core/wwwroot/static/js/theme-switcher.js
@@ -5,6 +5,7 @@
     const BOOTSWATCH_VERSION = '5.3.3';
     const BOOTSWATCH_CDN_BASE = `https://cdn.jsdelivr.net/npm/bootswatch@${BOOTSWATCH_VERSION}/dist`;
     const STORAGE_KEY = 'bm-selected-theme';
+    const DEFAULT_THEME = 'vapor';
 
     // Get or create the theme stylesheet link element
     function getThemeLink() {
@@ -27,42 +28,37 @@
     // Apply a theme
     function applyTheme(themeName) {
         const themeLink = getThemeLink();
-        
-        if (themeName === 'contrast' || themeName === 'muted') {
-            // Use built-in CSS custom properties for HC and Muted (defined in site.css)
-            // The :has() selectors automatically apply when radio buttons are checked
+
+        // Remove custom theme classes from body
+        document.body.classList.remove('bm-theme-contrast', 'bm-theme-muted');
+
+        if (themeName === 'contrast') {
             themeLink.href = '';
+            document.body.classList.add('bm-theme-contrast');
+        } else if (themeName === 'muted') {
+            themeLink.href = '';
+            document.body.classList.add('bm-theme-muted');
         } else {
-            // Use Bootswatch CDN for other themes
             themeLink.href = `${BOOTSWATCH_CDN_BASE}/${themeName}/bootstrap.min.css`;
         }
-        
-        // Save preference
+
         localStorage.setItem(STORAGE_KEY, themeName);
     }
 
     // Initialize theme switcher
     function init() {
-        const switcher = document.querySelector('.bm-theme-switcher');
-        if (!switcher) return;
+        const select = document.getElementById('bm-theme-select');
+        if (!select) return;
 
-        // Load saved theme or default to 'darkly'
-        const savedTheme = localStorage.getItem(STORAGE_KEY) || 'darkly';
-        const savedInput = document.getElementById(`theme-${savedTheme}`);
-        if (savedInput) {
-            savedInput.checked = true;
-            applyTheme(savedTheme);
-        }
+        const savedTheme = localStorage.getItem(STORAGE_KEY) || DEFAULT_THEME;
+        select.value = savedTheme;
+        applyTheme(savedTheme);
 
-        // Listen for theme changes
-        switcher.addEventListener('change', function(e) {
-            if (e.target.name === 'bm-theme') {
-                applyTheme(e.target.value);
-            }
+        select.addEventListener('change', function() {
+            applyTheme(this.value);
         });
     }
 
-    // Initialize when DOM is ready
     if (document.readyState === 'loading') {
         document.addEventListener('DOMContentLoaded', init);
     } else {

--- a/BareMetalWeb.Core/wwwroot/templates/index.footer.html
+++ b/BareMetalWeb.Core/wwwroot/templates/index.footer.html
@@ -4,25 +4,19 @@
                 <div class="col-md-6 small">
                     <p class="mb-0">&copy;{{CopyrightYear}} - {{CompanyDescription}}, All rights reserved. {{footer_user}}<span id="tz-info" class="ms-2"></span></p>
                 </div>
-                <div class="col-md-6">
-                    <form class="bm-theme-switcher" aria-label="Theme selector">
-                        <input type="radio" name="bm-theme" id="theme-darkly" value="darkly">
-                        <label for="theme-darkly">Darkly</label>
-                        <input type="radio" name="bm-theme" id="theme-cyborg" value="cyborg">
-                        <label for="theme-cyborg">Cyborg</label>
-                        <input type="radio" name="bm-theme" id="theme-slate" value="slate">
-                        <label for="theme-slate">Slate</label>
-                        <input type="radio" name="bm-theme" id="theme-superhero" value="superhero">
-                        <label for="theme-superhero">Superhero</label>
-                        <input type="radio" name="bm-theme" id="theme-flatly" value="flatly">
-                        <label for="theme-flatly">Flatly</label>
-                        <input type="radio" name="bm-theme" id="theme-lux" value="lux">
-                        <label for="theme-lux">Lux</label>
-                        <input type="radio" name="bm-theme" id="theme-contrast" value="contrast">
-                        <label for="theme-contrast">HC</label>
-                        <input type="radio" name="bm-theme" id="theme-muted" value="muted">
-                        <label for="theme-muted">Muted</label>
-                    </form>
+                <div class="col-md-6 text-end">
+                    <label for="bm-theme-select" class="bm-theme-label">Theme</label>
+                    <select id="bm-theme-select" class="bm-theme-select" aria-label="Theme selector">
+                        <option value="vapor">Vapor</option>
+                        <option value="darkly">Darkly</option>
+                        <option value="cyborg">Cyborg</option>
+                        <option value="slate">Slate</option>
+                        <option value="superhero">Superhero</option>
+                        <option value="flatly">Flatly</option>
+                        <option value="lux">Lux</option>
+                        <option value="contrast">High Contrast</option>
+                        <option value="muted">Muted</option>
+                    </select>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Changes

- **Default theme**: Changed from Darkly to **Vapor**
- **Theme switcher**: Replaced the inline radio button row with a compact `<select>` dropdown — much less intrusive in the footer
- **Added Vapor** to the available theme list
- **Custom themes** (Contrast, Muted): Switched from `:has()` pseudo-class selectors (which required radio buttons) to body class-based selectors (`body.bm-theme-contrast`, `body.bm-theme-muted`)

Fixes #40