### PR TITLE
Fix theme switcher not applying theme changes

### DIFF
--- a/BareMetalWeb.Core/wwwroot/templates/index.head.html
+++ b/BareMetalWeb.Core/wwwroot/templates/index.head.html
@@ -1,5 +1,5 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{{title}}</title>
-    <link rel="stylesheet" href="/static/css/bootstrap.min.css" />
+    <link id="bootswatch-theme" rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.3/dist/vapor/bootstrap.min.css" />
     <link rel="stylesheet" href="/static/css/site.css" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />


### PR DESCRIPTION
The local `bootstrap.min.css` in the head template was always loaded alongside the Bootswatch CDN theme link, so its styles won — changing the dropdown did nothing visible.

**Fix:** Replace the local `bootstrap.min.css` with the Bootswatch Vapor CDN link (using `id="bootswatch-theme"`). The theme-switcher JS already looks for this ID and updates the `href` on change, so themes now apply immediately.