### PR TITLE
Clean up mobile card view rendering

### DIFF
--- a/BareMetalWeb.Core/wwwroot/static/css/site.css
+++ b/BareMetalWeb.Core/wwwroot/static/css/site.css
@@ -329,54 +329,110 @@ body a:hover {
 }
 
 @media (max-width: 768px) {
+    .bm-page-card {
+        border-radius: 0.5rem;
+        margin: 0 -0.5rem;
+    }
+
+    .bm-page-card .card-header {
+        padding: 0.75rem 1rem;
+    }
+
+    .bm-page-card .card-header h1,
+    .bm-page-card .card-header h2,
+    .bm-page-card .card-header h3 {
+        font-size: 1.15rem;
+    }
+
+    .bm-page-card .card-body {
+        padding: 0.75rem 1rem;
+    }
+
     .bm-table thead {
         display: none;
     }
 
+    .bm-table {
+        border: none;
+        background: transparent;
+    }
+
     .bm-table tbody tr {
         display: block;
-        margin-bottom: 1rem;
+        margin-bottom: 0.75rem;
         border: 1px solid var(--bm-border);
-        border-radius: 0.5rem;
-        padding: 0.5rem 0.75rem;
+        border-radius: 0.75rem;
+        padding: 0;
         background: var(--bm-surface-elevated);
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+        overflow: hidden;
     }
 
     .bm-table tbody td {
         display: flex;
         justify-content: space-between;
+        align-items: baseline;
         gap: 0.75rem;
         border: none;
-        padding: 0.35rem 0;
+        padding: 0.5rem 0.85rem;
+        font-size: 0.9rem;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+    }
+
+    .bm-table tbody td:last-child {
+        border-bottom: none;
     }
 
     .bm-table tbody td::before {
-        content: attr(data-label) ": ";
+        content: attr(data-label);
         font-weight: 600;
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
         color: var(--bm-table-head);
         white-space: nowrap;
+        flex-shrink: 0;
+        min-width: 5rem;
     }
 
     .bm-table tbody td[data-label=""]::before {
         content: "";
+        min-width: 0;
     }
 
     .bm-table tbody td[data-label="Actions"],
     .bm-table tbody td[data-label="Id"] {
-        display: flex;
-        align-items: center;
         justify-content: flex-start;
         gap: 0.5rem;
-        padding: 0.5rem 0.25rem;
-        border-bottom: 1px solid var(--bm-border);
+        padding: 0.6rem 0.85rem;
         background: var(--bm-surface-soft);
-        margin: 0 -0.75rem 0.25rem;
-        border-radius: 0.35rem;
+    }
+
+    .bm-table tbody td[data-label="Actions"] {
+        border-bottom: 1px solid var(--bm-border);
     }
 
     .bm-table tbody td[data-label="Actions"]::before,
     .bm-table tbody td[data-label="Id"]::before {
         content: "";
+        min-width: 0;
+    }
+
+    .bm-table.table-striped > tbody > tr:nth-of-type(odd) {
+        background: var(--bm-surface-elevated);
+    }
+
+    .bm-content {
+        padding-left: 0.5rem;
+        padding-right: 0.5rem;
+    }
+
+    .bm-footer .row {
+        text-align: center;
+    }
+
+    .bm-footer .row > div {
+        margin-bottom: 0.25rem;
     }
 }
 


### PR DESCRIPTION
## Changes

Overhaul of the mobile (≤768px) card-style data views to look polished instead of clunky.

### Before
- Flat cards with minimal padding and cramped labels
- Colon-separated labels (`IP Address: 192...`)
- Negative margins on Actions/Id rows causing overflow
- Striped rows on cards looked odd
- No visual separation between fields

### After
- **Proper card treatment**: rounded corners, subtle box-shadow, contained overflow
- **Clean field labels**: uppercase, smaller font, letter-spacing — no colon suffix
- **Field separators**: subtle bottom borders between rows, none on last field
- **Actions header**: distinct background at top of each card
- **Page card**: reduced padding and border-radius for mobile fit
- **Footer**: centered on narrow screens
- **No striping on mobile** — cards are already visually distinct

Fixes #39