### PR TITLE
Fix themes: remove site.css color overrides blocking Bootswatch

### DIFF
--- a/BareMetalWeb.Core/wwwroot/static/css/site.css
+++ b/BareMetalWeb.Core/wwwroot/static/css/site.css
@@ -1,50 +1,13 @@
 :root {
     --bm-nav-height: 56px;
     --bm-footer-height: 56px;
-    --bm-surface: #0f141b;
-    --bm-surface-elevated: #161c26;
-    --bm-surface-soft: #1d2633;
-    --bm-border: #2a3545;
-    --bm-accent: #4f8cff;
-    --bm-accent-soft: rgba(79, 140, 255, 0.15);
-    --bm-shadow: 0 14px 30px rgba(8, 12, 20, 0.45);
-    --bm-bg: #0f141b;
-    --bm-bg-accent: #1d2633;
-    --bm-text: #e6e9ef;
-    --bm-muted: #c9d6e5;
-    --bm-link: #a8c3ff;
-    --bm-link-hover: #d2e2ff;
-    --bm-navbar-bg: linear-gradient(135deg, #0d3b99 0%, #122a63 100%);
-    --bm-navbar-shadow: 0 10px 24px rgba(8, 12, 20, 0.4);
-    --bm-navbar-border: rgba(255, 255, 255, 0.08);
-    --bm-footer-bg: #0b0f14;
-    --bm-footer-text: #8fa1b8;
-    --bm-table-head: #9db1cc;
-    --bm-row-hover: rgba(79, 140, 255, 0.08);
-    --bm-input-bg: #121821;
-    --bm-input-text: #e6e9ef;
-    --bm-input-placeholder: #8292a8;
-    --bm-input-border: #2a3545;
 }
 
 body {
     padding-top: var(--bm-nav-height);
     padding-bottom: var(--bm-footer-height);
-    background: radial-gradient(circle at top, var(--bm-bg-accent), var(--bm-bg) 45%);
-    color: var(--bm-text);
-    font-smoothing: antialiased;
-    -webkit-font-smoothing: antialiased;
     line-height: 1.6;
     letter-spacing: 0.01em;
-}
-
-body a {
-    color: var(--bm-link);
-    text-decoration: none;
-}
-
-body a:hover {
-    color: var(--bm-link-hover);
 }
 
 .bm-navbar {
@@ -52,9 +15,6 @@ body a:hover {
     left: 0;
     right: 0;
     z-index: 1030;
-    background: var(--bm-navbar-bg);
-    border-bottom: 1px solid var(--bm-navbar-border);
-    box-shadow: var(--bm-navbar-shadow);
 }
 
 .bm-navbar .navbar-brand {
@@ -64,7 +24,6 @@ body a:hover {
 
 .bm-navbar .nav-link {
     font-weight: 500;
-    color: rgba(255, 255, 255, 0.88);
     padding: 0.35rem 0.75rem;
     border-radius: 999px;
     transition: background-color 0.2s ease, color 0.2s ease;
@@ -72,14 +31,12 @@ body a:hover {
 
 .bm-navbar .nav-link:hover,
 .bm-navbar .nav-link:focus {
-    color: #ffffff;
     background: rgba(255, 255, 255, 0.12);
 }
 
 .bm-navbar .nav-link.active,
 .bm-navbar .nav-link.show {
     background: rgba(255, 255, 255, 0.18);
-    color: #ffffff;
 }
 
 .bm-content {
@@ -87,16 +44,12 @@ body a:hover {
 }
 
 .bm-page-card {
-    background: var(--bm-surface-elevated);
-    border: 1px solid var(--bm-border);
     border-radius: 1rem;
-    box-shadow: var(--bm-shadow);
     overflow: hidden;
 }
 
 .bm-page-card .card-header {
     background: transparent;
-    border-bottom: 1px solid var(--bm-border);
     padding: 1rem 1.5rem;
 }
 
@@ -111,99 +64,44 @@ body a:hover {
     padding: 1.5rem;
 }
 
-.bm-page-card .card-body p {
-    color: var(--bm-muted);
-}
-
 .bm-footer {
     min-height: var(--bm-footer-height);
-    background: var(--bm-footer-bg) !important;
     border-top: 1px solid rgba(255, 255, 255, 0.08);
-}
-
-.bm-footer p {
-    color: var(--bm-footer-text);
 }
 
 .bm-table {
     border-radius: 0.75rem;
     overflow: hidden;
-    border: 1px solid var(--bm-border);
-    background: var(--bm-surface-elevated);
 }
 
 .bm-table thead th {
     text-transform: uppercase;
     letter-spacing: 0.08em;
     font-size: 0.7rem;
-    color: var(--bm-table-head);
-    border-bottom-color: var(--bm-border);
 }
 
 .bm-table tbody tr {
-    background: var(--bm-surface-elevated);
     transition: background-color 0.15s ease;
-}
-
-.bm-table.table-striped > tbody > tr:nth-of-type(odd) {
-    background: var(--bm-surface-soft);
-}
-
-.bm-table tbody tr:hover {
-    background: var(--bm-row-hover);
-}
-
-.bm-table tbody td {
-    border-color: var(--bm-border);
-    color: var(--bm-text);
 }
 
 .form-control,
 .form-select {
     border-radius: 0.75rem;
-    border-color: var(--bm-input-border);
-    background-color: var(--bm-input-bg);
-    color: var(--bm-input-text);
 }
 
 .form-label {
     font-weight: 600;
-    color: var(--bm-muted);
-}
-
-.input-group-text {
-    background: var(--bm-input-bg);
-    border-color: var(--bm-input-border);
-    color: var(--bm-muted);
 }
 
 .form-control:focus,
 .form-select:focus {
-    border-color: var(--bm-accent);
-    box-shadow: 0 0 0 0.2rem var(--bm-accent-soft);
-}
-
-.form-control::placeholder {
-    color: var(--bm-input-placeholder);
+    box-shadow: 0 0 0 0.2rem rgba(var(--bs-primary-rgb, 13, 110, 253), 0.25);
 }
 
 .btn {
     border-radius: 999px;
     padding: 0.45rem 1.1rem;
     font-weight: 600;
-}
-
-.btn-outline-light {
-    border-color: rgba(255, 255, 255, 0.25);
-}
-
-.btn-primary {
-    background: linear-gradient(135deg, #4f8cff, #3569d6);
-    border: none;
-}
-
-.btn-primary:hover {
-    filter: brightness(1.05);
 }
 
 .bm-log-layout {
@@ -213,8 +111,7 @@ body a:hover {
 }
 
 .bm-log-panel {
-    background: var(--bm-surface-soft);
-    border: 1px solid var(--bm-border);
+    border: 1px solid rgba(255, 255, 255, 0.1);
     border-radius: 0.5rem;
     padding: 0.75rem;
     min-height: 320px;
@@ -285,24 +182,21 @@ body a:hover {
 .bm-log-viewer-content {
     white-space: pre-wrap;
     font-size: 0.8125rem;
-    background: #0c1118;
-    color: var(--bs-gray-100, #f8f9fa);
-    border: 1px solid var(--bm-border);
+    border: 1px solid rgba(255, 255, 255, 0.1);
     border-radius: 0.375rem;
     padding: 0.5rem;
     margin-bottom: 0;
 }
 
 .bm-log-actions {
-    background: #0f141b;
-    border: 1px solid var(--bm-border);
+    border: 1px solid rgba(255, 255, 255, 0.1);
     border-radius: 0.5rem;
     padding: 0.75rem;
 }
 
 .bm-log-actions-row {
     font-weight: 600;
-    color: var(--bm-table-head);
+    opacity: 0.7;
     margin-bottom: 0.5rem;
 }
 
@@ -360,10 +254,9 @@ body a:hover {
     .bm-table tbody tr {
         display: block;
         margin-bottom: 0.75rem;
-        border: 1px solid var(--bm-border);
+        border: 1px solid rgba(255, 255, 255, 0.1);
         border-radius: 0.75rem;
         padding: 0;
-        background: var(--bm-surface-elevated);
         box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
         overflow: hidden;
     }
@@ -389,7 +282,7 @@ body a:hover {
         font-size: 0.75rem;
         text-transform: uppercase;
         letter-spacing: 0.04em;
-        color: var(--bm-table-head);
+        opacity: 0.7;
         white-space: nowrap;
         flex-shrink: 0;
         min-width: 5rem;
@@ -405,11 +298,11 @@ body a:hover {
         justify-content: flex-start;
         gap: 0.5rem;
         padding: 0.6rem 0.85rem;
-        background: var(--bm-surface-soft);
+        opacity: 0.9;
     }
 
     .bm-table tbody td[data-label="Actions"] {
-        border-bottom: 1px solid var(--bm-border);
+        border-bottom: 1px solid rgba(255, 255, 255, 0.1);
     }
 
     .bm-table tbody td[data-label="Actions"]::before,
@@ -419,7 +312,7 @@ body a:hover {
     }
 
     .bm-table.table-striped > tbody > tr:nth-of-type(odd) {
-        background: var(--bm-surface-elevated);
+        background: inherit;
     }
 
     .bm-content {
@@ -439,7 +332,7 @@ body a:hover {
 .bm-theme-label {
     font-size: 0.75rem;
     font-weight: 600;
-    color: var(--bm-muted);
+    opacity: 0.7;
     margin-right: 0.4rem;
     vertical-align: middle;
 }
@@ -449,71 +342,75 @@ body a:hover {
     font-weight: 600;
     padding: 0.2rem 0.5rem;
     border-radius: 6px;
-    border: 1px solid var(--bm-border);
-    background: rgba(12, 16, 22, 0.8);
-    color: var(--bm-muted);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    background: rgba(0, 0, 0, 0.3);
+    color: inherit;
     cursor: pointer;
     outline: none;
     vertical-align: middle;
-    backdrop-filter: blur(8px);
 }
 
 .bm-theme-select:focus {
-    border-color: var(--bm-accent);
+    border-color: rgba(255, 255, 255, 0.5);
 }
 
 body.bm-theme-contrast {
-    --bm-surface: #000000;
-    --bm-surface-elevated: #0a0a0a;
-    --bm-surface-soft: #111111;
-    --bm-border: #ffffff;
-    --bm-accent: #ffe600;
-    --bm-accent-soft: rgba(255, 230, 0, 0.2);
-    --bm-shadow: 0 16px 32px rgba(0, 0, 0, 0.6);
-    --bm-bg: #000000;
-    --bm-bg-accent: #0c0c0c;
-    --bm-text: #ffffff;
-    --bm-muted: #f0f0f0;
-    --bm-link: #ffe600;
-    --bm-link-hover: #fff6a0;
-    --bm-navbar-bg: #000000;
-    --bm-navbar-shadow: none;
-    --bm-navbar-border: #ffffff;
-    --bm-footer-bg: #000000;
-    --bm-footer-text: #ffffff;
-    --bm-table-head: #ffe600;
-    --bm-row-hover: rgba(255, 230, 0, 0.25);
-    --bm-input-bg: #000000;
-    --bm-input-text: #ffffff;
-    --bm-input-placeholder: #ffe600;
-    --bm-input-border: #ffffff;
+    background: #000000 !important;
+    color: #ffffff !important;
+}
+
+body.bm-theme-contrast .navbar {
+    background: #000000 !important;
+    border-bottom: 2px solid #ffe600;
+}
+
+body.bm-theme-contrast a {
+    color: #ffe600;
+}
+
+body.bm-theme-contrast .bm-footer {
+    background: #000000 !important;
+    color: #ffffff;
+}
+
+body.bm-theme-contrast .form-control,
+body.bm-theme-contrast .form-select {
+    background: #000000;
+    color: #ffffff;
+    border-color: #ffffff;
+}
+
+body.bm-theme-contrast .table {
+    color: #ffffff;
 }
 
 body.bm-theme-muted {
-    --bm-surface: #1a1d22;
-    --bm-surface-elevated: #20242b;
-    --bm-surface-soft: #252b34;
-    --bm-border: #323a46;
-    --bm-accent: #8aa3b8;
-    --bm-accent-soft: rgba(138, 163, 184, 0.18);
-    --bm-shadow: 0 12px 26px rgba(12, 16, 22, 0.4);
-    --bm-bg: #181b20;
-    --bm-bg-accent: #1f242c;
-    --bm-text: #d6dde5;
-    --bm-muted: #b9c3cf;
-    --bm-link: #9db5c8;
-    --bm-link-hover: #c8d5e1;
-    --bm-navbar-bg: linear-gradient(135deg, #2c3a4d 0%, #222b38 100%);
-    --bm-navbar-shadow: 0 10px 20px rgba(12, 16, 22, 0.35);
-    --bm-navbar-border: rgba(255, 255, 255, 0.12);
-    --bm-footer-bg: #15181d;
-    --bm-footer-text: #9aa7b5;
-    --bm-table-head: #a9b7c6;
-    --bm-row-hover: rgba(138, 163, 184, 0.18);
-    --bm-input-bg: #1b2026;
-    --bm-input-text: #d6dde5;
-    --bm-input-placeholder: #8a96a3;
-    --bm-input-border: #323a46;
+    background: #181b20 !important;
+    color: #d6dde5 !important;
+}
+
+body.bm-theme-muted .navbar {
+    background: #222b38 !important;
+}
+
+body.bm-theme-muted a {
+    color: #9db5c8;
+}
+
+body.bm-theme-muted .bm-footer {
+    background: #15181d !important;
+    color: #9aa7b5;
+}
+
+body.bm-theme-muted .form-control,
+body.bm-theme-muted .form-select {
+    background: #1b2026;
+    color: #d6dde5;
+    border-color: #323a46;
+}
+
+body.bm-theme-muted .table {
+    color: #d6dde5;
 }
 
 /* Toast container z-index */


### PR DESCRIPTION
## Problem

Selecting a theme from the dropdown had no visible effect. All Bootswatch themes looked identical.

## Root Cause

`site.css` defined 25+ hardcoded `--bm-*` color CSS variables on `:root` and applied them to body, navbar, tables, forms, buttons, etc. Since `site.css` loads after the Bootswatch theme, these overrides won — making every theme look the same regardless of selection.

## Fix

Stripped all color overrides from `site.css`, keeping only layout/structural CSS (nav height, footer height, border-radius, spacing, transitions). Bootswatch themes now fully control colors.

Custom themes (Contrast, Muted) switched from unused `--bm-*` variables to direct property overrides via `body.bm-theme-contrast` / `body.bm-theme-muted` class selectors.

**Net: -171 lines, +68 lines** — much leaner CSS.