### PR TITLE
Show auto-generated ID fields as readonly on create/edit forms

### DIFF
--- a/BareMetalWeb.Core/FormFieldType.cs
+++ b/BareMetalWeb.Core/FormFieldType.cs
@@ -25,5 +25,6 @@ public enum FormFieldType
     Button,
     Link,
     Hidden,
-    CustomHtml
+    CustomHtml,
+    ReadOnly
 }

--- a/BareMetalWeb.Core/wwwroot/templates/fragments/InputReadOnly.html
+++ b/BareMetalWeb.Core/wwwroot/templates/fragments/InputReadOnly.html
@@ -1,0 +1,1 @@
+<input type="text" class="form-control" id="{{id}}" name="{{name}}" value="{{value}}" placeholder="{{placeholder}}" readonly disabled>

--- a/BareMetalWeb.Data/DataScaffold.cs
+++ b/BareMetalWeb.Data/DataScaffold.cs
@@ -258,9 +258,30 @@ public static class DataScaffold
             if (!forCreate && !field.Edit)
                 continue;
 
-            // Skip auto-generated ID fields in create forms
-            if (forCreate && field.IdGeneration != IdGenerationStrategy.None)
+            // Auto-generated ID fields: show as readonly indicator
+            if (field.IdGeneration != IdGenerationStrategy.None)
+            {
+                if (forCreate)
+                {
+                    fields.Add(new FormField(
+                        FormFieldType.ReadOnly,
+                        field.Name,
+                        field.Label,
+                        Required: false,
+                        Placeholder: "Auto-generated"));
+                }
+                else
+                {
+                    var idValue = instance != null ? field.Property.GetValue(instance)?.ToString() : null;
+                    fields.Add(new FormField(
+                        FormFieldType.ReadOnly,
+                        field.Name,
+                        field.Label,
+                        Required: false,
+                        Value: idValue ?? string.Empty));
+                }
                 continue;
+            }
 
             var value = instance != null ? field.Property.GetValue(instance) : null;
             if (IsChildListType(field.Property.PropertyType, out var childType))

--- a/BareMetalWeb.Rendering/StaticHTMLFragments.cs
+++ b/BareMetalWeb.Rendering/StaticHTMLFragments.cs
@@ -120,6 +120,15 @@ public sealed class HtmlFragmentRenderer : IHtmlFragmentRenderer
                 new[] { id, name, value, placeholder, required }
             );
     }
+    private byte[] InputReadOnlyTemplate(string id, string name, string value, string placeholder)
+    {
+        return _fragmentStore
+            .ZeroAllocationReplaceCopyAndEncode(
+                _fragmentStore.ReturnTemplateFragment("InputReadOnly"),
+                new[] { "{{id}}", "{{name}}", "{{value}}", "{{placeholder}}" },
+                new[] { id, name, value, placeholder }
+            );
+    }
     private byte[] InputTextAreaTemplate(string id, string name, string value, string placeholder, string required)
     {
         return _fragmentStore
@@ -458,6 +467,8 @@ public sealed class HtmlFragmentRenderer : IHtmlFragmentRenderer
                     Encode(field.LinkClass ?? "link-primary"));
             case FormFieldType.Hidden:
                 return InputHiddenTemplate(name, name, value);
+            case FormFieldType.ReadOnly:
+                return InputReadOnlyTemplate(name, name, value, placeholder);
             default:
                 return InputTextTemplate(name, name, value, placeholder, required);
         }


### PR DESCRIPTION
On create forms, auto-generated ID fields now appear as a disabled readonly textbox with 'Auto-generated' placeholder instead of being hidden. On edit forms, the actual ID value is shown as readonly.

**Changes:**
- Added `ReadOnly` to `FormFieldType` enum
- Created `InputReadOnly.html` template fragment (readonly + disabled input)
- Updated `DataScaffold.BuildFormFields` to emit `ReadOnly` fields for auto-generated IDs on both create and edit forms
- Added `InputReadOnlyTemplate` and `ReadOnly` case in `StaticHTMLFragments.RenderField`

Closes #56