### PR TITLE
Potential fix for code scanning alert no. 14: Uncontrolled data used in path expression

### DIFF
--- a/BareMetalWeb.Host/RouteHandlers.cs
+++ b/BareMetalWeb.Host/RouteHandlers.cs
@@ -2675,9 +2675,23 @@ public sealed class RouteHandlers : IRouteHandlers
             html.Append("<div class=\"bm-log-panel bm-log-viewer\">");
             if (!string.IsNullOrWhiteSpace(file))
             {
-                var fullPath = Path.Combine(root, date, hour, file);
+                var fullPath = Path.GetFullPath(Path.Combine(root, date ?? string.Empty, hour ?? string.Empty, file));
+                var normalizedRoot = Path.GetFullPath(root);
                 var selectedEntry = fileEntries.FirstOrDefault(entry => string.Equals(entry.Name, file, StringComparison.OrdinalIgnoreCase));
-                html.Append(RenderLogFile(fullPath, file, selectedEntry.IsError));
+
+                var isUnderRoot = fullPath.StartsWith(normalizedRoot, StringComparison.OrdinalIgnoreCase)
+                    && (fullPath.Length == normalizedRoot.Length
+                        || fullPath[normalizedRoot.Length] == Path.DirectorySeparatorChar
+                        || fullPath[normalizedRoot.Length] == Path.AltDirectorySeparatorChar);
+
+                if (isUnderRoot && selectedEntry != null && File.Exists(fullPath))
+                {
+                    html.Append(RenderLogFile(fullPath, file, selectedEntry.IsError));
+                }
+                else
+                {
+                    html.Append("<p class=\"text-danger mb-0\">Invalid log file selection.</p>");
+                }
             }
             else
             {


### PR DESCRIPTION
Potential fix for [https://github.com/WillEastbury/BareMetalWeb/security/code-scanning/14](https://github.com/WillEastbury/BareMetalWeb/security/code-scanning/14)

In general, to fix uncontrolled path usage you should treat all user-provided path components as untrusted, and either (a) validate them as simple names (no separators, no `..`) or (b) build the path within a known base directory and verify that the normalized final path is still contained within that base directory, and that it corresponds to an expected directory/file from an allow list obtained from the filesystem.

For this specific code, the safest minimally invasive fix is:

1. Construct the candidate log file path under `root` as currently done: `Path.Combine(root, date, hour, file)`.
2. Normalize it with `Path.GetFullPath`.
3. Normalize the log root directory as well.
4. Ensure the normalized log file path starts with the normalized root plus the directory separator and still exists.
5. Also ensure that `file` corresponds to one of the known `fileEntries` for the selected date/hour (which is already partially done with `FirstOrDefault`) before reading from disk.
6. Only call `RenderLogFile` when all these checks pass; otherwise show a generic “invalid selection” or “file not found” message.

We can implement this without altering `RenderLogFile` at all, by tightening the logic where `fullPath` is built and used (around lines 2673–2681). Specifically:

- In `BareMetalWeb.Host/RouteHandlers.cs`, in the block:

```csharp
if (!string.IsNullOrWhiteSpace(file))
{
    var fullPath = Path.Combine(root, date, hour, file);
    var selectedEntry = fileEntries.FirstOrDefault(entry => string.Equals(entry.Name, file, StringComparison.OrdinalIgnoreCase));
    html.Append(RenderLogFile(fullPath, file, selectedEntry.IsError));
}
```

we will:

- Compute `var normalizedRoot = Path.GetFullPath(root);`
- Compute `var fullPath = Path.GetFullPath(Path.Combine(root, date ?? string.Empty, hour ?? string.Empty, file));`
- Check that `fullPath` starts with `normalizedRoot + Path.DirectorySeparatorChar` using an ordinal, case-insensitive comparison where appropriate (we’ll keep it ordinal and accept the platform default behavior; for simplicity we can use `StartsWith(normalizedRoot, StringComparison.OrdinalIgnoreCase)` and also ensure the next character is a separator or path end).
- Ensure `selectedEntry` is not null and that `File.Exists(fullPath)` before calling `RenderLogFile`.
- Otherwise append a safe message like “Invalid log file selection.” instead of reading any file.

No new methods or imports are required; we already have `using System.IO;` and `using System.Net;` and `StringComparison` available.

This approach maintains existing functionality for valid selections, while preventing traversal or arbitrary path access via crafted query parameters, and it addresses both CodeQL variants because both concern user-sourced `date`/`hour` influencing the final `path`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
