### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,5 +1,8 @@
 name: Deploy to Production
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
 


### PR DESCRIPTION
Potential fix for [https://github.com/WillEastbury/BareMetalWeb/security/code-scanning/1](https://github.com/WillEastbury/BareMetalWeb/security/code-scanning/1)

To fix the problem, explicitly add a `permissions` block that grants the least privileges required for this workflow. Since the workflow only checks out code and then builds/tests/deploys using Azure credentials from secrets, it only needs read access to repository contents. It does not need to write to the repo, manage pull requests, or access other scopes.

The best minimal fix is to add a top-level `permissions` block with `contents: read` right after the `name:` (or before/after `on:`) so it applies to all jobs. Concretely, in `.github/workflows/deploy-prod.yml`, between line 1 (`name: Deploy to Production`) and line 3 (`on:`), insert:

```yml
permissions:
  contents: read
```

No additional methods, imports, or definitions are required; this is purely a YAML configuration change to the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
