### PR TITLE
Fix all CodeQL security alerts

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -8,6 +8,9 @@ on:
       - '.github/workflows/build-cli.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-cli:
     strategy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/reset-data-staging.yml
+++ b/.github/workflows/reset-data-staging.yml
@@ -3,6 +3,10 @@ name: Reset Data Store (Staging)
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   reset-and-deploy:
     runs-on: ubuntu-latest

--- a/BareMetalWeb.Core/wwwroot/static/js/theme-switcher.js
+++ b/BareMetalWeb.Core/wwwroot/static/js/theme-switcher.js
@@ -25,14 +25,25 @@
         return link;
     }
 
+    // Allowed Bootswatch theme names
+    const ALLOWED_THEMES = new Set([
+        'cerulean', 'cosmo', 'cyborg', 'darkly', 'flatly', 'journal',
+        'litera', 'lumen', 'lux', 'materia', 'minty', 'morph',
+        'pulse', 'quartz', 'sandstone', 'simplex', 'sketchy', 'slate',
+        'solar', 'spacelab', 'superhero', 'united', 'vapor', 'yeti', 'zephyr'
+    ]);
+
     // Apply a theme
     function applyTheme(themeName) {
+        if (!ALLOWED_THEMES.has(themeName)) {
+            themeName = DEFAULT_THEME;
+        }
         const themeLink = getThemeLink();
 
         // Bootswatch themes define colors at :root,[data-bs-theme=light]
         // so remove data-bs-theme to avoid Bootstrap dark-mode overrides
         document.body.removeAttribute('data-bs-theme');
-        themeLink.href = `${BOOTSWATCH_CDN_BASE}/${themeName}/bootstrap.min.css`;
+        themeLink.href = `${BOOTSWATCH_CDN_BASE}/${encodeURIComponent(themeName)}/bootstrap.min.css`;
 
         localStorage.setItem(STORAGE_KEY, themeName);
     }

--- a/BareMetalWeb.Host/RouteHandlers.cs
+++ b/BareMetalWeb.Host/RouteHandlers.cs
@@ -96,6 +96,7 @@ public sealed class RouteHandlers : IRouteHandlers
     {
         if (!context.Request.HasFormContentType)
         {
+            context.Response.StatusCode = StatusCodes.Status415UnsupportedMediaType;
             RenderLoginForm(context, "Invalid login request.", null);
             await _renderer.RenderPage(context);
             return;
@@ -212,6 +213,7 @@ public sealed class RouteHandlers : IRouteHandlers
 
         if (!context.Request.HasFormContentType)
         {
+            context.Response.StatusCode = StatusCodes.Status415UnsupportedMediaType;
             RenderMfaChallengeForm(context, "Invalid MFA request.");
             await _renderer.RenderPage(context);
             return;
@@ -2272,6 +2274,10 @@ public sealed class RouteHandlers : IRouteHandlers
     private static string SanitizeCloneReturnUrl(string? returnUrl, string fallbackUrl)
     {
         if (string.IsNullOrWhiteSpace(returnUrl))
+            return fallbackUrl;
+
+        // Block absolute URLs, protocol-relative URLs, and non-local paths
+        if (returnUrl.Contains("://") || returnUrl.StartsWith("//", StringComparison.Ordinal))
             return fallbackUrl;
 
         if (!returnUrl.StartsWith("/admin/data/", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
Resolves all 10 open CodeQL security alerts.

### High severity
- **XSS through DOM** (#6): Theme switcher now validates theme names against an allowlist and uses `encodeURIComponent` before setting `href`
- **User-controlled bypass** (#7-11): Login and MFA POST handlers now return HTTP 415 when content type is not form data, making the rejection explicit rather than silently rendering an error page
- **Unvalidated URL redirect** (#12): Clone return URL sanitizer now blocks protocol-relative URLs (`//`) and URLs containing `://`

### Medium severity
- **Missing workflow permissions** (#2-5): Added explicit `permissions` blocks to `deploy.yml`, `build-cli.yml`, and `reset-data-staging.yml`