### PR TITLE
Fix CookieProtection test race condition

### DIFF
--- a/BareMetalWeb.Host.Tests/AuthorizationTests.cs
+++ b/BareMetalWeb.Host.Tests/AuthorizationTests.cs
@@ -13,6 +13,7 @@ namespace BareMetalWeb.Host.Tests;
 /// Tests for authorization logic in BareMetalWebServer.IsAuthorized method.
 /// These tests validate that empty permissions allow public access (fix for blank permissions issue).
 /// </summary>
+[Collection("CookieProtection")]
 public class AuthorizationTests : IClassFixture<DataStoreFixture>
 {
     private readonly DataStoreFixture _fixture;

--- a/BareMetalWeb.Host.Tests/BareMetalWebServerTests.cs
+++ b/BareMetalWeb.Host.Tests/BareMetalWebServerTests.cs
@@ -26,6 +26,7 @@ namespace BareMetalWeb.Host.Tests;
 /// Tests for BareMetalWebServer request pipeline including routing, error handling,
 /// CORS, HTTPS redirect, proxy headers, menu building, and setup flow.
 /// </summary>
+[Collection("CookieProtection")]
 public class BareMetalWebServerTests : IDisposable
 {
     private readonly IDataObjectStore _originalStore;
@@ -37,9 +38,14 @@ public class BareMetalWebServerTests : IDisposable
     private readonly MockClientRequestTracker _clientRequests;
     private readonly CancellationTokenSource _cts;
     private readonly WebApplication _app;
+    private readonly string _keyRootDirectory;
 
     public BareMetalWebServerTests()
     {
+        _keyRootDirectory = Path.Combine(Path.GetTempPath(), $"bmw-server-tests-{Guid.NewGuid()}");
+        Directory.CreateDirectory(_keyRootDirectory);
+        CookieProtection.ConfigureKeyRoot(_keyRootDirectory);
+
         _originalStore = DataStoreProvider.Current;
         _testStore = new InMemoryDataStore();
         DataStoreProvider.Current = _testStore;
@@ -81,6 +87,8 @@ public class BareMetalWebServerTests : IDisposable
         DataStoreProvider.Current = _originalStore;
         _cts.Cancel();
         _cts.Dispose();
+        if (Directory.Exists(_keyRootDirectory))
+            Directory.Delete(_keyRootDirectory, true);
     }
 
     private void EnsureStore()

--- a/BareMetalWeb.Host.Tests/CookieProtectionTests.cs
+++ b/BareMetalWeb.Host.Tests/CookieProtectionTests.cs
@@ -4,6 +4,7 @@ using Xunit;
 
 namespace BareMetalWeb.Host.Tests;
 
+[Collection("CookieProtection")]
 public class CookieProtectionTests : IDisposable
 {
     private readonly string _tempDirectory;

--- a/BareMetalWeb.Host/CookieProtection.cs
+++ b/BareMetalWeb.Host/CookieProtection.cs
@@ -11,10 +11,10 @@ public static class CookieProtection
     private const int HmacKeySize = 32;
     private static string KeyRootFolder = AppContext.BaseDirectory;
 
-    private static readonly Lazy<SynchronousEncryption> Encryption = new(() =>
+    private static Lazy<SynchronousEncryption> Encryption = new(() =>
         SynchronousEncryption.CreateFromKeyFile(Path.Combine(KeyRootFolder, ".keys", "cookie.enc.key")));
 
-    private static readonly Lazy<byte[]> HmacKey = new(() =>
+    private static Lazy<byte[]> HmacKey = new(() =>
         LoadOrCreateKey(Path.Combine(KeyRootFolder, ".keys", "cookie.hmac.key"), HmacKeySize));
 
     public static void ConfigureKeyRoot(string rootFolder)
@@ -23,6 +23,11 @@ public static class CookieProtection
             throw new ArgumentException("Key root folder cannot be null or whitespace.", nameof(rootFolder));
 
         KeyRootFolder = rootFolder;
+        // Reset lazy initializers so they pick up the new root folder
+        Encryption = new(() =>
+            SynchronousEncryption.CreateFromKeyFile(Path.Combine(KeyRootFolder, ".keys", "cookie.enc.key")));
+        HmacKey = new(() =>
+            LoadOrCreateKey(Path.Combine(KeyRootFolder, ".keys", "cookie.hmac.key"), HmacKeySize));
     }
 
     public static string Protect(string value)


### PR DESCRIPTION
## Problem

Deploy has been failing because 10 tests fail with `DirectoryNotFoundException` for `/tmp/<guid>/.keys/cookie.enc.key`.

Root cause: `CookieProtection` uses static `Lazy<>` fields for encryption keys, but `ConfigureKeyRoot()` only changed the path without resetting the Lazy initializers. When `CookieProtectionTests` changed `KeyRootFolder` to a temp directory and deleted it in `Dispose()`, other test classes (`BareMetalWebServerTests`, `AuthorizationTests`) calling `Protect()` would fail because the Lazy tried to create keys in a deleted directory.

## Fix

1. **`CookieProtection.ConfigureKeyRoot`** — now resets `Lazy` fields so they use the new root folder path
2. **`[Collection("CookieProtection")]`** — added to all 3 test classes that share `CookieProtection` static state, preventing parallel execution
3. **`BareMetalWebServerTests`** — now configures its own key root directory with cleanup in `Dispose()`