### PR TITLE
Fix FormFieldType build error in IdGenerationTests

### DIFF
--- a/BareMetalWeb.Data.Tests/IdGenerationTests.cs
+++ b/BareMetalWeb.Data.Tests/IdGenerationTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using BareMetalWeb.Core;
 using BareMetalWeb.Data;
+using BareMetalWeb.Rendering.Models;
 using Xunit;
 
 namespace BareMetalWeb.Data.Tests;


### PR DESCRIPTION
Adds missing `using BareMetalWeb.Rendering.Models` for `FormFieldType` enum used in the updated test assertion.