### PR TITLE
Fix CSP: allow cdn.jsdelivr.net for themes and icons

### DIFF
--- a/BareMetalWeb.Host.Tests/BareMetalWebServerTests.cs
+++ b/BareMetalWeb.Host.Tests/BareMetalWebServerTests.cs
@@ -860,9 +860,9 @@ public class BareMetalWebServerTests : IDisposable
         Assert.Contains("https://fonts.googleapis.com", csp);
         Assert.Contains("https://fonts.gstatic.com", csp);
         Assert.Contains("nonce-", csp);
-        Assert.DoesNotContain("style-src 'self' https://cdn.jsdelivr.net", csp);
-        Assert.DoesNotContain("style-src 'self' https://cdnjs.cloudflare.com", csp);
-        Assert.Contains("font-src 'self'", csp);
+        Assert.Contains("style-src 'self' https://cdn.jsdelivr.net", csp);
+        Assert.DoesNotContain("https://cdnjs.cloudflare.com", csp);
+        Assert.Contains("font-src 'self' https://cdn.jsdelivr.net", csp);
     }
 
     #endregion

--- a/BareMetalWeb.Host/BareMetalWebServer.cs
+++ b/BareMetalWeb.Host/BareMetalWebServer.cs
@@ -12,7 +12,7 @@ public class BareMetalWebServer : IBareWebHost
 {
     // Content Security Policy: Uses nonces for inline scripts/styles to provide strong XSS protection.
     // The {0} placeholder is replaced with the request-specific nonce at runtime.
-    private const string ContentSecurityPolicyTemplate = "default-src 'self'; script-src 'self' https://cdn.jsdelivr.net 'nonce-{0}'; style-src 'self' https://fonts.googleapis.com 'nonce-{0}'; img-src 'self' data: blob:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://cdn.jsdelivr.net; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'";
+    private const string ContentSecurityPolicyTemplate = "default-src 'self'; script-src 'self' https://cdn.jsdelivr.net 'nonce-{0}'; style-src 'self' https://cdn.jsdelivr.net https://fonts.googleapis.com 'nonce-{0}'; img-src 'self' data: blob:; font-src 'self' https://cdn.jsdelivr.net https://fonts.gstatic.com; connect-src 'self' https://cdn.jsdelivr.net; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'";
     private static readonly TimeSpan MenuCacheTtl = TimeSpan.FromSeconds(30);
     private static readonly QueryDefinition RootUserQuery = new()
     {


### PR DESCRIPTION
PR #131 restored CDN-based Bootswatch themes and added CDN Bootstrap Icons, but the CSP `style-src` and `font-src` didn't include `cdn.jsdelivr.net`, causing both to be blocked.

**Changes:**
- `style-src`: added `https://cdn.jsdelivr.net` (Bootswatch CSS + Bootstrap Icons CSS)
- `font-src`: added `https://cdn.jsdelivr.net` (Bootstrap Icons font files)
- Updated CSP test assertions to match