### PR TITLE
Fix theme flicker on page load

### DIFF
--- a/BareMetalWeb.Core/wwwroot/templates/index.head.html
+++ b/BareMetalWeb.Core/wwwroot/templates/index.head.html
@@ -2,5 +2,8 @@
     <title>{{title}}</title>
     <link rel="icon" type="image/x-icon" href="/static/favicon.ico" />
     <link id="bootswatch-theme" rel="stylesheet" href="/static/css/bootstrap.min.css" />
+    <script nonce="{{csp_nonce}}">
+    (function(){var m=document.cookie.match(/(?:^|;\s*)bm-selected-theme=([^;]+)/);if(m){var t=decodeURIComponent(m[1]),a=['cerulean','cosmo','cyborg','darkly','flatly','journal','litera','lumen','lux','materia','minty','morph','pulse','quartz','sandstone','simplex','sketchy','slate','solar','spacelab','superhero','united','vapor','yeti','zephyr'];if(a.indexOf(t)>=0)document.getElementById('bootswatch-theme').href='https://cdn.jsdelivr.net/npm/bootswatch@5.3.3/dist/'+encodeURIComponent(t)+'/bootstrap.min.css';}})();
+    </script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+" crossorigin="anonymous" />
     <link rel="stylesheet" href="/static/css/site.css" />


### PR DESCRIPTION
Eliminates the visible flash/flicker when loading pages where the default local CSS loads first, then gets swapped to the Bootswatch CDN theme on DOMContentLoaded.

**Fix:** Added a synchronous inline `<script>` in `<head>` immediately after the theme `<link>` element. It reads the `bm-selected-theme` cookie and sets the correct CDN URL on the stylesheet link *before* the browser starts fetching CSS — so only the correct theme is ever loaded.

- Validates theme against the same allowlist as theme-switcher.js
- Uses `{{csp_nonce}}` for CSP compliance
- No server-side changes needed