### PR TITLE
Fix DataStoreProvider test race in LookupFieldButtonTests

### DIFF
--- a/BareMetalWeb.Data.Tests/LookupFieldButtonTests.cs
+++ b/BareMetalWeb.Data.Tests/LookupFieldButtonTests.cs
@@ -13,6 +13,7 @@ using Xunit;
 
 namespace BareMetalWeb.Data.Tests;
 
+[Collection("DataStoreProvider")]
 public class LookupFieldButtonTests : IDisposable
 {
     private readonly IDataObjectStore _originalStore;


### PR DESCRIPTION
Adds missing `[Collection("DataStoreProvider")]` to `LookupFieldButtonTests` which modifies `DataStoreProvider.Current` but was running in parallel with `DataStoreProviderTests` and `DataScaffoldLookupTests`, causing intermittent failures.