### PR TITLE
Fix lookup dropdown selected value and URL cleanup

### DIFF
--- a/BareMetalWeb.Core/wwwroot/static/js/lookup-helper.js
+++ b/BareMetalWeb.Core/wwwroot/static/js/lookup-helper.js
@@ -2,6 +2,14 @@
 (function() {
     'use strict';
 
+    // Clean up cache-busting params from the URL after page load
+    if (window.location.search.includes('_refresh')) {
+        const cleanUrl = new URL(window.location.href);
+        cleanUrl.searchParams.delete('_refresh');
+        cleanUrl.searchParams.delete('_field');
+        window.history.replaceState(null, '', cleanUrl.toString());
+    }
+
     // Refresh lookup field values
     window.refreshLookup = function(fieldName) {
         const selectElement = document.getElementById(fieldName);

--- a/BareMetalWeb.Data/DataScaffold.cs
+++ b/BareMetalWeb.Data/DataScaffold.cs
@@ -335,7 +335,9 @@ public static class DataScaffold
             }
             var selectedValue = effectiveFieldType == FormFieldType.YesNo
                 ? (IsTruthy(value) ? "true" : "false")
-                : effectiveFieldType == FormFieldType.Enum ? value?.ToString() : null;
+                : effectiveFieldType == FormFieldType.Enum || effectiveFieldType == FormFieldType.LookupList
+                    ? value?.ToString()
+                    : null;
 
             lookupOptions ??= effectiveFieldType == FormFieldType.Enum
                 ? BuildEnumOptions(field.Property.PropertyType)


### PR DESCRIPTION
Fixes #154

- LookupList fields now preserve their selected value in the dropdown (was always defaulting to first row)
- Cache-busting _refresh/_field params are stripped from URL after page load