### PR TITLE
Add [RemoteCommand] attribute for server-side entity commands

### DIFF
--- a/BareMetalWeb.Core/Interfaces/IRouteHandlers.cs
+++ b/BareMetalWeb.Core/Interfaces/IRouteHandlers.cs
@@ -60,4 +60,5 @@ public interface IRouteHandlers
     ValueTask DataApiPutHandler(HttpContext context);
     ValueTask DataApiPatchHandler(HttpContext context);
     ValueTask DataApiDeleteHandler(HttpContext context);
+    ValueTask DataCommandHandler(HttpContext context);
 }

--- a/BareMetalWeb.Core/wwwroot/static/js/remote-command.js
+++ b/BareMetalWeb.Core/wwwroot/static/js/remote-command.js
@@ -1,0 +1,53 @@
+// Remote command execution
+(function() {
+    'use strict';
+
+    window.executeRemoteCommand = function(button) {
+        var url = button.getAttribute('data-command-url');
+        var confirmMsg = button.getAttribute('data-confirm');
+
+        if (confirmMsg && !confirm(confirmMsg)) return;
+
+        button.disabled = true;
+        var originalHtml = button.innerHTML;
+        button.innerHTML = '<span class="spinner-border spinner-border-sm" role="status"></span> Running…';
+
+        fetch(url, { method: 'POST', headers: { 'Accept': 'application/json' } })
+            .then(function(response) { return response.json(); })
+            .then(function(data) {
+                button.disabled = false;
+                button.innerHTML = originalHtml;
+                showCommandToast(data.success, data.message);
+                if (data.success && data.redirectUrl) {
+                    window.location.href = data.redirectUrl;
+                } else if (data.success) {
+                    window.location.reload();
+                }
+            })
+            .catch(function(err) {
+                button.disabled = false;
+                button.innerHTML = originalHtml;
+                showCommandToast(false, 'Request failed: ' + err.message);
+            });
+    };
+
+    function showCommandToast(success, message) {
+        var container = document.getElementById('bm-toast-container');
+        if (!container) {
+            container = document.createElement('div');
+            container.id = 'bm-toast-container';
+            container.className = 'position-fixed top-0 end-0 p-3';
+            container.style.zIndex = '1080';
+            document.body.appendChild(container);
+        }
+        var cls = success ? 'bg-success' : 'bg-danger';
+        var toast = document.createElement('div');
+        toast.className = 'toast align-items-center text-white ' + cls + ' border-0 show';
+        toast.setAttribute('role', 'alert');
+        toast.innerHTML = '<div class="d-flex"><div class="toast-body">' +
+            message.replace(/</g, '&lt;') +
+            '</div><button type="button" class="btn-close btn-close-white me-2 m-auto" onclick="this.closest(\'.toast\').remove()"></button></div>';
+        container.appendChild(toast);
+        setTimeout(function() { toast.remove(); }, 5000);
+    }
+})();

--- a/BareMetalWeb.Core/wwwroot/templates/index.footer.html
+++ b/BareMetalWeb.Core/wwwroot/templates/index.footer.html
@@ -25,3 +25,4 @@
     <script src="/static/js/timezone.js" nonce="{{csp_nonce}}"></script>
     <script src="/static/js/image-preview.js" nonce="{{csp_nonce}}"></script>
     <script src="/static/js/lookup-helper.js" nonce="{{csp_nonce}}"></script>
+    <script src="/static/js/remote-command.js" nonce="{{csp_nonce}}"></script>

--- a/BareMetalWeb.Data/DataScaffold.cs
+++ b/BareMetalWeb.Data/DataScaffold.cs
@@ -40,7 +40,8 @@ public sealed record DataEntityMetadata(
     ViewType ViewType,
     DataFieldMetadata? ParentField,
     IReadOnlyList<DataFieldMetadata> Fields,
-    DataEntityHandlers Handlers
+    DataEntityHandlers Handlers,
+    IReadOnlyList<RemoteCommandMetadata> Commands
 );
 
 public sealed record DataEntityHandlers(
@@ -2285,6 +2286,31 @@ public static class DataScaffold
             CountTypedAsync<T>
         );
 
+        // Discover [RemoteCommand] methods
+        var commands = new List<RemoteCommandMetadata>();
+        var methods = type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+        foreach (var method in methods)
+        {
+            var cmdAttr = method.GetCustomAttribute<RemoteCommandAttribute>();
+            if (cmdAttr == null) continue;
+            var returnType = method.ReturnType;
+            if (returnType != typeof(RemoteCommandResult)
+                && returnType != typeof(Task<RemoteCommandResult>)
+                && returnType != typeof(ValueTask<RemoteCommandResult>))
+                continue;
+            commands.Add(new RemoteCommandMetadata(
+                method,
+                method.Name,
+                cmdAttr.Label ?? DeCamelcaseWithId(method.Name),
+                cmdAttr.Icon,
+                cmdAttr.ConfirmMessage,
+                cmdAttr.Destructive,
+                cmdAttr.Permission,
+                cmdAttr.OverrideEntityPermissions,
+                cmdAttr.Order
+            ));
+        }
+
         return new DataEntityMetadata(
             type,
             name,
@@ -2297,7 +2323,8 @@ public static class DataScaffold
             viewType,
             parentField,
             fields.OrderBy(f => f.Order).ToList(),
-            handlers
+            handlers,
+            commands.OrderBy(c => c.Order).ToList()
         );
     }
 

--- a/BareMetalWeb.Data/RemoteCommandAttribute.cs
+++ b/BareMetalWeb.Data/RemoteCommandAttribute.cs
@@ -1,0 +1,13 @@
+namespace BareMetalWeb.Data;
+
+[AttributeUsage(AttributeTargets.Method, Inherited = true, AllowMultiple = false)]
+public sealed class RemoteCommandAttribute : Attribute
+{
+    public string? Label { get; set; }
+    public string? Icon { get; set; }
+    public string? ConfirmMessage { get; set; }
+    public bool Destructive { get; set; } = false;
+    public string? Permission { get; set; }
+    public bool OverrideEntityPermissions { get; set; } = false;
+    public int Order { get; set; } = 0;
+}

--- a/BareMetalWeb.Data/RemoteCommandMetadata.cs
+++ b/BareMetalWeb.Data/RemoteCommandMetadata.cs
@@ -1,0 +1,15 @@
+using System.Reflection;
+
+namespace BareMetalWeb.Core;
+
+public sealed record RemoteCommandMetadata(
+    MethodInfo Method,
+    string Name,
+    string Label,
+    string? Icon,
+    string? ConfirmMessage,
+    bool Destructive,
+    string? Permission,
+    bool OverrideEntityPermissions,
+    int Order
+);

--- a/BareMetalWeb.Data/RemoteCommandResult.cs
+++ b/BareMetalWeb.Data/RemoteCommandResult.cs
@@ -1,0 +1,10 @@
+namespace BareMetalWeb.Data;
+
+public record RemoteCommandResult(
+    bool Success,
+    string Message,
+    string? RedirectUrl = null)
+{
+    public static RemoteCommandResult Ok(string message) => new(true, message);
+    public static RemoteCommandResult Fail(string message) => new(false, message);
+}

--- a/BareMetalWeb.Host/RouteHandlers.cs
+++ b/BareMetalWeb.Host/RouteHandlers.cs
@@ -1588,8 +1588,9 @@ public sealed class RouteHandlers : IRouteHandlers
 
         var rtfHtml = $"<a class=\"btn btn-sm btn-outline-info ms-2\" href=\"/admin/data/{typeSlug}/{WebUtility.UrlEncode(id)}/rtf\" title=\"Download RTF\" aria-label=\"Download RTF\"><i class=\"bi bi-download\" aria-hidden=\"true\"></i><i class=\"bi bi-file-earmark-text ms-1\" aria-hidden=\"true\"></i> RTF</a>";
         var htmlHtml = $"<a class=\"btn btn-sm btn-outline-primary ms-2\" href=\"/admin/data/{typeSlug}/{WebUtility.UrlEncode(id)}/html\" title=\"Download HTML\" aria-label=\"Download HTML\"><i class=\"bi bi-download\" aria-hidden=\"true\"></i><i class=\"bi bi-filetype-html ms-1\" aria-hidden=\"true\"></i> HTML</a>";
+        var commandButtons = BuildCommandButtonsHtml(meta, typeSlug, id);
         context.SetStringValue("title", $"{WebUtility.HtmlEncode(meta.Name)} Details");
-        context.SetStringValue("message", $"<p><a class=\"btn btn-sm btn-outline-warning\" href=\"/admin/data/{typeSlug}/{WebUtility.UrlEncode(id)}/edit\" title=\"Edit\" aria-label=\"Edit\"><i class=\"bi bi-pencil\" aria-hidden=\"true\"></i></a>{rtfHtml}{htmlHtml}</p>");
+        context.SetStringValue("message", $"<p><a class=\"btn btn-sm btn-outline-warning\" href=\"/admin/data/{typeSlug}/{WebUtility.UrlEncode(id)}/edit\" title=\"Edit\" aria-label=\"Edit\"><i class=\"bi bi-pencil\" aria-hidden=\"true\"></i></a>{rtfHtml}{htmlHtml}{commandButtons}</p>");
         context.AddTable(new[] { "Field", "Value" }, rows);
         await _renderer.RenderPage(context);
     }
@@ -4411,5 +4412,100 @@ public sealed class RouteHandlers : IRouteHandlers
             ViewType.OrgChart => "Org Chart",
             _ => "Table View"
         };
+    }
+
+    private static string BuildCommandButtonsHtml(DataEntityMetadata meta, string typeSlug, string id)
+    {
+        if (meta.Commands.Count == 0) return string.Empty;
+        var sb = new StringBuilder();
+        var safeId = WebUtility.UrlEncode(id);
+        foreach (var cmd in meta.Commands)
+        {
+            var btnClass = cmd.Destructive ? "btn-outline-danger" : "btn-outline-secondary";
+            var icon = string.IsNullOrEmpty(cmd.Icon) ? "" : $"<i class=\"bi {WebUtility.HtmlEncode(cmd.Icon)}\" aria-hidden=\"true\"></i> ";
+            var confirm = string.IsNullOrEmpty(cmd.ConfirmMessage) ? "" : $" data-confirm=\"{WebUtility.HtmlEncode(cmd.ConfirmMessage)}\"";
+            sb.Append($"<button class=\"btn btn-sm {btnClass} ms-2\" data-command-url=\"/api/{typeSlug}/{safeId}/_command/{WebUtility.UrlEncode(cmd.Name)}\"{confirm} onclick=\"executeRemoteCommand(this)\">{icon}{WebUtility.HtmlEncode(cmd.Label)}</button>");
+        }
+        return sb.ToString();
+    }
+
+    public async ValueTask DataCommandHandler(HttpContext context)
+    {
+        var meta = ResolveEntity(context, out _, out var errorMessage);
+        var id = GetRouteValue(context, "id");
+        var commandName = GetRouteValue(context, "command");
+        if (meta == null || string.IsNullOrWhiteSpace(id) || string.IsNullOrWhiteSpace(commandName))
+        {
+            context.Response.StatusCode = StatusCodes.Status404NotFound;
+            await WriteJsonResponseAsync(context, new { success = false, message = errorMessage ?? "Not found." });
+            return;
+        }
+
+        var cmd = meta.Commands.FirstOrDefault(c => string.Equals(c.Name, commandName, StringComparison.OrdinalIgnoreCase));
+        if (cmd == null)
+        {
+            context.Response.StatusCode = StatusCodes.Status404NotFound;
+            await WriteJsonResponseAsync(context, new { success = false, message = $"Command '{commandName}' not found." });
+            return;
+        }
+
+        // Permission check
+        if (!cmd.OverrideEntityPermissions)
+        {
+            if (!await HasEntityPermissionAsync(context, meta, context.RequestAborted).ConfigureAwait(false))
+            {
+                context.Response.StatusCode = StatusCodes.Status403Forbidden;
+                await WriteJsonResponseAsync(context, new { success = false, message = "Access denied." });
+                return;
+            }
+        }
+
+        if (!string.IsNullOrEmpty(cmd.Permission))
+        {
+            var user = await UserAuth.GetUserAsync(context, context.RequestAborted).ConfigureAwait(false);
+            if (user == null || !user.Permissions.Split(',', StringSplitOptions.TrimEntries).Contains(cmd.Permission, StringComparer.OrdinalIgnoreCase))
+            {
+                context.Response.StatusCode = StatusCodes.Status403Forbidden;
+                await WriteJsonResponseAsync(context, new { success = false, message = "Insufficient permissions." });
+                return;
+            }
+        }
+
+        var instance = await DataScaffold.LoadAsync(meta, id);
+        if (instance == null)
+        {
+            context.Response.StatusCode = StatusCodes.Status404NotFound;
+            await WriteJsonResponseAsync(context, new { success = false, message = "Item not found." });
+            return;
+        }
+
+        try
+        {
+            RemoteCommandResult result;
+            var returnType = cmd.Method.ReturnType;
+            if (returnType == typeof(RemoteCommandResult))
+            {
+                result = (RemoteCommandResult)cmd.Method.Invoke(instance, null)!;
+            }
+            else if (returnType == typeof(Task<RemoteCommandResult>))
+            {
+                result = await (Task<RemoteCommandResult>)cmd.Method.Invoke(instance, null)!;
+            }
+            else
+            {
+                result = await (ValueTask<RemoteCommandResult>)cmd.Method.Invoke(instance, null)!;
+            }
+
+            // Save the entity in case the command modified it
+            await DataScaffold.SaveAsync(meta, instance);
+
+            context.Response.StatusCode = result.Success ? StatusCodes.Status200OK : StatusCodes.Status422UnprocessableEntity;
+            await WriteJsonResponseAsync(context, new { success = result.Success, message = result.Message, redirectUrl = result.RedirectUrl });
+        }
+        catch (Exception ex)
+        {
+            context.Response.StatusCode = StatusCodes.Status500InternalServerError;
+            await WriteJsonResponseAsync(context, new { success = false, message = $"Command failed: {ex.InnerException?.Message ?? ex.Message}" });
+        }
     }
 }

--- a/BareMetalWeb.Host/RouteRegistrationExtensions.cs
+++ b/BareMetalWeb.Host/RouteRegistrationExtensions.cs
@@ -304,5 +304,10 @@ public static class RouteRegistrationExtensions
         host.RegisterRoute("DELETE /api/{type}/{id}", new RouteHandlerData(
             pageInfoFactory.RawPage("Authenticated", false),
             routeHandlers.DataApiDeleteHandler));
+
+        // Remote commands
+        host.RegisterRoute("POST /api/{type}/{id}/_command/{command}", new RouteHandlerData(
+            pageInfoFactory.RawPage("Authenticated", false),
+            routeHandlers.DataCommandHandler));
     }
 }

--- a/BareMetalWeb.UserClasses/DataObjects/Order.cs
+++ b/BareMetalWeb.UserClasses/DataObjects/Order.cs
@@ -31,4 +31,22 @@ public class Order : RenderableDataObject
 
     [DataField(Label = "Order Rows", Order = 8)]
     public List<OrderRow> OrderRows { get; set; } = new();
+
+    [RemoteCommand(Label = "Approve", Icon = "bi-check-circle", ConfirmMessage = "Approve this order?", Order = 1)]
+    public RemoteCommandResult Approve()
+    {
+        if (Status == "Approved") return RemoteCommandResult.Fail("Order is already approved.");
+        Status = "Approved";
+        IsOpen = false;
+        return RemoteCommandResult.Ok("Order approved successfully.");
+    }
+
+    [RemoteCommand(Label = "Cancel", Icon = "bi-x-circle", Destructive = true, ConfirmMessage = "Cancel this order? This cannot be undone.", Order = 2)]
+    public RemoteCommandResult Cancel()
+    {
+        if (Status == "Cancelled") return RemoteCommandResult.Fail("Order is already cancelled.");
+        Status = "Cancelled";
+        IsOpen = false;
+        return RemoteCommandResult.Ok("Order cancelled.");
+    }
 }


### PR DESCRIPTION
Fixes #59

Adds `[RemoteCommand]` attribute infrastructure allowing developers to decorate entity methods as invocable actions. The framework auto-discovers commands at startup, renders action buttons on entity view pages, and exposes a `POST /api/{type}/{id}/_command/{method}` endpoint for execution.

**What's included:**
- `RemoteCommandAttribute` — Label, Icon, ConfirmMessage, Destructive, Permission, Order
- `RemoteCommandResult` — Success/Fail with message and optional redirect
- Discovery in `DataScaffold.BuildEntityMetadata` scanning for decorated methods
- Server-side execution with entity-level + command-level permission checks
- Client-side JS with confirmation dialog, spinner, toast feedback
- Example: Order entity with Approve and Cancel commands