### PR TITLE
Fix flaky DiskBufferedLogger test - shorten temp path

### DIFF
--- a/BareMetalWeb.Host.Tests/DiskBufferedLoggerTests.cs
+++ b/BareMetalWeb.Host.Tests/DiskBufferedLoggerTests.cs
@@ -13,7 +13,7 @@ public class DiskBufferedLoggerTests : IDisposable
 
     public DiskBufferedLoggerTests()
     {
-        _tempDir = Path.Combine(Path.GetTempPath(), $"DiskBufferedLoggerTests_{Guid.NewGuid():N}");
+        _tempDir = Path.Combine(Path.GetTempPath(), $"bmw_log_{Guid.NewGuid().ToString("N")[..8]}");
         Directory.CreateDirectory(_tempDir);
     }
 


### PR DESCRIPTION
Shortens the temp directory name in DiskBufferedLoggerTests from `DiskBufferedLoggerTests_<32-char-guid>` (56 chars) to `bmw_log_<8-char-guid>` (12 chars).

This prevents sporadic `OnApplicationStopping_FlushesRemainingLogs` failures on environments where `Path.GetTempPath()` returns a long path (e.g., Windows CI runners with deep user profile paths), causing the full log file path to exceed OS limits.

All 24 DiskBufferedLogger tests pass.