### PR TITLE
Fix flaky DiskBufferedLogger shutdown flush race condition

### DIFF
--- a/BareMetalWeb.Host.Tests/DiskBufferedLoggerTests.cs
+++ b/BareMetalWeb.Host.Tests/DiskBufferedLoggerTests.cs
@@ -355,23 +355,21 @@ public class DiskBufferedLoggerTests : IDisposable
     // ── Empty buffer flush ───────────────────────────────────────────
 
     [Fact]
-    public async Task RunAsync_EmptyBuffer_DoesNotCreateFile()
+    public async Task RunAsync_EmptyBuffer_StillWritesShutdownMessage()
     {
         // Arrange
         var logger = new DiskBufferedLogger(_tempDir);
 
-        // Act – run briefly with nothing buffered; Task.Delay throws before
-        // the final flush can execute, so no file is created
+        // Act – run briefly with nothing buffered
         using var cts = new CancellationTokenSource();
         cts.CancelAfter(TimeSpan.FromMilliseconds(100));
-        try { await logger.RunAsync(cts.Token); }
-        catch (OperationCanceledException) { }
+        await logger.RunAsync(cts.Token);
 
-        // Assert – no log file is created because the empty-buffer early-return
-        // in FlushOnceAsync prevents writing, and cancellation prevents
-        // the shutdown flush from being reached
+        // Assert – final shutdown flush always runs, writing the shutdown marker
         var infoFiles = Directory.GetFiles(_tempDir, "info_*.log", SearchOption.AllDirectories);
-        Assert.Empty(infoFiles);
+        Assert.Single(infoFiles);
+        var content = await File.ReadAllTextAsync(infoFiles[0]);
+        Assert.Contains("Clean shutdown completed", content);
     }
 
     // ── Shutdown flush with empty buffer ─────────────────────────────

--- a/BareMetalWeb.Host/DiskBufferedLogger.cs
+++ b/BareMetalWeb.Host/DiskBufferedLogger.cs
@@ -64,14 +64,20 @@ public sealed class DiskBufferedLogger : IBufferedLogger
     // If diagnosing why your logging is not working, remove this attribute
     public async Task RunAsync(CancellationToken cancellationToken)
     {
-  
-        while (!cancellationToken.IsCancellationRequested)
+        try
         {
-            await FlushOnceAsync(cancellationToken);
-            await Task.Delay(200, cancellationToken);
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                await FlushOnceAsync(cancellationToken);
+                await Task.Delay(200, cancellationToken);
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Expected during shutdown — fall through to final flush
         }
 
-        // Final flush on shutdown
+        // Final flush on shutdown — always runs even after cancellation
         await FlushOnceAsync(CancellationToken.None, isShutdown: true);
     }
 


### PR DESCRIPTION
## Root cause

`RunAsync` uses `Task.Delay(200, cancellationToken)` in its loop. When cancelled during the delay, `TaskCanceledException` propagates out of `RunAsync`, **skipping the final shutdown flush entirely**. This causes `OnApplicationStopping_FlushesRemainingLogs` to fail intermittently in CI (seen in PR #211 deploy run).

## Fix

Wrap the loop in `try/catch (OperationCanceledException)` so the final flush always executes after cancellation.

Also updates the empty-buffer test to reflect correct behavior (shutdown message is always written).