### PR TITLE
Add concurrency groups to all workflows (cancel-in-progress)

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -10,6 +10,10 @@ on:
       - '.github/workflows/build-cli.yml'
   workflow_dispatch:
 
+concurrency:
+  group: build-cli-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,6 +16,10 @@ on:
     - cron: '0 2 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/deploy-cimigrate.yml
+++ b/.github/workflows/deploy-cimigrate.yml
@@ -9,6 +9,10 @@ on:
   #   branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: deploy-cimigrate
+  cancel-in-progress: true
+
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/deploy-cireset.yml
+++ b/.github/workflows/deploy-cireset.yml
@@ -8,6 +8,10 @@ on:
   #   branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: deploy-cireset
+  cancel-in-progress: true
+
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -10,6 +10,10 @@ permissions:
 on:
   workflow_dispatch:
 
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
 jobs:
   build-and-deploy-prod:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: deploy-staging-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -5,6 +5,10 @@ run-name: "Performance Tests - V${{ vars.MAJOR_VERSION || '1' }}.${{ github.run_
 on:
   workflow_dispatch:
 
+concurrency:
+  group: performance-tests
+  cancel-in-progress: true
+
 permissions:
   contents: read
 

--- a/.github/workflows/reset-data-staging.yml
+++ b/.github/workflows/reset-data-staging.yml
@@ -5,6 +5,10 @@ run-name: "Reset Data Store (Staging) - V${{ vars.MAJOR_VERSION || '1' }}.${{ gi
 on:
   workflow_dispatch:
 
+concurrency:
+  group: reset-data-staging
+  cancel-in-progress: true
+
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,6 +5,10 @@ run-name: "Unit Tests - V${{ vars.MAJOR_VERSION || '1' }}.${{ github.run_number 
 on:
   workflow_dispatch:
 
+concurrency:
+  group: unit-tests-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Adds `concurrency` blocks to all 9 workflows so a new run cancels any in-progress run for the same group. This prevents queued builds from piling up when multiple pushes land in quick succession.

| Workflow | Group | Cancel in-progress? |
|----------|-------|---------------------|
| deploy.yml (staging) | `deploy-staging-{ref}` | ✅ Yes |
| build-cli.yml | `build-cli-{ref}` | ✅ Yes |
| unit-tests.yml | `unit-tests-{ref}` | ✅ Yes |
| codeql.yml | `codeql-{ref}` | ✅ Yes |
| deploy-cimigrate.yml | `deploy-cimigrate` | ✅ Yes |
| deploy-cireset.yml | `deploy-cireset` | ✅ Yes |
| performance-tests.yml | `performance-tests` | ✅ Yes |
| reset-data-staging.yml | `reset-data-staging` | ✅ Yes |
| **deploy-prod.yml** | `deploy-production` | ❌ **No** (queues, never cancels) |

Production deploy uses `cancel-in-progress: false` to ensure deployments always complete.