### PR TITLE
Add API CSRF protection to mutation handlers

### DIFF
--- a/BareMetalWeb.Host.Tests/CsrfProtectionTests.cs
+++ b/BareMetalWeb.Host.Tests/CsrfProtectionTests.cs
@@ -1,0 +1,80 @@
+using System;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace BareMetalWeb.Host.Tests;
+
+public class CsrfProtectionTests
+{
+    [Fact]
+    public void EnsureToken_CreatesTokenAndSetsCookie()
+    {
+        var context = new DefaultHttpContext();
+        var token = CsrfProtection.EnsureToken(context);
+
+        Assert.False(string.IsNullOrWhiteSpace(token));
+    }
+
+    [Fact]
+    public void EnsureToken_ReturnsSameTokenOnSecondCall()
+    {
+        var context = new DefaultHttpContext();
+        // Simulate a cookie already present
+        context.Request.Headers["Cookie"] = "csrf_token=existing-token-value";
+
+        var token = CsrfProtection.EnsureToken(context);
+        Assert.Equal("existing-token-value", token);
+    }
+
+    [Fact]
+    public void ValidateApiToken_ReturnsTrue_WhenHeaderMatchesCookie()
+    {
+        var context = new DefaultHttpContext();
+        var tokenValue = "test-csrf-token-abc123";
+        context.Request.Headers["Cookie"] = $"csrf_token={tokenValue}";
+        context.Request.Headers[CsrfProtection.ApiTokenHeaderName] = tokenValue;
+
+        Assert.True(CsrfProtection.ValidateApiToken(context));
+    }
+
+    [Fact]
+    public void ValidateApiToken_ReturnsFalse_WhenHeaderMissing()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers["Cookie"] = "csrf_token=test-token";
+
+        Assert.False(CsrfProtection.ValidateApiToken(context));
+    }
+
+    [Fact]
+    public void ValidateApiToken_ReturnsFalse_WhenCookieMissing()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers[CsrfProtection.ApiTokenHeaderName] = "test-token";
+
+        Assert.False(CsrfProtection.ValidateApiToken(context));
+    }
+
+    [Fact]
+    public void ValidateApiToken_ReturnsFalse_WhenTokensMismatch()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers["Cookie"] = "csrf_token=token-one";
+        context.Request.Headers[CsrfProtection.ApiTokenHeaderName] = "token-two";
+
+        Assert.False(CsrfProtection.ValidateApiToken(context));
+    }
+
+    [Fact]
+    public void ValidateApiToken_ReturnsFalse_WhenBothEmpty()
+    {
+        var context = new DefaultHttpContext();
+        Assert.False(CsrfProtection.ValidateApiToken(context));
+    }
+
+    [Fact]
+    public void ValidateApiToken_ThrowsOnNullContext()
+    {
+        Assert.Throws<ArgumentNullException>(() => CsrfProtection.ValidateApiToken(null!));
+    }
+}

--- a/BareMetalWeb.Host/CsrfProtection.cs
+++ b/BareMetalWeb.Host/CsrfProtection.cs
@@ -49,6 +49,27 @@ public static class CsrfProtection
         return FixedTimeEquals(cookieToken, formToken);
     }
 
+    public const string ApiTokenHeaderName = "X-CSRF-Token";
+
+    /// <summary>
+    /// Validates CSRF for API requests using double-submit cookie pattern.
+    /// Token is read from the X-CSRF-Token header instead of a form field.
+    /// </summary>
+    public static bool ValidateApiToken(HttpContext context)
+    {
+        if (context == null) throw new ArgumentNullException(nameof(context));
+
+        var cookieToken = context.GetCookie(CookieName);
+        if (string.IsNullOrWhiteSpace(cookieToken))
+            return false;
+
+        var headerToken = context.Request.Headers[ApiTokenHeaderName].ToString();
+        if (string.IsNullOrWhiteSpace(headerToken))
+            return false;
+
+        return FixedTimeEquals(cookieToken, headerToken);
+    }
+
     private static string GenerateToken()
     {
         Span<byte> buffer = stackalloc byte[32];

--- a/BareMetalWeb.Host/RouteHandlers.cs
+++ b/BareMetalWeb.Host/RouteHandlers.cs
@@ -2896,6 +2896,13 @@ public sealed class RouteHandlers : IRouteHandlers
             return;
         }
 
+        if (!ValidateApiCsrfHeader(context) || !CsrfProtection.ValidateApiToken(context))
+        {
+            context.Response.StatusCode = StatusCodes.Status403Forbidden;
+            await context.Response.WriteAsync("CSRF validation failed.");
+            return;
+        }
+
         var instance = meta.Handlers.Create();
 
         // Apply auto-generated IDs before binding JSON values
@@ -2961,6 +2968,13 @@ public sealed class RouteHandlers : IRouteHandlers
         {
             context.Response.StatusCode = StatusCodes.Status403Forbidden;
             await context.Response.WriteAsync("Access denied.");
+            return;
+        }
+
+        if (!ValidateApiCsrfHeader(context) || !CsrfProtection.ValidateApiToken(context))
+        {
+            context.Response.StatusCode = StatusCodes.Status403Forbidden;
+            await context.Response.WriteAsync("CSRF validation failed.");
             return;
         }
 
@@ -3034,6 +3048,13 @@ public sealed class RouteHandlers : IRouteHandlers
             return;
         }
 
+        if (!ValidateApiCsrfHeader(context) || !CsrfProtection.ValidateApiToken(context))
+        {
+            context.Response.StatusCode = StatusCodes.Status403Forbidden;
+            await context.Response.WriteAsync("CSRF validation failed.");
+            return;
+        }
+
         var instance = await DataScaffold.LoadAsync(meta, id);
         if (instance == null)
         {
@@ -3100,6 +3121,13 @@ public sealed class RouteHandlers : IRouteHandlers
         {
             context.Response.StatusCode = StatusCodes.Status403Forbidden;
             await context.Response.WriteAsync("Access denied.");
+            return;
+        }
+
+        if (!ValidateApiCsrfHeader(context) || !CsrfProtection.ValidateApiToken(context))
+        {
+            context.Response.StatusCode = StatusCodes.Status403Forbidden;
+            await context.Response.WriteAsync("CSRF validation failed.");
             return;
         }
 
@@ -4828,6 +4856,12 @@ public sealed class RouteHandlers : IRouteHandlers
         
         return html.ToString();
     }
+
+    private const string ApiCsrfHeaderName = "X-Requested-With";
+    private const string ApiCsrfHeaderValue = "BareMetalWeb";
+
+    private static bool ValidateApiCsrfHeader(HttpContext context)
+        => string.Equals(context.Request.Headers[ApiCsrfHeaderName], ApiCsrfHeaderValue, StringComparison.Ordinal);
 
     private static async ValueTask<bool> HasEntityPermissionAsync(HttpContext context, DataEntityMetadata meta, CancellationToken cancellationToken = default)
     {


### PR DESCRIPTION
## Summary

Adds dual-layer CSRF protection to all API mutation endpoints (POST, PUT, PATCH, DELETE).

### Changes

**Server-side validation (RouteHandlers.cs):**
- All 4 API mutation handlers now require:
  1. `X-Requested-With: BareMetalWeb` custom header — prevents cross-origin requests via CORS preflight
  2. `X-CSRF-Token` header matching `csrf_token` cookie — double-submit cookie pattern for defense in depth
- Returns 403 with 'CSRF validation failed' if either check fails

**CsrfProtection.cs:**
- Added `ValidateApiToken()` method — validates `X-CSRF-Token` header against `csrf_token` cookie using constant-time comparison
- Added `ApiTokenHeaderName` constant

**Tests (CsrfProtectionTests.cs):**
- 8 unit tests covering all validation paths (match, mismatch, missing header, missing cookie, both empty, null context, token generation)

### API consumers must now include:
```js
headers: {
  'X-Requested-With': 'BareMetalWeb',
  'X-CSRF-Token': document.cookie.match(/csrf_token=([^;]+)/)?.[1]
}
```

### Context
- Addresses CSRF vulnerability identified during PR #260 review
- Cookie auth means browsers auto-attach session cookies on cross-origin requests
- Custom header approach is industry standard (used by Azure DevOps, GitHub, etc.)
- No existing API consumers to break — safe to add as a requirement

Closes the CSRF concern raised in PR #260 review.