### PR TITLE
Add CSRF headers to classic UI remote commands

### DIFF
--- a/BareMetalWeb.Core/wwwroot/static/js/remote-command.js
+++ b/BareMetalWeb.Core/wwwroot/static/js/remote-command.js
@@ -5,6 +5,7 @@
     function executeRemoteCommand(button) {
         var url = button.getAttribute('data-command-url');
         var confirmMsg = button.getAttribute('data-confirm');
+        var csrfToken = button.getAttribute('data-csrf-token') || '';
 
         if (confirmMsg && !confirm(confirmMsg)) return;
 
@@ -12,7 +13,11 @@
         var originalHtml = button.innerHTML;
         button.innerHTML = '<span class="spinner-border spinner-border-sm" role="status"></span> Running\u2026';
 
-        fetch(url, { method: 'POST', headers: { 'Accept': 'application/json' } })
+        fetch(url, { method: 'POST', headers: {
+            'Accept': 'application/json',
+            'X-Requested-With': 'BareMetalWeb',
+            'X-CSRF-Token': csrfToken
+        } })
             .then(function(response) { return response.json(); })
             .then(function(data) {
                 button.disabled = false;

--- a/BareMetalWeb.Host.Tests/RouteHandlerTests.cs
+++ b/BareMetalWeb.Host.Tests/RouteHandlerTests.cs
@@ -807,7 +807,7 @@ public class RouteHandlerTests : IDisposable
     public void BuildCommandButtonsHtml_NoCommands_ReturnsEmpty()
     {
         var meta = CreateEmptyEntityMetadata();
-        var result = InvokeStatic<string>("BuildCommandButtonsHtml", meta, "product", "id1");
+        var result = InvokeStatic<string>("BuildCommandButtonsHtml", meta, "product", "id1", "test-csrf-token");
         Assert.Equal(string.Empty, result);
     }
 

--- a/BareMetalWeb.Host/RouteHandlers.cs
+++ b/BareMetalWeb.Host/RouteHandlers.cs
@@ -1610,7 +1610,7 @@ public sealed class RouteHandlers : IRouteHandlers
         var exportDropdown = BuildExportDropdown(typeSlug, string.Empty, hasNested, id);
         var rtfHtml = $"<a class=\"btn btn-sm btn-outline-info ms-2\" href=\"/admin/data/{typeSlug}/{WebUtility.UrlEncode(id)}/rtf\" title=\"Download RTF\" aria-label=\"Download RTF\"><i class=\"bi bi-download\" aria-hidden=\"true\"></i><i class=\"bi bi-file-earmark-text ms-1\" aria-hidden=\"true\"></i> RTF</a>";
         var htmlHtml = $"<a class=\"btn btn-sm btn-outline-primary ms-2\" href=\"/admin/data/{typeSlug}/{WebUtility.UrlEncode(id)}/html\" title=\"Download HTML\" aria-label=\"Download HTML\"><i class=\"bi bi-download\" aria-hidden=\"true\"></i><i class=\"bi bi-filetype-html ms-1\" aria-hidden=\"true\"></i> HTML</a>";
-        var commandButtons = BuildCommandButtonsHtml(meta, typeSlug, id);
+        var commandButtons = BuildCommandButtonsHtml(meta, typeSlug, id, CsrfProtection.EnsureToken(context));
         context.SetStringValue("title", $"{WebUtility.HtmlEncode(meta.Name)} Details");
         context.SetStringValue("message", $"<p><a class=\"btn btn-sm btn-outline-warning\" href=\"/admin/data/{typeSlug}/{WebUtility.UrlEncode(id)}/edit\" title=\"Edit\" aria-label=\"Edit\"><i class=\"bi bi-pencil\" aria-hidden=\"true\"></i> Edit</a>{exportDropdown}{rtfHtml}{htmlHtml}{commandButtons}</p>");
         context.AddTable(new[] { "Field", "Value" }, rows);
@@ -6046,17 +6046,18 @@ public sealed class RouteHandlers : IRouteHandlers
         return fields;
     }
 
-    private static string BuildCommandButtonsHtml(DataEntityMetadata meta, string typeSlug, string id)
+    private static string BuildCommandButtonsHtml(DataEntityMetadata meta, string typeSlug, string id, string csrfToken)
     {
         if (meta.Commands.Count == 0) return string.Empty;
         var sb = new StringBuilder();
         var safeId = WebUtility.UrlEncode(id);
+        var safeToken = WebUtility.HtmlEncode(csrfToken);
         foreach (var cmd in meta.Commands)
         {
             var btnClass = cmd.Destructive ? "btn-outline-danger" : "btn-outline-secondary";
             var icon = string.IsNullOrEmpty(cmd.Icon) ? "" : $"<i class=\"bi {WebUtility.HtmlEncode(cmd.Icon)}\" aria-hidden=\"true\"></i> ";
             var confirm = string.IsNullOrEmpty(cmd.ConfirmMessage) ? "" : $" data-confirm=\"{WebUtility.HtmlEncode(cmd.ConfirmMessage)}\"";
-            sb.Append($"<button class=\"btn btn-sm {btnClass} ms-2\" data-command-url=\"/api/{typeSlug}/{safeId}/_command/{WebUtility.UrlEncode(cmd.Name)}\"{confirm}>{icon}{WebUtility.HtmlEncode(cmd.Label)}</button>");
+            sb.Append($"<button class=\"btn btn-sm {btnClass} ms-2\" data-command-url=\"/api/{typeSlug}/{safeId}/_command/{WebUtility.UrlEncode(cmd.Name)}\" data-csrf-token=\"{safeToken}\"{confirm}>{icon}{WebUtility.HtmlEncode(cmd.Label)}</button>");
         }
         return sb.ToString();
     }
@@ -6090,6 +6091,13 @@ public sealed class RouteHandlers : IRouteHandlers
                 await WriteJsonResponseAsync(context, new { success = false, message = "Access denied." });
                 return;
             }
+        }
+
+        if (!ValidateApiCsrfHeader(context) || !CsrfProtection.ValidateApiToken(context))
+        {
+            context.Response.StatusCode = StatusCodes.Status403Forbidden;
+            await WriteJsonResponseAsync(context, new { success = false, message = "CSRF validation failed." });
+            return;
         }
 
         if (!string.IsNullOrEmpty(cmd.Permission))


### PR DESCRIPTION
## Summary

Extends CSRF protection (from PR #265) to the classic UI's remote command execution.

### Changes

**remote-command.js:**
- Sends `X-Requested-With: BareMetalWeb` and `X-CSRF-Token` headers on all POST requests
- Reads CSRF token from `data-csrf-token` attribute on the command button

**RouteHandlers.cs:**
- `BuildCommandButtonsHtml` now accepts a `csrfToken` parameter and embeds it as `data-csrf-token` on each button
- `DataCommandHandler` (`POST /api/{type}/{id}/_command/{command}`) now validates both CSRF headers

### Context
- `bmw-lookup.js` — GET-only, no changes needed
- `bulk-operations.js` — uses form POST to `/admin/data/` with form CSRF token, not affected
- `remote-command.js` — was the only classic UI JS making unprotected API POSTs