### PR TITLE
Fix VNext: lookup display names, date fields, navbar dropdowns

### DIFF
--- a/BareMetalWeb.Core/wwwroot/static/js/BareMetalBind.js
+++ b/BareMetalWeb.Core/wwwroot/static/js/BareMetalBind.js
@@ -18,9 +18,16 @@ const BareMetalBind = (() => {
   function bind(root, state, watch) {
     root.querySelectorAll('[rv-value]').forEach(n => {
       const k = n.getAttribute('rv-value'), chk = n.type === 'checkbox';
+      const isDate = n.type === 'date', isDtLocal = n.type === 'datetime-local';
+      const fmt = v => {
+        if (v == null || v === '') return '';
+        if (isDate) return String(v).slice(0, 10);          // YYYY-MM-DD
+        if (isDtLocal) return String(v).slice(0, 16);        // YYYY-MM-DDTHH:MM
+        return String(v);
+      };
       const sync = () => {
         if (chk) { n.checked = !!state[k]; }
-        else { const v = String(state[k] ?? ''); if (n.value !== v) n.value = v; }
+        else { const v = fmt(state[k]); if (n.value !== v) n.value = v; }
       };
       sync(); watch(k, sync);
       n.addEventListener(chk ? 'change' : 'input', () => state[k] = chk ? n.checked : n.value);

--- a/BareMetalWeb.Core/wwwroot/static/js/BareMetalRendering.js
+++ b/BareMetalWeb.Core/wwwroot/static/js/BareMetalRendering.js
@@ -69,7 +69,19 @@ const BareMetalRendering = (() => {
       BareMetalBind.bind(c, state, watch);
     };
 
-    return { state, save, load, renderUI, meta, api };
+    // Build a lookup resolver: fieldName → (rawValue → displayLabel)
+    const _lookupMaps = {};
+    Object.entries(schemaFields).forEach(([name, f]) => {
+      if (f && f.options && f.options.length) {
+        const m = new Map();
+        f.options.forEach(o => m.set(String(o.value), String(o.label)));
+        _lookupMaps[name] = v => m.get(String(v ?? '')) ?? String(v ?? '');
+      }
+    });
+    const resolve = (fieldName, rawValue) =>
+      _lookupMaps[fieldName] ? _lookupMaps[fieldName](rawValue) : String(rawValue ?? '');
+
+    return { state, save, load, renderUI, meta, api, resolve };
   }
 
   async function listEntities() {

--- a/BareMetalWeb.Core/wwwroot/static/js/BareMetalTemplate.js
+++ b/BareMetalWeb.Core/wwwroot/static/js/BareMetalTemplate.js
@@ -73,6 +73,7 @@ const BareMetalTemplate = (() => {
 
   function buildTable(fields, items, callbacks) {
     const cb    = callbacks || {};
+    const resolve = cb.resolve || ((name, v) => String(v ?? ''));
     const names = Object.keys(fields).filter(n => !fields[n].readonly).slice(0, 6);
     const wrap  = mk('div', { className: 'table-responsive' });
     const tbl   = mk('table', { className: 'table table-hover table-sm align-middle' });
@@ -82,7 +83,7 @@ const BareMetalTemplate = (() => {
     const tbody = tbl.createTBody();
     items.forEach(item => {
       const tr = tbody.insertRow();
-      names.forEach(n => { tr.insertCell().textContent = item[n] ?? ''; });
+      names.forEach(n => { tr.insertCell().textContent = resolve(n, item[n]); });
       const td = tr.insertCell(); td.className = 'text-end';
       const id = item.id || item.Id || '';
       if (cb.onView) {

--- a/BareMetalWeb.Core/wwwroot/static/js/vnext-app.js
+++ b/BareMetalWeb.Core/wwwroot/static/js/vnext-app.js
@@ -32,13 +32,48 @@
     brand.setAttribute('data-go', '');
     nav.appendChild(brand);
     const ul = el('ul', { className: 'navbar-nav me-auto' });
+
+    // Group entities by navGroup for dropdown menus
+    const groups = new Map();
     all.filter(e => e.showOnNav).forEach(e => {
-      const li = el('li', { className: 'nav-item' });
-      const a  = el('a', { className: 'nav-link' + (e.slug === activeSlug ? ' active' : ''), href: '/vnext/' + e.slug, textContent: e.name });
-      a.setAttribute('data-go', '');
-      li.appendChild(a);
-      ul.appendChild(li);
+      const g = e.navGroup || '';
+      if (!groups.has(g)) groups.set(g, []);
+      groups.get(g).push(e);
     });
+
+    groups.forEach((entities, groupName) => {
+      if (!groupName || entities.length === 1) {
+        // No group or single item — render as flat nav links
+        entities.forEach(e => {
+          const li = el('li', { className: 'nav-item' });
+          const a  = el('a', { className: 'nav-link' + (e.slug === activeSlug ? ' active' : ''), href: '/vnext/' + e.slug, textContent: e.name });
+          a.setAttribute('data-go', '');
+          li.appendChild(a);
+          ul.appendChild(li);
+        });
+      } else {
+        // Multiple items in a group — Bootstrap dropdown
+        const li = el('li', { className: 'nav-item dropdown' });
+        const toggle = el('a', {
+          className: 'nav-link dropdown-toggle' + (entities.some(e => e.slug === activeSlug) ? ' active' : ''),
+          href: '#', textContent: groupName, role: 'button'
+        });
+        toggle.setAttribute('data-bs-toggle', 'dropdown');
+        toggle.setAttribute('aria-expanded', 'false');
+        li.appendChild(toggle);
+        const menu = el('ul', { className: 'dropdown-menu' });
+        entities.forEach(e => {
+          const mli = el('li');
+          const a = el('a', { className: 'dropdown-item' + (e.slug === activeSlug ? ' active' : ''), href: '/vnext/' + e.slug, textContent: e.name });
+          a.setAttribute('data-go', '');
+          mli.appendChild(a);
+          menu.appendChild(mli);
+        });
+        li.appendChild(menu);
+        ul.appendChild(li);
+      }
+    });
+
     nav.appendChild(ul);
     nav.appendChild(el('a', { className: 'btn btn-sm btn-outline-light', href: '/admin/data', textContent: 'Classic UI' }));
     return nav;
@@ -95,6 +130,7 @@
           entity.meta.schema?.fields || {},
           Array.isArray(items) ? items : [],
           {
+            resolve:  (name, v) => entity.resolve(name, v),
             onView:   i => go(`/vnext/${slug}/${i}`),
             onEdit:   i => go(`/vnext/${slug}/${i}/edit`),
             onDelete: async i => {
@@ -141,7 +177,8 @@
             if (!f || f.type === 'hidden') return;
             const dt = el('dt', { className: 'col-sm-3 fw-semibold', textContent: f.label || name });
             const v  = entity.state[name];
-            const dd = el('dd', { className: 'col-sm-9', textContent: (v == null || v === '') ? '\u2014' : String(v) });
+            const display = entity.resolve(name, v);
+            const dd = el('dd', { className: 'col-sm-9', textContent: (v == null || v === '') ? '\u2014' : display });
             dl.append(dt, dd);
           });
           main.appendChild(dl);


### PR DESCRIPTION
Fixes three open VNext issues:

### Lookup fields show raw IDs (#268)
- `BareMetalRendering.createEntity()` now builds a `resolve(fieldName, rawValue)` function from the hydrated lookup options
- `BareMetalTemplate.buildTable()` accepts an optional `resolve` callback in its callbacks object
- `vnext-app.js` list view and detail view both use `entity.resolve()` to show display names instead of GUIDs

### Date fields don't populate in edit form (#269)
- `BareMetalBind.js` rv-value sync now detects `input[type=date]` and `input[type=datetime-local]`
- ISO date strings are sliced to `YYYY-MM-DD` or `YYYY-MM-DDTHH:MM` before setting `input.value`

### Navbar wraps with many entities (#270)
- `vnext-app.js` `navbar()` groups entities by `navGroup` into Bootstrap dropdown menus
- Single/ungrouped items render as flat nav links
- Active state highlighted on both dropdown toggle and individual items

Closes #268, closes #269, closes #270