### PR TITLE
fix: remove duplicate lookup route registrations, fix 3 broken tests

### DIFF
--- a/BareMetalWeb.Host.Tests/RouteRegistrationExtensionsTests.cs
+++ b/BareMetalWeb.Host.Tests/RouteRegistrationExtensionsTests.cs
@@ -953,6 +953,9 @@ public class RouteRegistrationExtensionsTests : IDisposable
         _server.RegisterDataRoutes(_routeHandlers, _pageInfoFactory, _mainTemplate);
         var afterData = _server.routes.Count;
 
+        _server.RegisterLookupApiRoutes(_pageInfoFactory);
+        var afterLookup = _server.routes.Count;
+
         _server.RegisterApiRoutes(_routeHandlers, _pageInfoFactory);
         var total = _server.routes.Count;
 
@@ -961,8 +964,9 @@ public class RouteRegistrationExtensionsTests : IDisposable
         Assert.True(afterMonitoring > afterAuth);
         Assert.True(afterAdmin > afterMonitoring);
         Assert.True(afterData > afterAdmin);
-        Assert.True(total > afterData);
-        Assert.Equal(staticCount + 16 + 4 + 8 + 21 + 7, total); // 3+16+4+8+21+7=59
+        Assert.True(afterLookup > afterData);
+        Assert.True(total > afterLookup);
+        Assert.Equal(staticCount + 16 + 4 + 7 + 21 + 4 + 8, total); // 3+16+4+7+21+4+8=63
     }
 
     [Fact]

--- a/BareMetalWeb.Host/RouteRegistrationExtensions.cs
+++ b/BareMetalWeb.Host/RouteRegistrationExtensions.cs
@@ -459,16 +459,8 @@ public static class RouteRegistrationExtensions
         IRouteHandlers routeHandlers,
         IPageInfoFactory pageInfoFactory)
     {
-        // Lookup API endpoints — must be registered before parameterised /api/{type}
-        // routes to prevent /api/_lookup/customers matching as {type}=_lookup {id}=customers
-        host.RegisterRoute("GET /api/_lookup/{type}/_field/{id}/{fieldName}", new RouteHandlerData(
-            pageInfoFactory.RawPage("Public", false), LookupApiHandlers.GetEntityFieldHandler));
-        host.RegisterRoute("GET /api/_lookup/{type}/_aggregate", new RouteHandlerData(
-            pageInfoFactory.RawPage("Public", false), LookupApiHandlers.AggregateEntitiesHandler));
-        host.RegisterRoute("GET /api/_lookup/{type}/{id}", new RouteHandlerData(
-            pageInfoFactory.RawPage("Public", false), LookupApiHandlers.GetEntityByIdHandler));
-        host.RegisterRoute("GET /api/_lookup/{type}", new RouteHandlerData(
-            pageInfoFactory.RawPage("Public", false), LookupApiHandlers.QueryEntitiesHandler));
+        // Lookup API routes are registered separately via RegisterLookupApiRoutes()
+        // which must be called before this method (see BareMetalWebExtensions.cs).
 
         // List and create
         host.RegisterRoute("GET /api/{type}", new RouteHandlerData(


### PR DESCRIPTION
## Problem

3 route registration tests were failing after PR #284 merged lookup routes:

1. **RegisterApiRoutes_RegistersExactlySevenRoutes** — expected 8, got 12
2. **RegisterApiRoutes_AllRoutes_HaveAuthenticatedPermission** — found 'Public' routes
3. **AllRegistrationMethods_ProduceNonOverlappingRoutes** — expected 59, got 63

## Root cause

`RegisterApiRoutes` contained 4 duplicate `_lookup` route registrations that were already handled by `RegisterLookupApiRoutes` (added in PR #284). The duplicates inflated the route count and introduced Public-permission routes in a method where all routes should be Authenticated.

## Fix

- Removed the 4 duplicate `_lookup` route registrations from `RegisterApiRoutes`
- Added `RegisterLookupApiRoutes` call to the `AllRegistrationMethods` test
- Updated total route count: 59 → 63 (accounting for lookup + admin changes)

All 1,474 non-integration tests pass.