### PR TITLE
Refactor Employee to metadata-driven virtual entity

### DIFF
--- a/BareMetalWeb.Data.Tests/VirtualEmployeeTests.cs
+++ b/BareMetalWeb.Data.Tests/VirtualEmployeeTests.cs
@@ -1,0 +1,343 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using BareMetalWeb.Core;
+using BareMetalWeb.Data;
+using BareMetalWeb.Rendering.Models;
+using Xunit;
+
+namespace BareMetalWeb.Data.Tests;
+
+/// <summary>
+/// Tests for the virtual Employee entity (issue #301): viewType, parentField,
+/// self-referencing lookup, and two-pass lookup resolution.
+/// </summary>
+public class VirtualEmployeeTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public VirtualEmployeeTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"VEmpTests_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, recursive: true); } catch { }
+    }
+
+    private string WriteJson(string json)
+    {
+        var path = Path.Combine(_tempDir, $"ve_{Guid.NewGuid():N}.json");
+        File.WriteAllText(path, json);
+        return path;
+    }
+
+    // ── ViewType support ────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("treeview", ViewType.TreeView)]
+    [InlineData("tree", ViewType.TreeView)]
+    [InlineData("orgchart", ViewType.OrgChart)]
+    [InlineData("timeline", ViewType.Timeline)]
+    [InlineData("timetable", ViewType.Timetable)]
+    [InlineData(null, ViewType.Table)]
+    [InlineData("table", ViewType.Table)]
+    public void ViewType_MapsCorrectly(string? viewTypeValue, ViewType expected)
+    {
+        var slug = $"vt-{Guid.NewGuid():N}";
+        var vtJson = viewTypeValue != null ? $"\"viewType\": \"{viewTypeValue}\"," : "";
+        var json = $$"""
+        {
+          "virtualEntities": [{
+            "entityId": "{{Guid.NewGuid():D}}",
+            "name": "VTTest",
+            "slug": "{{slug}}",
+            {{vtJson}}
+            "fields": [{ "fieldId": "{{Guid.NewGuid():D}}", "name": "Title", "type": "string" }]
+          }]
+        }
+        """;
+
+        var path = WriteJson(json);
+        VirtualEntityLoader.LoadFromFile(path, _tempDir);
+
+        Assert.True(DataScaffold.TryGetEntity(slug, out var meta));
+        Assert.Equal(expected, meta!.ViewType);
+    }
+
+    // ── ParentField support ─────────────────────────────────────────────────
+
+    [Fact]
+    public void ParentField_ResolvesToMatchingFieldMetadata()
+    {
+        var slug = $"pf-{Guid.NewGuid():N}";
+        var json = $$"""
+        {
+          "virtualEntities": [{
+            "entityId": "{{Guid.NewGuid():D}}",
+            "name": "PFTest",
+            "slug": "{{slug}}",
+            "viewType": "treeview",
+            "parentField": "ParentId",
+            "fields": [
+              { "fieldId": "{{Guid.NewGuid():D}}", "name": "Name", "type": "string", "order": 1 },
+              { "fieldId": "{{Guid.NewGuid():D}}", "name": "ParentId", "type": "string", "order": 2 }
+            ]
+          }]
+        }
+        """;
+
+        var path = WriteJson(json);
+        VirtualEntityLoader.LoadFromFile(path, _tempDir);
+
+        Assert.True(DataScaffold.TryGetEntity(slug, out var meta));
+        Assert.NotNull(meta!.ParentField);
+        Assert.Equal("ParentId", meta.ParentField!.Name);
+    }
+
+    [Fact]
+    public void ParentField_NullWhenNotSpecified()
+    {
+        var slug = $"npf-{Guid.NewGuid():N}";
+        var json = $$"""
+        {
+          "virtualEntities": [{
+            "entityId": "{{Guid.NewGuid():D}}",
+            "name": "NPFTest",
+            "slug": "{{slug}}",
+            "fields": [
+              { "fieldId": "{{Guid.NewGuid():D}}", "name": "Title", "type": "string" }
+            ]
+          }]
+        }
+        """;
+
+        var path = WriteJson(json);
+        VirtualEntityLoader.LoadFromFile(path, _tempDir);
+
+        Assert.True(DataScaffold.TryGetEntity(slug, out var meta));
+        Assert.Null(meta!.ParentField);
+    }
+
+    // ── Self-referencing lookup (two-pass resolution) ───────────────────────
+
+    [Fact]
+    public void SelfReferencingLookup_ResolvesViaTwoPassLoading()
+    {
+        var slug = $"selfref-{Guid.NewGuid():N}";
+        var json = $$"""
+        {
+          "virtualEntities": [{
+            "entityId": "{{Guid.NewGuid():D}}",
+            "name": "SelfRefEntity",
+            "slug": "{{slug}}",
+            "viewType": "treeview",
+            "parentField": "ParentId",
+            "fields": [
+              { "fieldId": "{{Guid.NewGuid():D}}", "name": "Name", "type": "string", "order": 1 },
+              {
+                "fieldId": "{{Guid.NewGuid():D}}",
+                "name": "ParentId",
+                "type": "lookup",
+                "lookupEntity": "{{slug}}",
+                "lookupDisplayField": "Name",
+                "lookupQueryField": "Id",
+                "lookupQueryOperator": "notequals",
+                "order": 2
+              }
+            ]
+          }]
+        }
+        """;
+
+        var path = WriteJson(json);
+        VirtualEntityLoader.LoadFromFile(path, _tempDir);
+
+        Assert.True(DataScaffold.TryGetEntity(slug, out var meta));
+        var lookupField = meta!.Fields.FirstOrDefault(f => f.Name == "ParentId");
+        Assert.NotNull(lookupField);
+        Assert.NotNull(lookupField!.Lookup);
+        Assert.Equal("Name", lookupField.Lookup!.DisplayField);
+        Assert.Equal("Id", lookupField.Lookup.QueryField);
+        Assert.Equal(QueryOperator.NotEquals, lookupField.Lookup.QueryOperator);
+    }
+
+    // ── Cross-entity lookup resolves between virtual entities ───────────────
+
+    [Fact]
+    public void CrossEntityLookup_ResolvesBetweenVirtualEntities()
+    {
+        var deptSlug = $"dept-{Guid.NewGuid():N}";
+        var empSlug = $"emp-{Guid.NewGuid():N}";
+        var json = $$"""
+        {
+          "virtualEntities": [
+            {
+              "entityId": "{{Guid.NewGuid():D}}",
+              "name": "VDept",
+              "slug": "{{deptSlug}}",
+              "fields": [
+                { "fieldId": "{{Guid.NewGuid():D}}", "name": "DeptName", "type": "string" }
+              ]
+            },
+            {
+              "entityId": "{{Guid.NewGuid():D}}",
+              "name": "VEmpWithDept",
+              "slug": "{{empSlug}}",
+              "fields": [
+                { "fieldId": "{{Guid.NewGuid():D}}", "name": "Name", "type": "string", "order": 1 },
+                {
+                  "fieldId": "{{Guid.NewGuid():D}}",
+                  "name": "DeptId",
+                  "type": "lookup",
+                  "lookupEntity": "{{deptSlug}}",
+                  "lookupDisplayField": "DeptName",
+                  "order": 2
+                }
+              ]
+            }
+          ]
+        }
+        """;
+
+        var path = WriteJson(json);
+        VirtualEntityLoader.LoadFromFile(path, _tempDir);
+
+        Assert.True(DataScaffold.TryGetEntity(empSlug, out var meta));
+        var lookup = meta!.Fields.First(f => f.Name == "DeptId").Lookup;
+        Assert.NotNull(lookup);
+        Assert.Equal("DeptName", lookup!.DisplayField);
+    }
+
+    // ── Full VEmployee definition matches compiled Employee shape ────────────
+
+    [Fact]
+    public void VEmployee_FromJson_MatchesCompiledEmployeeShape()
+    {
+        var slug = $"vemp-full-{Guid.NewGuid():N}";
+        var json = $$"""
+        {
+          "virtualEntities": [{
+            "entityId": "{{Guid.NewGuid():D}}",
+            "name": "VEmployeeFull",
+            "slug": "{{slug}}",
+            "showOnNav": true,
+            "navGroup": "Organization",
+            "navOrder": 11,
+            "viewType": "treeview",
+            "parentField": "ManagerId",
+            "idStrategy": "guid",
+            "fields": [
+              { "fieldId": "{{Guid.NewGuid():D}}", "name": "Name", "type": "string", "required": true, "order": 2, "list": true, "view": true, "edit": true, "create": true },
+              { "fieldId": "{{Guid.NewGuid():D}}", "name": "Title", "type": "string", "order": 3, "list": true, "view": true, "edit": true, "create": true },
+              { "fieldId": "{{Guid.NewGuid():D}}", "name": "Email", "type": "email", "order": 4, "list": true, "view": true, "edit": true, "create": true },
+              {
+                "fieldId": "{{Guid.NewGuid():D}}",
+                "name": "ManagerId",
+                "type": "lookup",
+                "label": "Manager",
+                "lookupEntity": "{{slug}}",
+                "lookupDisplayField": "Name",
+                "lookupQueryField": "Id",
+                "lookupQueryOperator": "notequals",
+                "order": 5,
+                "list": true, "view": true, "edit": true, "create": true
+              },
+              { "fieldId": "{{Guid.NewGuid():D}}", "name": "Department", "type": "string", "order": 6, "list": true, "view": true, "edit": true, "create": true },
+              { "fieldId": "{{Guid.NewGuid():D}}", "name": "HireDate", "type": "date", "nullable": true, "order": 7, "list": false, "view": true, "edit": true, "create": true }
+            ]
+          }]
+        }
+        """;
+
+        var path = WriteJson(json);
+        VirtualEntityLoader.LoadFromFile(path, _tempDir);
+
+        Assert.True(DataScaffold.TryGetEntity(slug, out var meta));
+        Assert.NotNull(meta);
+
+        // Entity-level properties
+        Assert.True(meta!.ShowOnNav);
+        Assert.Equal("Organization", meta.NavGroup);
+        Assert.Equal(ViewType.TreeView, meta.ViewType);
+        Assert.Equal(AutoIdStrategy.Guid, meta.IdGeneration);
+
+        // ParentField
+        Assert.NotNull(meta.ParentField);
+        Assert.Equal("ManagerId", meta.ParentField!.Name);
+
+        // Field count (6 user fields, matching compiled Employee)
+        Assert.Equal(6, meta.Fields.Count);
+
+        // Field names in order
+        var names = meta.Fields.Select(f => f.Name).ToList();
+        Assert.Equal(new[] { "Name", "Title", "Email", "ManagerId", "Department", "HireDate" }, names);
+
+        // Name is required
+        Assert.True(meta.Fields.First(f => f.Name == "Name").Required);
+
+        // Email uses Email field type
+        Assert.Equal(FormFieldType.Email, meta.Fields.First(f => f.Name == "Email").FieldType);
+
+        // HireDate is DateOnly
+        Assert.Equal(FormFieldType.DateOnly, meta.Fields.First(f => f.Name == "HireDate").FieldType);
+        Assert.False(meta.Fields.First(f => f.Name == "HireDate").List);
+
+        // ManagerId has self-referencing lookup
+        var mgr = meta.Fields.First(f => f.Name == "ManagerId");
+        Assert.NotNull(mgr.Lookup);
+        Assert.Equal("Name", mgr.Lookup!.DisplayField);
+        Assert.Equal("Id", mgr.Lookup.QueryField);
+        Assert.Equal(QueryOperator.NotEquals, mgr.Lookup.QueryOperator);
+    }
+
+    // ── CRUD works for virtual Employee ─────────────────────────────────────
+
+    [Fact]
+    public async Task VEmployee_CRUD_WorksWithJsonStore()
+    {
+        var slug = $"vemp-crud-{Guid.NewGuid():N}";
+        var json = $$"""
+        {
+          "virtualEntities": [{
+            "entityId": "{{Guid.NewGuid():D}}",
+            "name": "VEmpCrud",
+            "slug": "{{slug}}",
+            "idStrategy": "guid",
+            "fields": [
+              { "fieldId": "{{Guid.NewGuid():D}}", "name": "Name", "type": "string", "required": true, "order": 1 },
+              { "fieldId": "{{Guid.NewGuid():D}}", "name": "Department", "type": "string", "order": 2 }
+            ]
+          }]
+        }
+        """;
+
+        var path = WriteJson(json);
+        VirtualEntityLoader.LoadFromFile(path, _tempDir);
+
+        Assert.True(DataScaffold.TryGetEntity(slug, out var meta));
+
+        // Create
+        var emp = (DynamicDataObject)meta!.Handlers.Create();
+        emp.Id = Guid.NewGuid().ToString("D");
+        emp.SetField("Name", "Alice Smith");
+        emp.SetField("Department", "Engineering");
+
+        // Save
+        await DataScaffold.SaveAsync(meta, emp);
+
+        // Load
+        var loaded = (DynamicDataObject?)await DataScaffold.LoadAsync(meta, emp.Id);
+        Assert.NotNull(loaded);
+        Assert.Equal("Alice Smith", loaded!.GetField("Name"));
+        Assert.Equal("Engineering", loaded.GetField("Department"));
+
+        // Delete
+        await meta.Handlers.DeleteAsync(emp.Id, default);
+        var deleted = await DataScaffold.LoadAsync(meta, emp.Id);
+        Assert.Null(deleted);
+    }
+}

--- a/BareMetalWeb.Data/VirtualEntityDefinition.cs
+++ b/BareMetalWeb.Data/VirtualEntityDefinition.cs
@@ -50,6 +50,14 @@ public sealed class VirtualEntityDef
     [JsonPropertyName("navOrder")]
     public int NavOrder { get; set; } = 0;
 
+    /// <summary>View type for list rendering: "table" (default), "treeview", "orgchart", "timeline", "timetable".</summary>
+    [JsonPropertyName("viewType")]
+    public string? ViewType { get; set; }
+
+    /// <summary>Field name used as the parent reference for tree/org chart views.</summary>
+    [JsonPropertyName("parentField")]
+    public string? ParentField { get; set; }
+
     /// <summary>Field definitions for this entity.</summary>
     [JsonPropertyName("fields")]
     public List<VirtualFieldDef> Fields { get; set; } = new();
@@ -107,6 +115,14 @@ public sealed class VirtualFieldDef
     /// <summary>Display field on the target entity (default: "Id").</summary>
     [JsonPropertyName("lookupDisplayField")]
     public string? LookupDisplayField { get; set; }
+
+    /// <summary>Query field used to filter lookup results (e.g. "Id" to exclude current record).</summary>
+    [JsonPropertyName("lookupQueryField")]
+    public string? LookupQueryField { get; set; }
+
+    /// <summary>Query operator for lookup filtering: "equals", "notequals", "contains", etc.</summary>
+    [JsonPropertyName("lookupQueryOperator")]
+    public string? LookupQueryOperator { get; set; }
 
     /// <summary>Display order in forms and list views.</summary>
     [JsonPropertyName("order")]

--- a/BareMetalWeb.Data/VirtualEntityLoader.cs
+++ b/BareMetalWeb.Data/VirtualEntityLoader.cs
@@ -43,20 +43,38 @@ public static class VirtualEntityLoader
 
         var store = new VirtualEntityJsonStore(dataRootPath);
 
+        // Pass 1: Register all entities without lookup resolution so self-referencing
+        // and cross-entity lookups can resolve in the second pass.
+        var deferredLookups = new List<(VirtualEntityDef Def, DataEntityMetadata Meta)>();
+
         foreach (var entityDef in root.VirtualEntities)
         {
             if (string.IsNullOrWhiteSpace(entityDef.Name))
                 continue;
 
-            var metadata = BuildEntityMetadata(entityDef, store);
+            var metadata = BuildEntityMetadata(entityDef, store, resolveLookups: false);
             if (metadata != null)
+            {
                 DataScaffold.RegisterVirtualEntity(metadata);
+                deferredLookups.Add((entityDef, metadata));
+            }
+        }
+
+        // Pass 2: Re-register entities that have lookup fields now that all slugs exist.
+        foreach (var (entityDef, meta) in deferredLookups)
+        {
+            if (!entityDef.Fields.Any(f => string.Equals(f.Type, "lookup", StringComparison.OrdinalIgnoreCase)))
+                continue;
+
+            var updated = BuildEntityMetadata(entityDef, store, resolveLookups: true);
+            if (updated != null)
+                DataScaffold.RegisterVirtualEntity(updated);
         }
     }
 
     // ── Entity metadata ───────────────────────────────────────────────────────
 
-    private static DataEntityMetadata? BuildEntityMetadata(VirtualEntityDef def, VirtualEntityJsonStore store)
+    private static DataEntityMetadata? BuildEntityMetadata(VirtualEntityDef def, VirtualEntityJsonStore store, bool resolveLookups = true)
     {
         var entityTypeName = def.Name;
         var slug = !string.IsNullOrWhiteSpace(def.Slug)
@@ -78,7 +96,7 @@ public static class VirtualEntityLoader
         var fields = new List<DataFieldMetadata>();
         for (int i = 0; i < def.Fields.Count; i++)
         {
-            var field = BuildFieldMetadata(def.Fields[i], defaultOrder: i + 1);
+            var field = BuildFieldMetadata(def.Fields[i], defaultOrder: i + 1, resolveLookups: resolveLookups);
             if (field != null)
                 fields.Add(field);
         }
@@ -108,6 +126,22 @@ public static class VirtualEntityLoader
             CountAsync: (query, ct) => store.CountAsync(entityTypeName, query, ct)
         );
 
+        var viewType = (def.ViewType?.ToLowerInvariant()) switch
+        {
+            "treeview" or "tree" => Data.ViewType.TreeView,
+            "orgchart" or "org" => Data.ViewType.OrgChart,
+            "timeline" => Data.ViewType.Timeline,
+            "timetable" => Data.ViewType.Timetable,
+            _ => Data.ViewType.Table
+        };
+
+        var orderedFields = fields.OrderBy(f => f.Order).ToList();
+
+        DataFieldMetadata? parentField = null;
+        if (!string.IsNullOrWhiteSpace(def.ParentField))
+            parentField = orderedFields.FirstOrDefault(f =>
+                string.Equals(f.Name, def.ParentField, StringComparison.OrdinalIgnoreCase));
+
         return new DataEntityMetadata(
             Type: typeof(DynamicDataObject),
             Name: def.Name,
@@ -117,9 +151,9 @@ public static class VirtualEntityLoader
             NavGroup: def.NavGroup,
             NavOrder: def.NavOrder,
             IdGeneration: idStrategy,
-            ViewType: ViewType.Table,
-            ParentField: null,
-            Fields: fields.OrderBy(f => f.Order).ToList(),
+            ViewType: viewType,
+            ParentField: parentField,
+            Fields: orderedFields,
             Handlers: handlers,
             Commands: Array.Empty<RemoteCommandMetadata>()
         );
@@ -127,7 +161,7 @@ public static class VirtualEntityLoader
 
     // ── Field metadata ─────────────────────────────────────────────────────────
 
-    private static DataFieldMetadata? BuildFieldMetadata(VirtualFieldDef fieldDef, int defaultOrder)
+    private static DataFieldMetadata? BuildFieldMetadata(VirtualFieldDef fieldDef, int defaultOrder, bool resolveLookups = true)
     {
         if (string.IsNullOrWhiteSpace(fieldDef.Name))
             return null;
@@ -139,7 +173,7 @@ public static class VirtualEntityLoader
         var order = fieldDef.Order > 0 ? fieldDef.Order : defaultOrder;
 
         var (clrType, fieldType) = MapFieldType(fieldDef);
-        var lookup = BuildLookupConfig(fieldDef);
+        var lookup = resolveLookups ? BuildLookupConfig(fieldDef) : null;
         var validation = BuildValidationConfig(fieldDef);
 
         return new DataFieldMetadata(
@@ -275,12 +309,25 @@ public static class VirtualEntityLoader
             ? fieldDef.LookupDisplayField!
             : valueField;
 
+        var queryField = !string.IsNullOrWhiteSpace(fieldDef.LookupQueryField)
+            ? fieldDef.LookupQueryField
+            : null;
+
+        var queryOperator = (fieldDef.LookupQueryOperator?.ToLowerInvariant()) switch
+        {
+            "notequals" or "ne" or "!=" => QueryOperator.NotEquals,
+            "equals" or "eq" or "==" => QueryOperator.Equals,
+            "greaterthan" or "gt" or ">" => QueryOperator.GreaterThan,
+            "lessthan" or "lt" or "<" => QueryOperator.LessThan,
+            _ => QueryOperator.Contains
+        };
+
         return new DataLookupConfig(
             TargetType: targetMeta.Type,
             ValueField: valueField,
             DisplayField: displayField,
-            QueryField: null,
-            QueryOperator: QueryOperator.Contains,
+            QueryField: queryField,
+            QueryOperator: queryOperator,
             QueryValue: null,
             SortField: null,
             SortDirection: SortDirection.Asc,

--- a/BareMetalWeb.Host/virtualEntities.json
+++ b/BareMetalWeb.Host/virtualEntities.json
@@ -67,6 +67,92 @@
           "order": 5
         }
       ]
+    },
+    {
+      "entityId": "b2c3d4e5-f6a7-8901-bcde-f23456789012",
+      "name": "VEmployee",
+      "slug": "vemployees",
+      "showOnNav": true,
+      "permissions": "authenticated",
+      "idStrategy": "guid",
+      "navGroup": "Organization",
+      "navOrder": 11,
+      "viewType": "treeview",
+      "parentField": "ManagerId",
+      "fields": [
+        {
+          "fieldId": "f2000001-0000-0000-0000-000000000001",
+          "name": "Name",
+          "type": "string",
+          "required": true,
+          "label": "Name",
+          "list": true,
+          "view": true,
+          "edit": true,
+          "create": true,
+          "order": 2
+        },
+        {
+          "fieldId": "f2000001-0000-0000-0000-000000000002",
+          "name": "Title",
+          "type": "string",
+          "label": "Title",
+          "list": true,
+          "view": true,
+          "edit": true,
+          "create": true,
+          "order": 3
+        },
+        {
+          "fieldId": "f2000001-0000-0000-0000-000000000003",
+          "name": "Email",
+          "type": "email",
+          "label": "Email",
+          "list": true,
+          "view": true,
+          "edit": true,
+          "create": true,
+          "order": 4
+        },
+        {
+          "fieldId": "f2000001-0000-0000-0000-000000000004",
+          "name": "ManagerId",
+          "type": "lookup",
+          "label": "Manager",
+          "lookupEntity": "vemployees",
+          "lookupDisplayField": "Name",
+          "lookupQueryField": "Id",
+          "lookupQueryOperator": "notequals",
+          "list": true,
+          "view": true,
+          "edit": true,
+          "create": true,
+          "order": 5
+        },
+        {
+          "fieldId": "f2000001-0000-0000-0000-000000000005",
+          "name": "Department",
+          "type": "string",
+          "label": "Department",
+          "list": true,
+          "view": true,
+          "edit": true,
+          "create": true,
+          "order": 6
+        },
+        {
+          "fieldId": "f2000001-0000-0000-0000-000000000006",
+          "name": "HireDate",
+          "type": "date",
+          "label": "Hire Date",
+          "nullable": true,
+          "list": false,
+          "view": true,
+          "edit": true,
+          "create": true,
+          "order": 7
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Closes #301

## Summary
Adds support for defining Employee as a virtual entity in `virtualEntities.json`, proving out the metadata-driven approach for entities that were previously compiled C# classes.

## Changes

### VirtualEntityDefinition.cs
- Added `viewType` property ("treeview", "orgchart", "timeline", "timetable", "table")
- Added `parentField` property for tree/org chart parent reference
- Added `lookupQueryField` and `lookupQueryOperator` to `VirtualFieldDef` for filtered lookups

### VirtualEntityLoader.cs
- **Two-pass loading**: Pass 1 registers all entities without lookups, Pass 2 resolves lookup fields — enables self-referencing and cross-entity lookups between virtual entities
- Maps `viewType` string → `ViewType` enum
- Resolves `parentField` string → matching `DataFieldMetadata`
- Supports `lookupQueryField` / `lookupQueryOperator` (notequals, equals, gt, lt)

### virtualEntities.json
- Added `VEmployee` virtual entity with:
  - TreeView viewType + ManagerId parentField
  - 6 fields matching compiled Employee (Name, Title, Email, ManagerId, Department, HireDate)
  - Self-referencing ManagerId lookup with NotEquals filter
  - GUID ID strategy, Organization nav group

### Tests (13 new)
- ViewType mapping (7 theory cases)
- ParentField resolution
- Self-referencing lookup via two-pass loading
- Cross-entity lookup between virtual entities
- Full VEmployee shape validation against compiled Employee
- CRUD operations via JSON store

## Notes
- The compiled `Employee.cs` is kept alongside `VEmployee` for backwards compatibility — existing tests reference the compiled type directly
- VEmployee slug is `vemployees` to avoid collision with compiled `employees` slug
- This validates the full virtual entity pipeline: JSON definition → loader → scaffold registration → CRUD