### PR TITLE
Fix VNext form validation to use HTML5 constraint API

### DIFF
--- a/BareMetalWeb.Core/wwwroot/static/js/vnext-app.js
+++ b/BareMetalWeb.Core/wwwroot/static/js/vnext-app.js
@@ -1515,6 +1515,14 @@
             }
         });
 
+        // Clear validation errors as user corrects fields
+        form.addEventListener('input', function (ev) {
+            var el = ev.target;
+            if (el && el.classList.contains('is-invalid') && el.checkValidity()) {
+                el.classList.remove('is-invalid');
+            }
+        });
+
         // Form submit
         form.addEventListener('submit', function (e) {
             e.preventDefault();
@@ -1710,11 +1718,14 @@
 
     function validateForm(form) {
         var valid = true;
-        form.querySelectorAll('input[required], select[required], textarea[required]').forEach(function (el) {
-            if (!el.value.trim()) {
+        form.querySelectorAll('input, select, textarea').forEach(function (el) {
+            if (el.type === 'hidden' || el.readOnly || el.disabled) return;
+            if (!el.checkValidity()) {
                 el.classList.add('is-invalid');
                 var fb = el.nextElementSibling;
-                if (fb && fb.classList.contains('invalid-feedback')) fb.textContent = el.labels && el.labels[0] ? el.labels[0].textContent.trim() + ' is required.' : 'Required.';
+                if (fb && fb.classList.contains('invalid-feedback')) {
+                    fb.textContent = el.validationMessage || 'Invalid value.';
+                }
                 valid = false;
             } else {
                 el.classList.remove('is-invalid');


### PR DESCRIPTION
Closes #356

## Problem
`validateForm()` only checked `required` fields for empty values, completely ignoring `minlength`, `maxlength`, `min`, `max`, and `pattern` attributes that were already being rendered on form inputs.

## Fix
- Use `el.checkValidity()` (browser's built-in HTML5 constraint validation API) instead of manual empty-string check
- Validates ALL input/select/textarea elements, not just `[required]` ones
- Displays the browser's native `validationMessage` in the Bootstrap `invalid-feedback` div
- Skips hidden, readonly, and disabled fields
- Adds live `input` handler to clear `.is-invalid` as user corrects values

## What now works
- `minlength` / `maxlength` validation
- `min` / `max` range validation
- `pattern` regex validation
- `required` (still works, via checkValidity)
- Type-specific validation (email format, number format, date format)