### PR TITLE
perf: bundle VNext SPA scripts into single vnext-bundle.js (#439)

### DIFF
--- a/BareMetalWeb.Host/JsBundleService.cs
+++ b/BareMetalWeb.Host/JsBundleService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.IO;
 using System.Security.Cryptography;
 using System.Text;
@@ -8,15 +9,14 @@ using Microsoft.AspNetCore.Http;
 namespace BareMetalWeb.Host;
 
 /// <summary>
-/// Runtime JS bundle service that concatenates all static JS files into a single
-/// cached bundle, served at /static/js/bundle.js to reduce round-trips.
-/// The bundle is built once at application startup from the JS source files.
+/// Runtime JS bundle service that concatenates static JS files into cached
+/// bundles served as single requests to reduce round-trips.
+/// Bundles are built once at application startup from the JS source files.
 /// </summary>
 public static class JsBundleService
 {
     /// <summary>
-    /// JS files to include in the bundle, in dependency order.
-    /// This matches the order scripts were previously loaded in index.footer.html.
+    /// JS files to include in the SSR bundle, in dependency order.
     /// </summary>
     public static readonly string[] BundleFileOrder = new[]
     {
@@ -35,24 +35,51 @@ public static class JsBundleService
         "gantt-view.js"
     };
 
-    /// <summary>The route path at which the bundle is served.</summary>
+    /// <summary>
+    /// JS files to include in the VNext SPA bundle, in dependency order.
+    /// </summary>
+    public static readonly string[] VNextBundleFileOrder = new[]
+    {
+        "BareMetalRouting.js",
+        "BareMetalRest.js",
+        "BareMetalBind.js",
+        "BareMetalTemplate.js",
+        "BareMetalRendering.js",
+        "theme-switcher.js",
+        "vnext-app.js"
+    };
+
+    /// <summary>The route path at which the SSR bundle is served.</summary>
     public const string BundlePath = "/static/js/bundle.js";
 
-    private static byte[]? _bundleBytes;
-    private static string? _eTag;
-    private static string _lastModified = string.Empty;
+    /// <summary>The route path at which the VNext bundle is served.</summary>
+    public const string VNextBundlePath = "/static/js/vnext-bundle.js";
+
+    private sealed class BundleData
+    {
+        public byte[]? Bytes;
+        public string? ETag;
+        public string LastModified = string.Empty;
+    }
+
+    private static readonly ConcurrentDictionary<string, BundleData> _bundles = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
-    /// Builds and caches the JS bundle from files in <paramref name="jsDirectory"/>.
+    /// Builds and caches the SSR and VNext JS bundles from files in <paramref name="jsDirectory"/>.
     /// Should be called once at application startup.
-    /// Files listed in <see cref="BundleFileOrder"/> that do not exist are silently skipped.
     /// </summary>
     public static void BuildBundle(string jsDirectory)
+    {
+        BuildNamedBundle(BundlePath, BundleFileOrder, jsDirectory);
+        BuildNamedBundle(VNextBundlePath, VNextBundleFileOrder, jsDirectory);
+    }
+
+    private static void BuildNamedBundle(string path, string[] fileOrder, string jsDirectory)
     {
         var sb = new StringBuilder();
         var latestWrite = DateTime.MinValue;
 
-        foreach (var fileName in BundleFileOrder)
+        foreach (var fileName in fileOrder)
         {
             var filePath = Path.Combine(jsDirectory, fileName);
             if (!File.Exists(filePath))
@@ -66,9 +93,13 @@ public static class JsBundleService
             sb.AppendLine(File.ReadAllText(filePath, Encoding.UTF8));
         }
 
-        _bundleBytes = Encoding.UTF8.GetBytes(sb.ToString());
-        _lastModified = (latestWrite == DateTime.MinValue ? DateTime.UtcNow : latestWrite).ToString("R");
-        _eTag = $"\"{ComputeETag(_bundleBytes)}\"";
+        var bytes = Encoding.UTF8.GetBytes(sb.ToString());
+        _bundles[path] = new BundleData
+        {
+            Bytes = bytes,
+            LastModified = (latestWrite == DateTime.MinValue ? DateTime.UtcNow : latestWrite).ToString("R"),
+            ETag = $"\"{ComputeETag(bytes)}\""
+        };
     }
 
     private static string ComputeETag(byte[] data)
@@ -78,12 +109,13 @@ public static class JsBundleService
     }
 
     /// <summary>
-    /// Attempts to serve the JS bundle if the request path matches <see cref="BundlePath"/>.
+    /// Attempts to serve a JS bundle if the request path matches a known bundle path.
     /// Returns <c>true</c> if the path matched (response fully written); <c>false</c> otherwise.
     /// </summary>
     public static async Task<bool> TryServeAsync(HttpContext context)
     {
-        if (!context.Request.Path.Equals(BundlePath, StringComparison.OrdinalIgnoreCase))
+        var requestPath = context.Request.Path.Value ?? string.Empty;
+        if (!_bundles.TryGetValue(requestPath, out var bundle))
             return false;
 
         if (!HttpMethods.IsGet(context.Request.Method) && !HttpMethods.IsHead(context.Request.Method))
@@ -92,14 +124,14 @@ public static class JsBundleService
             return true;
         }
 
-        if (_bundleBytes == null)
+        if (bundle.Bytes == null)
         {
             context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
             return true;
         }
 
         var ifNoneMatch = context.Request.Headers.IfNoneMatch.ToString();
-        if (!string.IsNullOrEmpty(ifNoneMatch) && ifNoneMatch == _eTag)
+        if (!string.IsNullOrEmpty(ifNoneMatch) && ifNoneMatch == bundle.ETag)
         {
             context.Response.StatusCode = StatusCodes.Status304NotModified;
             return true;
@@ -107,12 +139,12 @@ public static class JsBundleService
 
         context.Response.ContentType = "application/javascript; charset=utf-8";
         context.Response.Headers.CacheControl = "public, max-age=86400";
-        context.Response.Headers.ETag = _eTag;
-        context.Response.Headers.LastModified = _lastModified;
-        context.Response.ContentLength = _bundleBytes.Length;
+        context.Response.Headers.ETag = bundle.ETag;
+        context.Response.Headers.LastModified = bundle.LastModified;
+        context.Response.ContentLength = bundle.Bytes.Length;
 
         if (HttpMethods.IsGet(context.Request.Method))
-            await context.Response.Body.WriteAsync(_bundleBytes);
+            await context.Response.Body.WriteAsync(bundle.Bytes);
 
         return true;
     }

--- a/BareMetalWeb.Host/RouteRegistrationExtensions.cs
+++ b/BareMetalWeb.Host/RouteRegistrationExtensions.cs
@@ -1205,13 +1205,7 @@ public static class RouteRegistrationExtensions
         sb.Append("<div id=\"vnext-toast-container\" class=\"position-fixed top-0 end-0 p-3\"></div>");
         sb.Append(ReplaceTemplateTokens(footerElement, tokens));
         sb.Append("<script src=\"https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js\" crossorigin=\"anonymous\"></script>");
-        sb.Append("<script src=\"/static/js/BareMetalRouting.js\"></script>");
-        sb.Append("<script src=\"/static/js/BareMetalRest.js\"></script>");
-        sb.Append("<script src=\"/static/js/BareMetalBind.js\"></script>");
-        sb.Append("<script src=\"/static/js/BareMetalTemplate.js\"></script>");
-        sb.Append("<script src=\"/static/js/BareMetalRendering.js\"></script>");
-        sb.Append("<script src=\"/static/js/theme-switcher.js\"></script>");
-        sb.Append("<script src=\"/static/js/vnext-app.js\"></script>");
+        sb.Append("<script src=\"/static/js/vnext-bundle.js\"></script>");
         sb.Append("</body></html>");
 
         context.Response.ContentType = "text/html; charset=utf-8";


### PR DESCRIPTION
## Summary
Closes #439 — VNext SPA scripts are now bundled into a single file.

## Changes

**`JsBundleService.cs`** — Refactored to support multiple named bundles:
- Added `VNextBundleFileOrder` array (7 files: BareMetalRouting, BareMetalRest, BareMetalBind, BareMetalTemplate, BareMetalRendering, theme-switcher, vnext-app)
- `BuildBundle()` now builds both SSR (`/static/js/bundle.js`) and VNext (`/static/js/vnext-bundle.js`) bundles at startup
- `TryServeAsync()` serves any registered bundle path with full ETag/304 caching support

**`RouteRegistrationExtensions.cs`** — Replaced 7 individual `<script>` tags with single `<script src="/static/js/vnext-bundle.js">`

## Result
- HTTP requests on VNext page load: **8 → 2** (bundle + Bootstrap CDN)
- All existing bundle tests pass (12/12)
- No new warnings
