### PR TITLE
fix: rename wipe-data setting to AllowWipeData and replace bare 419 with helpful page

### DIFF
--- a/BareMetalWeb.Data/WellKnownSettings.cs
+++ b/BareMetalWeb.Data/WellKnownSettings.cs
@@ -52,5 +52,5 @@ public static class WellKnownSettings
     /// The secret token required to trigger the wipe-all-data operation via
     /// <c>POST /admin/wipe-data</c>. When empty or absent the endpoint returns 419.
     /// </summary>
-    public const string AllowWipeData = "admin.allowWipeData";
+    public const string AllowWipeData = "AllowWipeData";
 }

--- a/BareMetalWeb.Host/RouteHandlers.cs
+++ b/BareMetalWeb.Host/RouteHandlers.cs
@@ -3835,7 +3835,18 @@ public sealed class RouteHandlers : IRouteHandlers
         var wipeToken = SettingsService.GetValue(WellKnownSettings.AllowWipeData);
         if (string.IsNullOrEmpty(wipeToken))
         {
-            context.Response.StatusCode = 419;
+            await BuildPageHandler(ctx =>
+            {
+                ctx.SetStringValue("title", "Wipe All Data");
+                ctx.SetStringValue("message",
+                    "<div class=\"alert alert-warning\">" +
+                    "<h4 class=\"alert-heading\">Endpoint Disabled</h4>" +
+                    $"<p>The wipe-data endpoint is disabled because the <code>{WellKnownSettings.AllowWipeData}</code> setting is empty or missing.</p>" +
+                    "<p>To enable it, go to <strong>Settings</strong> in the admin UI and set <code>" +
+                    WebUtility.HtmlEncode(WellKnownSettings.AllowWipeData) +
+                    "</code> to a secret token value. You can also set it via config (<code>Admin:AllowWipeData</code>) or environment variable (<code>Admin__AllowWipeData</code>).</p>" +
+                    "</div>");
+            })(context);
             return;
         }
 
@@ -3847,7 +3858,13 @@ public sealed class RouteHandlers : IRouteHandlers
         var wipeToken = SettingsService.GetValue(WellKnownSettings.AllowWipeData);
         if (string.IsNullOrEmpty(wipeToken))
         {
-            context.Response.StatusCode = 419;
+            context.Response.StatusCode = StatusCodes.Status403Forbidden;
+            context.SetStringValue("title", "Wipe All Data");
+            context.SetStringValue("message",
+                "<div class=\"alert alert-warning\">" +
+                "<h4 class=\"alert-heading\">Endpoint Disabled</h4>" +
+                $"<p>The <code>{WebUtility.HtmlEncode(WellKnownSettings.AllowWipeData)}</code> setting is empty or missing.</p></div>");
+            await _renderer.RenderPage(context);
             return;
         }
 


### PR DESCRIPTION
## Problem
The wipe-data setting was named `admin.allowWipeData` internally — when you see it in the Settings UI it looks like some obscure internal setting. If you create a setting called `AllowWipeData` (the obvious name) it doesn't match, and the endpoint returns a bare HTTP 419 with no body and no explanation.

## Changes

**`WellKnownSettings.cs`**
- Setting ID: `admin.allowWipeData` → `AllowWipeData`

**`RouteHandlers.cs`**
- GET handler: bare 419 → rendered page explaining the setting is missing, how to configure it (Settings UI, `Admin:AllowWipeData` in config, or `Admin__AllowWipeData` env var)
- POST handler: bare 419 → 403 with explanation page

The seeder in `BareMetalWebExtensions.cs` already reads from `Admin:AllowWipeData` config/env and creates the setting at startup via `EnsureDefaultsAsync` — no change needed there.

## Note
Existing deployments with the old `admin.allowWipeData` setting name will need to rename it to `AllowWipeData` in the Settings store (or set `Admin:AllowWipeData` in config/env and let the seeder create it on next restart).
