### PR TITLE
fix: UI cleanup — responsive tables, detail card polish, tag styling (#434)

### DIFF
--- a/BareMetalWeb.Core/wwwroot/static/css/site.css
+++ b/BareMetalWeb.Core/wwwroot/static/css/site.css
@@ -731,3 +731,50 @@ body {
 .bm-sort-icon-dim { opacity: 0.3; }
 .bm-img-preview { max-width: 200px; max-height: 200px; }
 #vnext-toast-container { z-index: 1100; }
+
+/* VNext SPA polish */
+.vnext-tag-container {
+    border-radius: 0.75rem;
+    padding: 0.35rem 0.5rem;
+}
+
+.vnext-tag-pill {
+    font-size: 0.8rem;
+    padding: 0.25em 0.6em;
+}
+
+/* Detail view description list spacing */
+.bm-page-card dl.row dt {
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid var(--bs-border-color-translucent, rgba(0,0,0,0.05));
+    margin-bottom: 0.25rem;
+}
+.bm-page-card dl.row dd {
+    padding-bottom: 0.5rem;
+    border-bottom: 1px solid var(--bs-border-color-translucent, rgba(0,0,0,0.05));
+    margin-bottom: 0.25rem;
+}
+
+/* Action buttons consistent sizing */
+.btn-xs {
+    padding: 0.2rem 0.45rem;
+    font-size: 0.75rem;
+    line-height: 1.4;
+}
+
+/* List toolbar breathing room */
+.vnext-list-toolbar {
+    margin-bottom: 1rem;
+}
+
+@media (max-width: 768px) {
+    /* Orgchart responsive */
+    .bm-orgchart-card {
+        min-width: 140px;
+        max-width: 180px;
+        padding: 0.5rem 0.75rem;
+    }
+    .bm-orgchart-level {
+        gap: 0.75rem;
+    }
+}

--- a/BareMetalWeb.Core/wwwroot/static/js/vnext-app.js
+++ b/BareMetalWeb.Core/wwwroot/static/js/vnext-app.js
@@ -354,7 +354,7 @@
             html += '</div>';
 
             // Table layout for wider viewports
-            html += '<div class="d-none d-md-block table-responsive"><table class="table table-hover table-striped table-sm align-middle">';
+            html += '<div class="d-none d-md-block table-responsive"><table class="table bm-table table-hover table-striped table-sm align-middle">';
             html += '<thead><tr>';
             html += '<th scope="col"><input type="checkbox" class="form-check-input" id="vnext-select-all" title="Select all"></th>';
             listFields.forEach(function (f) {
@@ -376,13 +376,13 @@
                     listFields.forEach(function (f) {
                         var val = nestedGet(item, f.name) || nestedGet(item, f.name.charAt(0).toLowerCase() + f.name.slice(1));
                         if (f.lookup && f.lookup.targetSlug && val) {
-                            html += '<td data-lookup-field="' + escHtml(f.name) + '" data-target-slug="' + escHtml(f.lookup.targetSlug) + '" data-display-field="' + escHtml(f.lookup.displayField) + '" data-value="' + escHtml(String(val)) + '">' +
+                            html += '<td data-label="' + escHtml(f.label) + '" data-lookup-field="' + escHtml(f.name) + '" data-target-slug="' + escHtml(f.lookup.targetSlug) + '" data-display-field="' + escHtml(f.lookup.displayField) + '" data-value="' + escHtml(String(val)) + '">' +
                                 '<a href="' + BASE + '/data/' + escHtml(f.lookup.targetSlug) + '/' + encodeURIComponent(val) + '">' + escHtml(String(val)) + '</a></td>';
                         } else {
-                            html += '<td>' + fmtValue(val, f.type) + '</td>';
+                            html += '<td data-label="' + escHtml(f.label) + '">' + fmtValue(val, f.type) + '</td>';
                         }
                     });
-                    html += '<td class="text-nowrap">';
+                    html += '<td data-label="Actions" class="text-nowrap">';
                     html += '<a class="btn btn-xs btn-outline-info btn-sm me-1" href="' + baseUrl + '/' + encId + '" title="View"><i class="bi bi-eye"></i></a>';
                     html += '<a class="btn btn-xs btn-outline-warning btn-sm me-1" href="' + baseUrl + '/' + encId + '/edit" title="Edit"><i class="bi bi-pencil"></i></a>';
                     html += '<button class="btn btn-xs btn-outline-primary btn-sm me-1 vnext-row-clone" data-id="' + escHtml(id) + '" data-slug="' + escHtml(slug) + '" title="Clone"><i class="bi bi-files"></i></button>';
@@ -1025,7 +1025,7 @@
         html += '</div>';
 
         // Fields table
-        html += '<div class="card"><div class="card-body"><dl class="row mb-0">';
+        html += '<div class="card bm-page-card"><div class="card-body"><dl class="row mb-0">';
         viewFields.forEach(function (f) {
             var val = nestedGet(item, f.name) || nestedGet(item, f.name.charAt(0).toLowerCase() + f.name.slice(1));
 


### PR DESCRIPTION
Fixes #434 (partial — addresses the highest-impact items)

## Changes
- **List table**: Added `bm-table` class and `data-label` attributes so mobile responsive card layout works
- **Detail view**: Uses `bm-page-card` class for consistent card styling with border separators on dl rows
- **Tags**: Styled `.vnext-tag-container` and `.vnext-tag-pill` for consistent rounded pill appearance
- **Buttons**: Added `.btn-xs` utility class for consistent small action buttons
- **Orgchart**: Added mobile breakpoint for compact card sizing
- **Spacing**: Added `.vnext-list-toolbar` for breathing room between toolbar and table
