### PR TITLE
docs: restructure documentation and update README for .NET 10 (#435)

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -17,7 +17,7 @@ Just Kestrel, explicit routing, streaming HTML templates, a custom binary serial
 
 ## What is this?
 
-BareMetalWeb is a lean, mean web server that uses ASP.NET Core **only** for HTTP/SSL — everything else is built from scratch for minimalism, performance, and clarity. Think classic-era `.ashx` handlers and `HttpModules` reborn in modern .NET 9.
+BareMetalWeb is a lean, mean web server that uses ASP.NET Core **only** for HTTP/SSL — everything else is built from scratch for minimalism, performance, and clarity. Think classic-era `.ashx` handlers and `HttpModules` reborn in modern .NET 10.
 
 ### Key Features
 
@@ -40,6 +40,41 @@ BareMetalWeb is a lean, mean web server that uses ASP.NET Core **only** for HTTP
 |-------------|-----|
 | Development | https://baremetalweb.azurewebsites.net |
 | Production  | https://baremetalweb-prod.azurewebsites.net |
+
+---
+
+## Quick Start
+
+```bash
+# Prerequisites: .NET 10 SDK
+dotnet --version   # should be 10.x
+
+# Build
+dotnet build
+
+# Run tests
+dotnet test --no-build
+
+# Run the server
+cd BareMetalWeb.Host
+dotnet run
+# → BareMetalWeb server is ready — PID 12345 — listening for requests on http://localhost:5232
+```
+
+The first run triggers the **Out-of-Box Experience (OOBE)** setup wizard at `http://localhost:5232/setup` where you create the admin account and seed sample data.
+
+### Project Structure
+
+| Project | Purpose |
+|---------|---------|
+| `BareMetalWeb.Host` | Kestrel server, routes, request handlers |
+| `BareMetalWeb.Core` | Shared models, enums, static assets (JS/CSS/templates) |
+| `BareMetalWeb.Data` | Storage, serialization, scaffolding, settings, auth |
+| `BareMetalWeb.Rendering` | SSR HTML fragment rendering |
+| `BareMetalWeb.Runtime` | Runtime/virtual entity definitions |
+| `BareMetalWeb.API` | REST API controller layer |
+| `BareMetalWeb.CLI` | Native AOT `metal` command-line tool |
+| `BareMetalWeb.UserClasses` | User-defined entity model classes |
 
 ---
 
@@ -224,7 +259,7 @@ The CLI uses `GET /api/_meta` to discover entity types at runtime. This means **
 The CLI is in `BareMetalWeb.CLI/` and can be built locally:
 
 ```bash
-# Standard build (requires .NET 9 SDK)
+# Standard build (requires .NET 10 SDK)
 dotnet build BareMetalWeb.CLI
 
 # Native AOT publish for your current platform

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,12 @@
 # BareMetalWeb Documentation
 
-Welcome to the BareMetalWeb documentation. This index covers all guides, references, and notes for users and developers.
+Welcome to the BareMetalWeb documentation. This index is organized by audience and purpose.
 
 ---
 
-## Architecture Diagrams
+## 🏗️ Architecture & Design
+
+Conceptual documentation explaining how the system works.
 
 - [System Overview](architecture/system-overview.md) — Component diagram, project dependencies, request lifecycle, and route divergence
 - [Data Layer & Storage](architecture/data-layer.md) — DataStore stack, entity registration, CRUD lifecycle, binary serializer, virtual entities
@@ -14,59 +16,75 @@ Welcome to the BareMetalWeb documentation. This index covers all guides, referen
 
 ---
 
-## Getting Started
+## 🚀 Getting Started
 
-- [Background Usage & REST API](BackgroundUsage.md) — REST endpoints, authentication, query language, and CLI usage
+How-to guides for setting up and running BareMetalWeb.
+
 - [Setup & Clear Data](SETUP_AND_CLEAR_DATA.md) — First-time setup wizard (OOBE), data-reset at startup, admin wipe, and sample-data generation
+- [Background Usage & REST API](BackgroundUsage.md) — REST endpoints, authentication, query language, and CLI usage
 - [Testing Guide](TESTING.md) — Test infrastructure, how to run tests, and test project overview
 - [Security Policy](../SECURITY.md) — Supported versions and how to report vulnerabilities
 - [OWASP Security Notes](OWASP.md) — OWASP-aligned security considerations
 
 ---
 
-## Feature Guides
+## 📖 API & Field Reference
 
+Reference documentation for APIs, field types, and configuration.
+
+- [Entity Field Definitions](ENTITY_FIELD_DEFINITIONS.md) — DataField attribute reference and field type catalog
+- [Lookup API](LOOKUP_API.md) — Lookup field API reference
+- [Search Index Types](SEARCH_INDEX_TYPES.md) — Search index types and configuration
+- [Validation](VALIDATION.md) — Field validation framework and rules
 - [Auto-ID Generation](AUTO_ID_GENERATION.md) — Automatic ID strategies (GUID, sequential) for data entities
+
+---
+
+## ⚙️ Feature Guides
+
+Detailed guides for specific features and view types.
+
 - [Calculated Fields](CALCULATED_FIELDS_IMPLEMENTATION.md) — Client-side and server-side expression-based field calculations
 - [Computed Fields](COMPUTED_FIELDS.md) — Server-side memoized snapshots and live lookups from related entities
-- [Validation](VALIDATION.md) — Field validation framework and rules
 - [Bulk Operations](BULK_OPERATIONS.md) — Bulk create, update, and delete on entity list views
-- [Entity Field Definitions](ENTITY_FIELD_DEFINITIONS.md) — DataField attribute reference and field type catalog
 - [Entity List Enhancements](ENTITY_LIST_ENHANCEMENTS.md) — Search, filtering, sorting, and pagination on list views
 - [Export & Nested Components](EXPORT_NESTED_COMPONENTS.md) — Export support for embedded/nested entity components
-- [Lookup API](LOOKUP_API.md) — Lookup field API reference
 - [Lookup Field Buttons](LOOKUP_FIELD_BUTTONS.md) — Refresh and Add buttons on lookup fields
 - [Lookup Field Buttons Visual](LOOKUP_FIELD_BUTTONS_VISUAL.md) — Visual examples for lookup field buttons
-- [Search Index Types](SEARCH_INDEX_TYPES.md) — Search index types and configuration
 - [Timeline View](TIMELINE_VIEW.md) — Timeline visualisation for date-based entities
 - [Timetable View](TIMETABLE_VIEW.md) — Timetable/schedule view for entities
 - [Tree View & Org Chart Guide](TREEVIEW_ORGCHART_GUIDE.md) — Explorer-style tree view and org chart rendering
 
 ---
 
-## Deployment & Operations
+## 🚢 Deployment & Operations
+
+Guides for deploying and operating BareMetalWeb in production.
 
 - [CI Migration Deployment](CIMIGRATE_DEPLOYMENT.md) — Setup guide for the CI migration deployment workflow
 - [CI Reset Deployment](CIRESET_DEPLOYMENT.md) — Setup guide for the CI reset deployment workflow
 
 ---
 
-## Developer Notes
+## 🛠️ Developer Notes
 
+Internal notes, reviews, and issue tracking for contributors.
+
+- [Developer Instructions](instructions.md) — Internal developer setup and workflow instructions
 - [Implementation Summary](IMPLEMENTATION_SUMMARY.md) — Summary of recent implementation work
 - [Test Coverage Summary](TEST_COVERAGE_SUMMARY.md) — Test coverage statistics and breakdown by component
+- [Known Footguns](footguns.md) — Gotchas and pitfalls to be aware of when working with the codebase
+- [Code Review Notes](review.md) — Code review findings and recommendations
+- [Bug Notes](bugs.md) — Informal bug tracking notes
 - [Issue Categorization](ISSUE_CATEGORIZATION.md) — Categorization of open issues by priority, type, and component
 - [Issue Labeling Summary](ISSUE_LABELING_SUMMARY.md) — Summary of issue labeling actions
 - [Issue Quick Reference](ISSUE_QUICK_REFERENCE.md) — Quick reference table of all open issues
-- [Known Footguns](footguns.md) — Gotchas and pitfalls to be aware of when working with the codebase
-- [Bug Notes](bugs.md) — Informal bug tracking notes
-- [Code Review Notes](review.md) — Code review findings and recommendations
-- [Developer Instructions](instructions.md) — Internal developer setup and workflow instructions
 
 ---
 
-## Release Notes
+## 📋 Release Notes
 
+- [V1.20260224.5](releases/V1.20260224.5-v1.20260224.222.md)
 - [V1.20260224.4 – V1.3](releases/V1.20260224.4-V1.3.md)
 - [V1.20260224.3 – V1.3](releases/V1.20260224.3-V1.3.md)
 - [V1.20260219.2 – v1.172](releases/V1.20260219.2-v1.172.md)


### PR DESCRIPTION
Fixes #435 (partial)

- README: Updated .NET 9 → .NET 10 references, added Quick Start (build/run/test), added Project Structure table
- docs/index.md: Reorganized into clear categories — Architecture, Getting Started, API Reference, Feature Guides, Deployment, Developer Notes, Release Notes
