### PR TITLE
perf: add missing [DataIndex] to all user class entities (#436)

### DIFF
--- a/BareMetalWeb.UserClasses/DataObjects/Address.cs
+++ b/BareMetalWeb.UserClasses/DataObjects/Address.cs
@@ -6,6 +6,7 @@ namespace BareMetalWeb.Data.DataObjects;
 public class Address : RenderableDataObject
 {
     [DataField(Label = "Label", Order = 1, Required = true)]
+    [DataIndex]
     public string Label { get; set; } = string.Empty;
 
     [DataField(Label = "Address Line 1", Order = 2, Required = true)]
@@ -15,6 +16,7 @@ public class Address : RenderableDataObject
     public string Line2 { get; set; } = string.Empty;
 
     [DataField(Label = "City", Order = 4, Required = true)]
+    [DataIndex]
     public string City { get; set; } = string.Empty;
 
     [DataField(Label = "Region", Order = 5)]

--- a/BareMetalWeb.UserClasses/DataObjects/Currency.cs
+++ b/BareMetalWeb.UserClasses/DataObjects/Currency.cs
@@ -6,6 +6,7 @@ namespace BareMetalWeb.Data.DataObjects;
 public class Currency : RenderableDataObject
 {
     [DataField(Label = "ISO Code", Order = 1, Required = true)]
+    [DataIndex]
     public string IsoCode { get; set; } = string.Empty;
 
     [DataField(Label = "Description", Order = 2, Required = true)]

--- a/BareMetalWeb.UserClasses/DataObjects/Customer.cs
+++ b/BareMetalWeb.UserClasses/DataObjects/Customer.cs
@@ -8,6 +8,7 @@ namespace BareMetalWeb.Data.DataObjects;
 public class Customer : RenderableDataObject
 {
     [DataField(Label = "Name", Order = 1, Required = true)]
+    [DataIndex]
     public string Name { get; set; } = string.Empty;
 
     [DataField(Label = "Email", Order = 2, Required = true, FieldType = Rendering.Models.FormFieldType.Email)]
@@ -26,6 +27,7 @@ public class Customer : RenderableDataObject
 
     [DataField(Label = "Address", Order = 6)]
     [DataLookup(typeof(Address), DisplayField = "Label", SortField = "Label", SortDirection = SortDirection.Asc, CacheSeconds = 120)]
+    [DataIndex]
     public string AddressId { get; set; } = string.Empty;
 
     [DataField(Label = "Active", Order = 7)]

--- a/BareMetalWeb.UserClasses/DataObjects/Employee.cs
+++ b/BareMetalWeb.UserClasses/DataObjects/Employee.cs
@@ -7,16 +7,19 @@ namespace BareMetalWeb.UserClasses.DataObjects;
 public class Employee : RenderableDataObject
 {
     [DataField(Order = 2, Label = "Name", List = true, View = true, Edit = true, Create = true, Required = true)]
+    [DataIndex]
     public string Name { get; set; } = string.Empty;
 
     [DataField(Order = 3, Label = "Title", List = true, View = true, Edit = true, Create = true)]
     public string? Title { get; set; }
 
     [DataField(Order = 4, Label = "Email", List = true, View = true, Edit = true, Create = true)]
+    [DataIndex]
     public string? Email { get; set; }
 
     [DataField(Order = 5, Label = "Manager", List = true, View = true, Edit = true, Create = true)]
     [DataLookup(typeof(Employee), DisplayField = nameof(Name), QueryField = nameof(Id), QueryOperator = QueryOperator.NotEquals)]
+    [DataIndex]
     public string? ManagerId { get; set; }
 
     [DataField(Order = 6, Label = "Department", List = true, View = true, Edit = true, Create = true)]

--- a/BareMetalWeb.UserClasses/DataObjects/LessonLog.cs
+++ b/BareMetalWeb.UserClasses/DataObjects/LessonLog.cs
@@ -5,6 +5,7 @@ public class LessonLog : RenderableDataObject
 {
     [DataField(Label = "Subject Id", Order = 1, Required = true)]
     [DataLookup(typeof(Subject), DisplayField = "Name", SortField = "Name", SortDirection = SortDirection.Asc, CacheSeconds = 120)]
+    [DataIndex]
     public string SubjectId { get; set; } = string.Empty;
 
     [DataField(Label = "Date", Order = 2, Required = true)]

--- a/BareMetalWeb.UserClasses/DataObjects/Order.cs
+++ b/BareMetalWeb.UserClasses/DataObjects/Order.cs
@@ -7,6 +7,7 @@ namespace BareMetalWeb.Data.DataObjects;
 public class Order : RenderableDataObject
 {
     [DataField(Label = "Order Number", Order = 1, Required = true)]
+    [DataIndex]
     public string OrderNumber { get; set; } = string.Empty;
 
     [DataField(Label = "Customer", Order = 2, Required = true)]
@@ -23,6 +24,7 @@ public class Order : RenderableDataObject
 
     [DataField(Label = "Currency", Order = 5, Required = true)]
     [DataLookup(typeof(Currency), DisplayField = "IsoCode", SortField = "IsoCode", SortDirection = SortDirection.Asc, CacheSeconds = 120)]
+    [DataIndex]
     public string CurrencyId { get; set; } = string.Empty;
 
     [DataField(Label = "Notes", Order = 6)]

--- a/BareMetalWeb.UserClasses/DataObjects/Product.cs
+++ b/BareMetalWeb.UserClasses/DataObjects/Product.cs
@@ -8,6 +8,7 @@ public class Product : RenderableDataObject
     public string Name { get; set; } = string.Empty;
 
     [DataField(Label = "SKU", Order = 2, Required = true)]
+    [DataIndex]
     public string Sku { get; set; } = string.Empty;
 
     [DataField(Label = "Category", Order = 3)]
@@ -16,10 +17,12 @@ public class Product : RenderableDataObject
 
     [DataField(Label = "Unit Of Measure", Order = 4, Required = true)]
     [DataLookup(typeof(UnitOfMeasure), DisplayField = "Name", SortField = "Name", SortDirection = SortDirection.Asc, CacheSeconds = 120)]
+    [DataIndex]
     public string UnitOfMeasureId { get; set; } = string.Empty;
 
     [DataField(Label = "Currency", Order = 5, Required = true)]
     [DataLookup(typeof(Currency), DisplayField = "IsoCode", SortField = "IsoCode", SortDirection = SortDirection.Asc, CacheSeconds = 120)]
+    [DataIndex]
     public string CurrencyId { get; set; } = string.Empty;
 
     [DataField(Label = "Price", Order = 6, Required = true, FieldType = Rendering.Models.FormFieldType.Decimal)]

--- a/BareMetalWeb.UserClasses/DataObjects/SessionLog.cs
+++ b/BareMetalWeb.UserClasses/DataObjects/SessionLog.cs
@@ -10,6 +10,7 @@ namespace BareMetalWeb.Data.DataObjects;
 public class SessionLog : BaseDataObject
 {
     [DataField(Label = "User", Order = 1, Required = true)]
+    [DataIndex]
     public string UserName { get; set; } = string.Empty;
 
     [DataField(Label = "IP Address", Order = 2)]

--- a/BareMetalWeb.UserClasses/DataObjects/Subject.cs
+++ b/BareMetalWeb.UserClasses/DataObjects/Subject.cs
@@ -7,5 +7,6 @@ namespace BareMetalWeb.Data.DataObjects;
 public class Subject : RenderableDataObject
 {
     [DataField(Label = "Name", Order = 1, Required = true)]
+    [DataIndex]
     public string Name { get; set; } = string.Empty;
 }

--- a/BareMetalWeb.UserClasses/DataObjects/TimeTablePlan.cs
+++ b/BareMetalWeb.UserClasses/DataObjects/TimeTablePlan.cs
@@ -5,6 +5,7 @@ public class TimeTablePlan : RenderableDataObject
 {
     [DataLookup(typeof(Subject), DisplayField = "Name", SortField = "Name", SortDirection = SortDirection.Asc, CacheSeconds = 120)]
     [DataField(Label = "Subject Id", Order = 1, Required = true, List = true)]
+    [DataIndex]
     public string SubjectId { get; set; } = string.Empty;
 
     [DataField(Label = "Notes", Order = 2, List = true)]

--- a/BareMetalWeb.UserClasses/DataObjects/ToDo.cs
+++ b/BareMetalWeb.UserClasses/DataObjects/ToDo.cs
@@ -5,6 +5,7 @@ public class ToDo : RenderableDataObject
 {
 
     [DataField(Label = "Title", Order = 1, Required = true)]
+    [DataIndex]
     public string Title { get; set; } = string.Empty;
 
     [DataField(Label = "Deadline", Order = 2, Required = true)]

--- a/BareMetalWeb.UserClasses/DataObjects/UnitOfMeasure.cs
+++ b/BareMetalWeb.UserClasses/DataObjects/UnitOfMeasure.cs
@@ -6,6 +6,7 @@ namespace BareMetalWeb.Data.DataObjects;
 public class UnitOfMeasure : RenderableDataObject
 {
     [DataField(Label = "Name", Order = 1, Required = true)]
+    [DataIndex]
     public string Name { get; set; } = string.Empty;
 
     [DataField(Label = "Abbreviation", Order = 2, Required = true)]


### PR DESCRIPTION
Fixes #436

Audited all 12 user class entities and added `[DataIndex]` to:
- All primary Name/identifier fields (for search/filter acceleration)
- All `[DataLookup]` FK fields (for join query performance)

19 indexes added across Customer, Employee, Product, Order, Address, ToDo, Currency, Subject, UnitOfMeasure, LessonLog, TimeTablePlan, SessionLog.

This ensures `SearchIndexManager` builds and maintains indexes for commonly queried fields, avoiding full-scan fallbacks during list/filter operations.
