### PR TITLE
perf: skip redundant index writes on unchanged field values

### DIFF
--- a/BareMetalWeb.Data/LocalFolderBinaryDataProvider.cs
+++ b/BareMetalWeb.Data/LocalFolderBinaryDataProvider.cs
@@ -414,8 +414,9 @@ public sealed class LocalFolderBinaryDataProvider : IDataProvider
                     if (oldObj != null)
                     {
                         var oldValue = prop.GetValue(oldObj)?.ToString() ?? string.Empty;
-                        if (!string.Equals(oldValue, newValue, StringComparison.OrdinalIgnoreCase))
-                            _indexStore.AppendEntry(type.Name, prop.Name, oldValue, obj.Id, 'D');
+                        if (string.Equals(oldValue, newValue, StringComparison.OrdinalIgnoreCase))
+                            continue; // value unchanged — existing index entry is still valid
+                        _indexStore.AppendEntry(type.Name, prop.Name, oldValue, obj.Id, 'D');
                     }
                     _indexStore.AppendEntry(type.Name, prop.Name, newValue, obj.Id, 'A');
                 }


### PR DESCRIPTION
When saving an entity where an indexed field value hasn't changed, skip writing the Delete+Add entries to the index log. This reduces I/O for updates that don't touch indexed fields.

Cherry-picked the optimization from #452 (which has merge conflicts with main after our .NET 10 upgrade and index coverage PR). The [DataIndex] attribute additions from #452 are already covered by #458.

Supersedes #452