### PR TITLE
fix: lookup rendering bugs + case-insensitive property resolution

### DIFF
--- a/BareMetalWeb.Core/wwwroot/static/js/vnext-app.js
+++ b/BareMetalWeb.Core/wwwroot/static/js/vnext-app.js
@@ -53,6 +53,9 @@
         return apiFetch(url).then(function (items) {
             _lookupCache[key] = Array.isArray(items) ? items : (items.items || []);
             return _lookupCache[key];
+        }).catch(function (err) {
+            console.warn('Lookup fetch failed for ' + targetSlug + ':', err);
+            return [];
         });
     }
 
@@ -170,7 +173,20 @@
         var cur = obj;
         for (var i = 0; i < parts.length; i++) {
             if (cur == null) return undefined;
-            cur = cur[parts[i]];
+            var p = parts[i];
+            if (p in cur) { cur = cur[p]; continue; }
+            // Case-insensitive fallback: try camelCase/PascalCase variants
+            var alt = p.charAt(0) === p.charAt(0).toLowerCase()
+                ? p.charAt(0).toUpperCase() + p.slice(1)
+                : p.charAt(0).toLowerCase() + p.slice(1);
+            if (alt in cur) { cur = cur[alt]; continue; }
+            // Full case-insensitive search as last resort
+            var lp = p.toLowerCase();
+            var found = false;
+            for (var k in cur) {
+                if (k.toLowerCase() === lp) { cur = cur[k]; found = true; break; }
+            }
+            if (!found) return undefined;
         }
         return cur;
     }
@@ -334,7 +350,7 @@
                     var encId = encodeURIComponent(id);
                     html += '<div class="card mb-2"><div class="card-body p-2">';
                     listFields.forEach(function (f) {
-                        var val = nestedGet(item, f.name) || nestedGet(item, f.name.charAt(0).toLowerCase() + f.name.slice(1));
+                        var val = nestedGet(item, f.name);
                         var cellHtml;
                         if (f.lookup && f.lookup.targetSlug && val) {
                             cellHtml = '<span data-lookup-field="' + escHtml(f.name) + '" data-target-slug="' + escHtml(f.lookup.targetSlug) + '" data-display-field="' + escHtml(f.lookup.displayField) + '" data-value="' + escHtml(String(val)) + '">' + escHtml(String(val)) + '</span>';
@@ -374,7 +390,7 @@
                     html += '<tr data-id="' + escHtml(id) + '">';
                     html += '<td><input type="checkbox" class="form-check-input vnext-row-select" value="' + escHtml(id) + '"></td>';
                     listFields.forEach(function (f) {
-                        var val = nestedGet(item, f.name) || nestedGet(item, f.name.charAt(0).toLowerCase() + f.name.slice(1));
+                        var val = nestedGet(item, f.name);
                         if (f.lookup && f.lookup.targetSlug && val) {
                             html += '<td data-label="' + escHtml(f.label) + '" data-lookup-field="' + escHtml(f.name) + '" data-target-slug="' + escHtml(f.lookup.targetSlug) + '" data-display-field="' + escHtml(f.lookup.displayField) + '" data-value="' + escHtml(String(val)) + '">' +
                                 '<a href="' + BASE + '/data/' + escHtml(f.lookup.targetSlug) + '/' + encodeURIComponent(val) + '">' + escHtml(String(val)) + '</a></td>';
@@ -434,7 +450,7 @@
 
         function getLabel(item) {
             var id = item.id || item.Id || '';
-            return labelField ? (nestedGet(item, labelField.name) || nestedGet(item, labelField.name.charAt(0).toLowerCase() + labelField.name.slice(1)) || id) : id;
+            return labelField ? (nestedGet(item, labelField.name) || id) : id;
         }
 
         function buildNodeHtml(node, depth) {
@@ -475,7 +491,7 @@
             });
             items.forEach(function (item) {
                 var id = item.id || item.Id || '';
-                var parentId = nestedGet(item, parentField) || nestedGet(item, parentField.charAt(0).toLowerCase() + parentField.slice(1)) || '';
+                var parentId = nestedGet(item, parentField) || '';
                 if (parentId && nodeMap[parentId] && parentId !== id) nodeMap[parentId].children.push(nodeMap[id]);
                 else roots.push(nodeMap[id]);
             });
@@ -504,12 +520,12 @@
 
         function buildCardHtml(item) {
             var id = item.id || item.Id || '';
-            var label = labelField ? (nestedGet(item, labelField.name) || nestedGet(item, labelField.name.charAt(0).toLowerCase() + labelField.name.slice(1)) || id) : id;
+            var label = labelField ? (nestedGet(item, labelField.name) || id) : id;
             var subtitle = '';
             if (titleField) {
-                subtitle = nestedGet(item, titleField.name) || nestedGet(item, titleField.name.charAt(0).toLowerCase() + titleField.name.slice(1)) || '';
+                subtitle = nestedGet(item, titleField.name) || '';
             } else if (subtitleField) {
-                subtitle = nestedGet(item, subtitleField.name) || nestedGet(item, subtitleField.name.charAt(0).toLowerCase() + subtitleField.name.slice(1)) || '';
+                subtitle = nestedGet(item, subtitleField.name) || '';
             }
             return '<div class="bm-orgchart-card">' +
                 '<div class="bm-orgchart-name">' + escHtml(String(label)) + '</div>' +
@@ -536,7 +552,7 @@
             });
             items.forEach(function (item) {
                 var id = item.id || item.Id || '';
-                var parentId = nestedGet(item, parentField) || nestedGet(item, parentField.charAt(0).toLowerCase() + parentField.slice(1)) || '';
+                var parentId = nestedGet(item, parentField) || '';
                 if (parentId && nodeMap[parentId] && parentId !== id) nodeMap[parentId].children.push(nodeMap[id]);
                 else roots.push(nodeMap[id]);
             });
@@ -1027,15 +1043,15 @@
         // Fields table
         html += '<div class="card bm-page-card"><div class="card-body"><dl class="row mb-0">';
         viewFields.forEach(function (f) {
-            var val = nestedGet(item, f.name) || nestedGet(item, f.name.charAt(0).toLowerCase() + f.name.slice(1));
+            var val = nestedGet(item, f.name);
 
             if (isSubListField(val)) {
                 html += '<dt class="col-sm-3">' + escHtml(f.label) + '</dt>';
                 html += '<dd class="col-sm-9">' + renderSubListReadonly(val, f) + '</dd>';
-            } else if (f.lookup && f.lookup.targetSlug) {
+            } else if (f.lookup && f.lookup.targetSlug && val) {
                 html += '<dt class="col-sm-3">' + escHtml(f.label) + '</dt>';
-                html += '<dd class="col-sm-9" data-lookup-field="' + escHtml(f.name) + '" data-target-slug="' + escHtml(f.lookup.targetSlug) + '" data-display-field="' + escHtml(f.lookup.displayField) + '" data-value="' + escHtml(String(val || '')) + '">' +
-                    '<a href="' + BASE + '/data/' + escHtml(f.lookup.targetSlug) + '/' + encodeURIComponent(val || '') + '">' + escHtml(String(val || '')) + '</a></dd>';
+                html += '<dd class="col-sm-9" data-lookup-field="' + escHtml(f.name) + '" data-target-slug="' + escHtml(f.lookup.targetSlug) + '" data-display-field="' + escHtml(f.lookup.displayField) + '" data-value="' + escHtml(String(val)) + '">' +
+                    '<a href="' + BASE + '/data/' + escHtml(f.lookup.targetSlug) + '/' + encodeURIComponent(val) + '">' + escHtml(String(val)) + '</a></dd>';
             } else {
                 html += '<dt class="col-sm-3">' + escHtml(f.label) + '</dt>';
                 html += '<dd class="col-sm-9">' + fmtValue(val, f.type) + '</dd>';
@@ -1090,13 +1106,19 @@
                         var displayField = el.dataset.displayField;
                         var obj = results[value];
                         if (obj) {
-                            var display = nestedGet(obj, displayField) || nestedGet(obj, displayField.charAt(0).toLowerCase() + displayField.slice(1)) || value;
+                            var display = nestedGet(obj, displayField) || value;
                             var href = BASE + '/data/' + encodeURIComponent(targetSlug) + '/' + encodeURIComponent(value);
                             el.innerHTML = '<a href="' + escHtml(href) + '">' + escHtml(String(display)) + '</a>';
                         }
                     });
                 })
-                .catch(function () {});
+                .catch(function (err) {
+                    console.warn('Batch lookup failed for ' + targetSlug + ':', err);
+                    els.forEach(function (el) {
+                        el.classList.add('text-warning');
+                        el.title = 'Lookup resolution failed';
+                    });
+                });
         });
     }
 
@@ -1150,7 +1172,7 @@
         html += '<input type="hidden" name="__csrf" value="' + escHtml(getCsrfToken()) + '">';
 
         formFields.forEach(function (f) {
-            var curVal = item ? (nestedGet(item, f.name) || nestedGet(item, f.name.charAt(0).toLowerCase() + f.name.slice(1))) : null;
+            var curVal = item ? (nestedGet(item, f.name)) : null;
             html += renderFormField(f, curVal, meta, item);
         });
 
@@ -1393,11 +1415,11 @@
                         var displayField = el.dataset.displayField;
                         var obj = results[value];
                         if (obj) {
-                            var display = nestedGet(obj, displayField) || nestedGet(obj, displayField.charAt(0).toLowerCase() + displayField.slice(1)) || value;
+                            var display = nestedGet(obj, displayField) || value;
                             el.textContent = String(display);
                         }
                     });
-                }).catch(function () {});
+                }).catch(function (err) { console.warn('Sub-list lookup failed for ' + targetSlug + ':', err); });
         });
     }
 
@@ -1487,8 +1509,8 @@
             .then(function (items) {
                 sel.innerHTML = '<option value="">— Select —</option>';
                 items.forEach(function (opt) {
-                    var optVal = nestedGet(opt, lk.valueField) || nestedGet(opt, lk.valueField.charAt(0).toLowerCase() + lk.valueField.slice(1)) || '';
-                    var optLbl = nestedGet(opt, lk.displayField) || nestedGet(opt, lk.displayField.charAt(0).toLowerCase() + lk.displayField.slice(1)) || optVal;
+                    var optVal = nestedGet(opt, lk.valueField) || '';
+                    var optLbl = nestedGet(opt, lk.displayField) || optVal;
                     var selected = String(optVal) === String(currentValue) ? ' selected' : '';
                     sel.insertAdjacentHTML('beforeend', '<option value="' + escHtml(String(optVal)) + '"' + selected + '>' + escHtml(String(optLbl)) + '</option>');
                 });
@@ -1651,12 +1673,12 @@
         // Load lookup options async
         formFields.forEach(function (f) {
             if (f.type === 'LookupList' && f.lookup && f.lookup.targetSlug) {
-                var curVal = item ? (nestedGet(item, f.name) || nestedGet(item, f.name.charAt(0).toLowerCase() + f.name.slice(1))) : null;
+                var curVal = item ? (nestedGet(item, f.name)) : null;
                 loadLookupSelect(f, curVal);
             }
             // Load enum options
             if (f.type === 'Enum') {
-                loadEnumOptions(f, item ? (nestedGet(item, f.name) || nestedGet(item, f.name.charAt(0).toLowerCase() + f.name.slice(1))) : null);
+                loadEnumOptions(f, item ? (nestedGet(item, f.name)) : null);
             }
             // Resolve lookup display values in sub-list table cells
             if (f.type === 'CustomHtml') {
@@ -1845,8 +1867,8 @@
                 }
                 sel.innerHTML = '<option value="">— Select —</option>';
                 items.forEach(function (opt) {
-                    var optVal = nestedGet(opt, lk.valueField) || nestedGet(opt, lk.valueField.charAt(0).toLowerCase() + lk.valueField.slice(1)) || '';
-                    var optLbl = nestedGet(opt, lk.displayField) || nestedGet(opt, lk.displayField.charAt(0).toLowerCase() + lk.displayField.slice(1)) || optVal;
+                    var optVal = nestedGet(opt, lk.valueField) || '';
+                    var optLbl = nestedGet(opt, lk.displayField) || optVal;
                     var selected = String(optVal) === String(currentValue) ? ' selected' : '';
                     sel.insertAdjacentHTML('beforeend', '<option value="' + escHtml(String(optVal)) + '"' + selected + '>' + escHtml(String(optLbl)) + '</option>');
                 });
@@ -1868,10 +1890,10 @@
         var currentDisplay = '';
         if (currentValue) {
             var curItem = allItems.find(function (o) {
-                var v = nestedGet(o, lk.valueField) || nestedGet(o, lk.valueField.charAt(0).toLowerCase() + lk.valueField.slice(1));
+                var v = nestedGet(o, lk.valueField);
                 return String(v) === String(currentValue);
             });
-            if (curItem) currentDisplay = nestedGet(curItem, lk.displayField) || nestedGet(curItem, lk.displayField.charAt(0).toLowerCase() + lk.displayField.slice(1)) || currentValue;
+            if (curItem) currentDisplay = nestedGet(curItem, lk.displayField) || currentValue;
         }
 
         var n = escHtml(field.name);

--- a/BareMetalWeb.Data.Tests/LookupRenderingTests.cs
+++ b/BareMetalWeb.Data.Tests/LookupRenderingTests.cs
@@ -1,0 +1,263 @@
+using System.Collections;
+using System.Net;
+using BareMetalWeb.Core;
+using BareMetalWeb.Core.Interfaces;
+using BareMetalWeb.Data;
+using BareMetalWeb.Data.DataObjects;
+using BareMetalWeb.Data.Interfaces;
+
+namespace BareMetalWeb.Data.Tests;
+
+/// <summary>
+/// Tests for lookup field rendering in list views and detail views.
+/// Covers edge cases: null FK, empty FK, missing target entity, and resolved display names.
+/// </summary>
+[Collection("DataStoreProvider")]
+public class LookupRenderingTests : IDisposable
+{
+    private readonly IDataObjectStore _originalStore;
+    private readonly InMemoryDataStore _store;
+
+    public LookupRenderingTests()
+    {
+        _originalStore = DataStoreProvider.Current;
+        _store = new InMemoryDataStore();
+        DataStoreProvider.Current = _store;
+
+        _ = typeof(Customer).Assembly;
+        DataEntityRegistry.RegisterAllEntities();
+        ClearLookupCache();
+    }
+
+    public void Dispose()
+    {
+        DataStoreProvider.Current = _originalStore;
+    }
+
+    // ─── FormatLookupDisplay tests (via BuildListRows) ──────────────────────
+
+    [Fact]
+    public void BuildListRows_LookupField_ResolvesDisplayName()
+    {
+        // Arrange: an Address exists and a Customer references it
+        _store.Save(new Address { Id = "addr-1", Label = "Home Office", Line1 = "1 Main St", City = "London", Country = "GB" });
+        ClearLookupCache();
+
+        var meta = DataScaffold.GetEntityByType(typeof(Customer));
+        Assert.NotNull(meta);
+        var customer = new Customer { Id = "cust-1", Name = "Jane", Email = "j@x.com", AddressId = "addr-1" };
+
+        // Act
+        var rows = DataScaffold.BuildListRows(meta!, new[] { customer }, "/data/customers", includeActions: false);
+
+        // Assert: the address cell should contain "Home Office" (the display name), not "addr-1"
+        Assert.Single(rows);
+        var addressCell = rows[0].FirstOrDefault(c => c.Contains("Home Office"));
+        Assert.NotNull(addressCell);
+        Assert.DoesNotContain(">addr-1<", addressCell);
+    }
+
+    [Fact]
+    public void BuildListRows_LookupField_NullValue_ShowsDash()
+    {
+        // Arrange: a Customer with null AddressId
+        ClearLookupCache();
+        var meta = DataScaffold.GetEntityByType(typeof(Customer));
+        Assert.NotNull(meta);
+        var customer = new Customer { Id = "cust-2", Name = "Null Addr", Email = "n@x.com", AddressId = "" };
+
+        // Act
+        var rows = DataScaffold.BuildListRows(meta!, new[] { customer }, "/data/customers", includeActions: false);
+
+        // Assert: empty lookup key should show dash placeholder, not raw empty string
+        Assert.Single(rows);
+        var allCells = string.Join("|", rows[0]);
+        // Should contain the "—" dash from FormatLookupDisplay for empty keys
+        Assert.Contains("\u2014", allCells);
+    }
+
+    [Fact]
+    public void BuildListRows_LookupField_MissingTarget_ShowsRawId()
+    {
+        // Arrange: Customer references an Address that doesn't exist
+        ClearLookupCache();
+        var meta = DataScaffold.GetEntityByType(typeof(Customer));
+        Assert.NotNull(meta);
+        var customer = new Customer { Id = "cust-3", Name = "Orphan", Email = "o@x.com", AddressId = "addr-gone" };
+
+        // Act
+        var rows = DataScaffold.BuildListRows(meta!, new[] { customer }, "/data/customers", includeActions: false);
+
+        // Assert: should gracefully show raw ID when target entity is missing
+        Assert.Single(rows);
+        var allCells = string.Join("|", rows[0]);
+        Assert.Contains("addr-gone", allCells);
+    }
+
+    // ─── BuildViewRowsHtml tests ─────────────────────────────────────────────
+
+    [Fact]
+    public void BuildViewRowsHtml_LookupField_ResolvesDisplayName()
+    {
+        // Arrange
+        _store.Save(new Address { Id = "addr-v1", Label = "View Test Address", Line1 = "42 View St", City = "Oxford", Country = "GB" });
+        ClearLookupCache();
+
+        var meta = DataScaffold.GetEntityByType(typeof(Customer));
+        Assert.NotNull(meta);
+        var customer = new Customer { Id = "cust-v1", Name = "View Test", Email = "v@x.com", AddressId = "addr-v1" };
+
+        // Act
+        var rows = DataScaffold.BuildViewRowsHtml(meta!, customer);
+
+        // Assert: address row should contain resolved display name
+        var addressRow = rows.FirstOrDefault(r => r.Label.Contains("Address"));
+        Assert.NotNull(addressRow);
+        Assert.Contains("View Test Address", addressRow.Value);
+    }
+
+    [Fact]
+    public void BuildViewRowsHtml_LookupField_EmptyValue_ShowsDash()
+    {
+        // Arrange
+        ClearLookupCache();
+        var meta = DataScaffold.GetEntityByType(typeof(Customer));
+        Assert.NotNull(meta);
+        var customer = new Customer { Id = "cust-v2", Name = "Empty Lookup", Email = "e@x.com", AddressId = "" };
+
+        // Act
+        var rows = DataScaffold.BuildViewRowsHtml(meta!, customer);
+
+        // Assert: empty lookup should produce dash placeholder
+        var addressRow = rows.FirstOrDefault(r => r.Label.Contains("Address"));
+        Assert.NotNull(addressRow);
+        var decoded = WebUtility.HtmlDecode(addressRow.Value);
+        Assert.Contains("—", decoded);
+    }
+
+    [Fact]
+    public void BuildViewRowsHtml_LookupField_DeletedTarget_ShowsRawId()
+    {
+        // Arrange: Customer references non-existent address
+        ClearLookupCache();
+        var meta = DataScaffold.GetEntityByType(typeof(Customer));
+        Assert.NotNull(meta);
+        var customer = new Customer { Id = "cust-v3", Name = "Deleted Ref", Email = "d@x.com", AddressId = "addr-deleted" };
+
+        // Act
+        var rows = DataScaffold.BuildViewRowsHtml(meta!, customer);
+
+        // Assert: should show raw ID as fallback
+        var addressRow = rows.FirstOrDefault(r => r.Label.Contains("Address"));
+        Assert.NotNull(addressRow);
+        Assert.Contains("addr-deleted", addressRow.Value);
+    }
+
+    // ─── Order → Customer lookup chain ───────────────────────────────────────
+
+    [Fact]
+    public void BuildListRows_OrderCustomerLookup_ResolvesCustomerName()
+    {
+        // Arrange
+        _store.Save(new Customer { Id = "cust-ord", Name = "Acme Corp", Email = "a@acme.com" });
+        ClearLookupCache();
+
+        var meta = DataScaffold.GetEntityByType(typeof(Order));
+        Assert.NotNull(meta);
+        var order = new Order
+        {
+            Id = "ord-1",
+            OrderNumber = "ORD-001",
+            CustomerId = "cust-ord",
+            Status = "Open",
+            OrderDate = DateOnly.FromDateTime(DateTime.UtcNow)
+        };
+
+        // Act
+        var rows = DataScaffold.BuildListRows(meta!, new[] { order }, "/data/orders", includeActions: false);
+
+        // Assert
+        Assert.Single(rows);
+        var allCells = string.Join("|", rows[0]);
+        Assert.Contains("Acme Corp", allCells);
+    }
+
+    // ─── Multiple items with mixed lookup states ─────────────────────────────
+
+    [Fact]
+    public void BuildListRows_MixedLookupStates_HandlesAllGracefully()
+    {
+        // Arrange: some addresses exist, some don't
+        _store.Save(new Address { Id = "addr-exists", Label = "Valid Address", Line1 = "1 Test", City = "Test", Country = "GB" });
+        ClearLookupCache();
+
+        var meta = DataScaffold.GetEntityByType(typeof(Customer));
+        Assert.NotNull(meta);
+        var customers = new[]
+        {
+            new Customer { Id = "c1", Name = "Has Address", Email = "a@x.com", AddressId = "addr-exists" },
+            new Customer { Id = "c2", Name = "No Address", Email = "b@x.com", AddressId = "" },
+            new Customer { Id = "c3", Name = "Bad Address", Email = "c@x.com", AddressId = "addr-missing" },
+        };
+
+        // Act
+        var rows = DataScaffold.BuildListRows(meta!, customers, "/data/customers", includeActions: false);
+
+        // Assert
+        Assert.Equal(3, rows.Count);
+        var row0 = string.Join("|", rows[0]);
+        var row1 = string.Join("|", rows[1]);
+        var row2 = string.Join("|", rows[2]);
+
+        Assert.Contains("Valid Address", row0);    // Resolved display name
+        Assert.Contains("\u2014", row1);            // Dash for empty
+        Assert.Contains("addr-missing", row2);      // Fallback to raw ID
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────────────
+
+    private static void ClearLookupCache()
+    {
+        var cacheField = typeof(DataScaffold).GetField("LookupCache",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        if (cacheField?.GetValue(null) is IDictionary cache)
+            cache.Clear();
+    }
+
+    private class InMemoryDataStore : IDataObjectStore
+    {
+        private readonly Dictionary<(Type, string), BaseDataObject> _store = new();
+
+        public IReadOnlyList<IDataProvider> Providers => Array.Empty<IDataProvider>();
+        public void RegisterProvider(IDataProvider provider, bool prepend = false) { }
+        public void RegisterFallbackProvider(IDataProvider provider) { }
+        public void ClearProviders() { }
+
+        public void Save<T>(T obj) where T : BaseDataObject
+            => _store[(typeof(T), obj.Id)] = obj;
+
+        public ValueTask SaveAsync<T>(T obj, CancellationToken cancellationToken = default) where T : BaseDataObject
+        { Save(obj); return ValueTask.CompletedTask; }
+
+        public T? Load<T>(string id) where T : BaseDataObject
+            => _store.TryGetValue((typeof(T), id), out var obj) ? obj as T : null;
+
+        public ValueTask<T?> LoadAsync<T>(string id, CancellationToken cancellationToken = default) where T : BaseDataObject
+            => ValueTask.FromResult(Load<T>(id));
+
+        public IEnumerable<T> Query<T>(QueryDefinition? query = null) where T : BaseDataObject
+            => _store.Values.OfType<T>();
+
+        public ValueTask<IEnumerable<T>> QueryAsync<T>(QueryDefinition? query = null, CancellationToken cancellationToken = default) where T : BaseDataObject
+            => ValueTask.FromResult(Query<T>(query));
+
+        public ValueTask<int> CountAsync<T>(QueryDefinition? query = null, CancellationToken cancellationToken = default) where T : BaseDataObject
+            => ValueTask.FromResult(Query<T>(query).Count());
+
+        public void Delete<T>(string id) where T : BaseDataObject
+            => _store.Remove((typeof(T), id));
+
+        public ValueTask DeleteAsync<T>(string id, CancellationToken cancellationToken = default) where T : BaseDataObject
+        { Delete<T>(id); return ValueTask.CompletedTask; }
+    }
+}

--- a/BareMetalWeb.Data/DataScaffold.cs
+++ b/BareMetalWeb.Data/DataScaffold.cs
@@ -1495,6 +1495,9 @@ public static class DataScaffold
 
     private static string FormatLookupDisplay(string key, string display)
     {
+        if (string.IsNullOrWhiteSpace(key) && string.IsNullOrWhiteSpace(display))
+            return "—";
+
         if (string.IsNullOrWhiteSpace(key))
             return display;
 


### PR DESCRIPTION
Fixes the recurring lookup/rendering issues that bite every time:

### Root Cause
`nestedGet()` in the VNext SPA was **case-sensitive** — API returns camelCase (`customerId`) but lookup metadata uses PascalCase (`CustomerId`). The manual fallback pattern (`|| nestedGet(obj, field.charAt(0).toLowerCase()...)`) was scattered in 18 places but missed edge cases.

### VNext JS Fixes
- **`nestedGet()` now case-insensitive** — tries exact match → camelCase/PascalCase flip → full case-insensitive scan
- **`fetchLookupOptions`** returns `[]` on error instead of throwing (prevents dropdowns stuck at 'Loading…')
- **`resolveViewLookups`** shows visual warning (`text-warning` + title) on batch lookup failure instead of silent swallow
- **Detail view** null/empty lookup values now show '—' instead of broken empty `<a>` links
- **Removed 18 redundant** manual camelCase fallback calls (now handled by nestedGet itself)

### SSR Fixes
- **`FormatLookupDisplay`** returns '—' when both key and display are empty (was returning empty string → blank cells in lists)

### Tests (8 new)
- Resolved display name in list view
- Null/empty FK → dash placeholder
- Missing target entity → graceful raw ID fallback
- Mixed lookup states (resolved + empty + missing) in same list
- Order → Customer lookup chain resolution
- View rows HTML: resolved, empty, and deleted target