### PR TITLE
fix: VNext orders fail to save when detail lines are included

### DIFF
--- a/BareMetalWeb.Data.Tests/ChildListJsonBindingTests.cs
+++ b/BareMetalWeb.Data.Tests/ChildListJsonBindingTests.cs
@@ -1,0 +1,201 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using BareMetalWeb.Core;
+using BareMetalWeb.Data;
+using BareMetalWeb.Data.DataObjects;
+using BareMetalWeb.Data.Interfaces;
+using Xunit;
+
+namespace BareMetalWeb.Data.Tests;
+
+/// <summary>
+/// Tests that child list fields (e.g. Order.OrderRows) can be deserialized
+/// from JSON payloads sent by the VNext SPA.
+/// </summary>
+[Collection("DataStoreProvider")]
+public class ChildListJsonBindingTests : IDisposable
+{
+    private readonly IDataObjectStore _originalStore;
+
+    public ChildListJsonBindingTests()
+    {
+        _originalStore = DataStoreProvider.Current;
+        DataStoreProvider.Current = new InMemoryDataStore();
+        _ = typeof(Customer).Assembly;
+        DataEntityRegistry.RegisterAllEntities();
+    }
+
+    public void Dispose()
+    {
+        DataStoreProvider.Current = _originalStore;
+    }
+
+    [Fact]
+    public void TryConvertJson_ChildList_Array_Of_Objects()
+    {
+        // Simulate VNext payload: OrderRows as JSON array of objects
+        var json = """
+        [
+            { "ProductId": "prod-1", "Quantity": 3, "UnitPrice": 9.99, "Notes": "rush" },
+            { "ProductId": "prod-2", "Quantity": 1, "UnitPrice": 25.00 }
+        ]
+        """;
+        var element = JsonDocument.Parse(json).RootElement;
+
+        var result = DataScaffold.TryConvertJson(element, typeof(List<OrderRow>), out var converted);
+
+        Assert.True(result, "TryConvertJson should succeed for List<OrderRow>");
+        var list = Assert.IsType<List<OrderRow>>(converted);
+        Assert.Equal(2, list.Count);
+
+        Assert.Equal("prod-1", list[0].ProductId);
+        Assert.Equal(3, list[0].Quantity);
+        Assert.Equal(9.99m, list[0].UnitPrice);
+        Assert.Equal("rush", list[0].Notes);
+
+        Assert.Equal("prod-2", list[1].ProductId);
+        Assert.Equal(1, list[1].Quantity);
+        Assert.Equal(25.00m, list[1].UnitPrice);
+    }
+
+    [Fact]
+    public void TryConvertJson_ChildList_Empty_Array()
+    {
+        var element = JsonDocument.Parse("[]").RootElement;
+
+        var result = DataScaffold.TryConvertJson(element, typeof(List<OrderRow>), out var converted);
+
+        Assert.True(result);
+        var list = Assert.IsType<List<OrderRow>>(converted);
+        Assert.Empty(list);
+    }
+
+    [Fact]
+    public void TryConvertJson_ChildList_Null_Returns_Empty_List()
+    {
+        var element = JsonDocument.Parse("null").RootElement;
+
+        var result = DataScaffold.TryConvertJson(element, typeof(List<OrderRow>), out var converted);
+
+        Assert.True(result);
+        var list = Assert.IsType<List<OrderRow>>(converted);
+        Assert.Empty(list);
+    }
+
+    [Fact]
+    public void TryConvertJson_ChildList_Ignores_Unknown_Properties()
+    {
+        var json = """[{ "ProductId": "x", "Quantity": 1, "UnitPrice": 5, "Bogus": "ignored" }]""";
+        var element = JsonDocument.Parse(json).RootElement;
+
+        var result = DataScaffold.TryConvertJson(element, typeof(List<OrderRow>), out var converted);
+
+        Assert.True(result);
+        var list = Assert.IsType<List<OrderRow>>(converted);
+        Assert.Single(list);
+        Assert.Equal("x", list[0].ProductId);
+    }
+
+    [Fact]
+    public void TryConvertJson_ChildList_CaseInsensitive_Properties()
+    {
+        // VNext payload may use camelCase while C# uses PascalCase
+        var json = """[{ "productId": "p1", "quantity": 2, "unitPrice": 10.5 }]""";
+        var element = JsonDocument.Parse(json).RootElement;
+
+        var result = DataScaffold.TryConvertJson(element, typeof(List<OrderRow>), out var converted);
+
+        Assert.True(result);
+        var list = Assert.IsType<List<OrderRow>>(converted);
+        Assert.Single(list);
+        Assert.Equal("p1", list[0].ProductId);
+        Assert.Equal(2, list[0].Quantity);
+        Assert.Equal(10.5m, list[0].UnitPrice);
+    }
+
+    [Fact]
+    public void ApplyValuesFromJson_Order_With_Rows_No_Error()
+    {
+        Assert.True(DataScaffold.TryGetEntity("orders", out var metadata));
+
+        var order = new Order();
+        var json = """
+        {
+            "OrderNumber": "ORD-001",
+            "CustomerId": "cust-1",
+            "OrderDate": "2025-01-15",
+            "Status": "Open",
+            "CurrencyId": "GBP",
+            "OrderRows": [
+                { "ProductId": "prod-1", "Quantity": 2, "UnitPrice": 15.00 }
+            ]
+        }
+        """;
+
+        var doc = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json)!;
+        var errors = DataScaffold.ApplyValuesFromJson(metadata, order, doc, forCreate: true, allowMissing: true);
+
+        // Should NOT contain "Order Rows is invalid."
+        Assert.DoesNotContain(errors, e => e.Contains("Order Rows", System.StringComparison.OrdinalIgnoreCase));
+        Assert.Equal("ORD-001", order.OrderNumber);
+        Assert.Single(order.OrderRows);
+        Assert.Equal("prod-1", order.OrderRows[0].ProductId);
+        Assert.Equal(2, order.OrderRows[0].Quantity);
+        Assert.Equal(15.00m, order.OrderRows[0].UnitPrice);
+    }
+
+    [Fact]
+    public void TryConvertJson_ListString_Still_Works()
+    {
+        // Ensure we didn't break List<string> handling
+        var json = """["tag1", "tag2", "tag3"]""";
+        var element = JsonDocument.Parse(json).RootElement;
+
+        var result = DataScaffold.TryConvertJson(element, typeof(List<string>), out var converted);
+
+        Assert.True(result);
+        var list = Assert.IsType<List<string>>(converted);
+        Assert.Equal(3, list.Count);
+        Assert.Equal("tag1", list[0]);
+    }
+
+    private class InMemoryDataStore : IDataObjectStore
+    {
+        private readonly Dictionary<(Type, string), BaseDataObject> _store = new();
+
+        public IReadOnlyList<IDataProvider> Providers => Array.Empty<IDataProvider>();
+        public void RegisterProvider(IDataProvider provider, bool prepend = false) { }
+        public void RegisterFallbackProvider(IDataProvider provider) { }
+        public void ClearProviders() { }
+
+        public void Save<T>(T obj) where T : BaseDataObject
+            => _store[(typeof(T), obj.Id)] = obj;
+
+        public ValueTask SaveAsync<T>(T obj, CancellationToken cancellationToken = default) where T : BaseDataObject
+        { Save(obj); return ValueTask.CompletedTask; }
+
+        public T? Load<T>(string id) where T : BaseDataObject
+            => _store.TryGetValue((typeof(T), id), out var obj) ? obj as T : null;
+
+        public ValueTask<T?> LoadAsync<T>(string id, CancellationToken cancellationToken = default) where T : BaseDataObject
+            => ValueTask.FromResult(Load<T>(id));
+
+        public IEnumerable<T> Query<T>(QueryDefinition? query = null) where T : BaseDataObject
+            => _store.Values.OfType<T>();
+
+        public ValueTask<IEnumerable<T>> QueryAsync<T>(QueryDefinition? query = null, CancellationToken cancellationToken = default) where T : BaseDataObject
+            => ValueTask.FromResult(Query<T>(query));
+
+        public ValueTask<int> CountAsync<T>(QueryDefinition? query = null, CancellationToken cancellationToken = default) where T : BaseDataObject
+            => ValueTask.FromResult(Query<T>(query).Count());
+
+        public void Delete<T>(string id) where T : BaseDataObject
+            => _store.Remove((typeof(T), id));
+
+        public ValueTask DeleteAsync<T>(string id, CancellationToken cancellationToken = default) where T : BaseDataObject
+        { Delete<T>(id); return ValueTask.CompletedTask; }
+    }
+}

--- a/BareMetalWeb.Data/DataScaffold.cs
+++ b/BareMetalWeb.Data/DataScaffold.cs
@@ -3121,6 +3121,14 @@ public static class DataScaffold
                 converted = Enum.Parse(effectiveType, element.GetString() ?? string.Empty, ignoreCase: true);
                 return true;
             }
+
+            // Child list: List<T> where T is a complex class (e.g. List<OrderRow>)
+            if (IsChildListType(effectiveType, out var childType)
+                && (element.ValueKind == JsonValueKind.Array || element.ValueKind == JsonValueKind.Null))
+            {
+                if (TryConvertJsonChildList(element, childType, out converted))
+                    return true;
+            }
         }
         catch
         {
@@ -3128,6 +3136,59 @@ public static class DataScaffold
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Deserialises a JSON array of objects into a <c>List&lt;T&gt;</c> where T is a child entity type.
+    /// Each element's properties are matched against the child type's public writable properties
+    /// and individually converted with <see cref="TryConvertJson"/>.
+    /// </summary>
+    private static bool TryConvertJsonChildList(JsonElement element, Type childType, out object? list)
+    {
+        list = null;
+        var listType = typeof(List<>).MakeGenericType(childType);
+
+        if (element.ValueKind == JsonValueKind.Null)
+        {
+            list = Activator.CreateInstance(listType);
+            return true;
+        }
+
+        try
+        {
+            var typedList = (IList)Activator.CreateInstance(listType)!;
+            var props = childType.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Where(p => p.CanRead && p.CanWrite)
+                .ToDictionary(p => p.Name, p => p, StringComparer.OrdinalIgnoreCase);
+
+            foreach (var row in element.EnumerateArray())
+            {
+                if (row.ValueKind != JsonValueKind.Object)
+                    continue;
+
+                var instance = Activator.CreateInstance(childType);
+                if (instance == null)
+                    continue;
+
+                foreach (var prop in row.EnumerateObject())
+                {
+                    if (!props.TryGetValue(prop.Name, out var pi))
+                        continue;
+
+                    if (TryConvertJson(prop.Value, pi.PropertyType, out var val))
+                        pi.SetValue(instance, val);
+                }
+
+                typedList.Add(instance);
+            }
+
+            list = typedList;
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
     }
 
     public static FormFieldType MapFieldType(Type type)


### PR DESCRIPTION
## Problem

When saving an Order with OrderRows (detail lines) via the VNext SPA, the server rejects the payload with **"Order Rows is invalid."**

## Root Cause

`TryConvertJson()` in `DataScaffold.cs` only handled:
- Primitives (int, decimal, bool, DateTime, etc.)
- String arrays/lists (`string[]`, `List<string>`)
- Enums

It had **no handler for `List<T>` where T is a complex child type** (e.g. `List<OrderRow>`). When VNext sent the JSON payload with `"OrderRows": [{...}, {...}]`, `TryConvertJson` returned `false`, causing the "is invalid" error.

The form-based SSR path (`ApplyValuesFromForm`) worked fine because it uses `TryParseChildList` which handles `Dictionary<string, string>` rows. Only the JSON path (used by VNext) was broken.

## Fix

Added `TryConvertJsonChildList()` which:
- Detects `List<T>` where T is a complex class via the existing `IsChildListType()`
- Creates a typed list and iterates each JSON array element
- Maps each property **case-insensitively** to the child type's public writable properties
- Recursively calls `TryConvertJson` for individual property conversion (handles nested types correctly)
- Handles null/empty arrays gracefully

## Tests

7 new tests in `ChildListJsonBindingTests.cs`:
- ✅ Array of objects → `List<OrderRow>` 
- ✅ Empty array → empty list
- ✅ Null → empty list
- ✅ Unknown properties silently ignored
- ✅ camelCase → PascalCase property matching
- ✅ Full `ApplyValuesFromJson` round-trip with Order + OrderRows
- ✅ Regression: `List<string>` still works