### PR TITLE
fix: re-enable reflection-based JSON serialization (fixes #472)

### DIFF
--- a/BareMetalWeb.Host/BareMetalWeb.Host.csproj
+++ b/BareMetalWeb.Host/BareMetalWeb.Host.csproj
@@ -8,6 +8,8 @@
     <PublishTrimmed>true</PublishTrimmed>
     <TrimMode>partial</TrimMode>
     <SuppressTrimAnalysisWarnings>false</SuppressTrimAnalysisWarnings>
+    <!-- Required: app uses reflection-based JsonSerializer throughout -->
+    <JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## 🚨 Critical — live site crash

Fixes #472

The trimming spike (#470) added `PublishTrimmed=true` which causes .NET 10 to set `JsonSerializerIsReflectionEnabledByDefault=false`. This crashes the app at startup in `VirtualEntityLoader.LoadFromFile`:

```
System.InvalidOperationException: Reflection-based serialization has been disabled for this application.
```

### Fix
Add `<JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>` to Host.csproj.

The app uses reflection-based `JsonSerializer` across 12+ files — migrating to source-generated `JsonSerializerContext` is a separate effort.

### One-line change
```xml
<JsonSerializerIsReflectionEnabledByDefault>true</JsonSerializerIsReflectionEnabledByDefault>
```