### PR TITLE
feat: binary wire API with metadata-driven serializer

### DIFF
--- a/BareMetalWeb.Core/wwwroot/static/js/BareMetalBinary.js
+++ b/BareMetalWeb.Core/wwwroot/static/js/BareMetalBinary.js
@@ -1,0 +1,496 @@
+// BareMetalBinary — BSO1 binary wire serializer for BareMetalWeb
+// Mirrors MetadataWireSerializer.cs: metadata-driven, zero-copy DataView reads,
+// HMAC-SHA256 signing via Web Crypto API.
+const BareMetalBinary = (() => {
+  'use strict';
+
+  const MAGIC = 0x314F5342; // "BSO1" LE
+  const VERSION = 3;
+  const SIG_SIZE = 32;
+  const HDR_FIELDS = 13; // magic(4) + version(4) + schema(4) + arch(1)
+  const HDR_SIZE = HDR_FIELDS + SIG_SIZE; // 45
+  const MAX_STR = 4 * 1024 * 1024;
+  const MAX_DEPTH = 64;
+  const utf8 = new TextEncoder();
+  const utf8d = new TextDecoder('utf-8');
+
+  let _cryptoKey = null; // CryptoKey for HMAC-SHA256
+
+  // ────────── Key management ──────────
+
+  async function setSigningKey(base64Key) {
+    const raw = Uint8Array.from(atob(base64Key), c => c.charCodeAt(0));
+    _cryptoKey = await crypto.subtle.importKey('raw', raw, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign', 'verify']);
+  }
+
+  async function setSigningKeyBytes(keyBytes) {
+    _cryptoKey = await crypto.subtle.importKey('raw', keyBytes, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign', 'verify']);
+  }
+
+  // ────────── SpanReader ──────────
+
+  class SpanReader {
+    constructor(buffer) {
+      this.dv = new DataView(buffer instanceof ArrayBuffer ? buffer : buffer.buffer, buffer.byteOffset || 0, buffer.byteLength);
+      this.buf = new Uint8Array(buffer instanceof ArrayBuffer ? buffer : buffer.buffer, buffer.byteOffset || 0, buffer.byteLength);
+      this.off = 0;
+    }
+    ensure(n) { if (this.off + n > this.dv.byteLength) throw new Error('EOF'); }
+    readByte() { this.ensure(1); return this.dv.getUint8(this.off++); }
+    readSByte() { this.ensure(1); return this.dv.getInt8(this.off++); }
+    readBool() { return this.readByte() !== 0; }
+    readInt16() { this.ensure(2); const v = this.dv.getInt16(this.off, true); this.off += 2; return v; }
+    readUInt16() { this.ensure(2); const v = this.dv.getUint16(this.off, true); this.off += 2; return v; }
+    readInt32() { this.ensure(4); const v = this.dv.getInt32(this.off, true); this.off += 4; return v; }
+    readUInt32() { this.ensure(4); const v = this.dv.getUint32(this.off, true); this.off += 4; return v; }
+    readInt64() {
+      this.ensure(8);
+      const lo = this.dv.getUint32(this.off, true);
+      const hi = this.dv.getInt32(this.off + 4, true);
+      this.off += 8;
+      return BigInt(hi) * 0x100000000n + BigInt(lo >>> 0);
+    }
+    readUInt64() {
+      this.ensure(8);
+      const lo = this.dv.getUint32(this.off, true);
+      const hi = this.dv.getUint32(this.off + 4, true);
+      this.off += 8;
+      return BigInt(hi) * 0x100000000n + BigInt(lo >>> 0);
+    }
+    readFloat32() { this.ensure(4); const v = this.dv.getFloat32(this.off, true); this.off += 4; return v; }
+    readFloat64() { this.ensure(8); const v = this.dv.getFloat64(this.off, true); this.off += 8; return v; }
+    readDecimal() {
+      const lo = this.readInt32(); const mid = this.readInt32();
+      const hi = this.readInt32(); const flags = this.readInt32();
+      const neg = (flags & 0x80000000) !== 0;
+      const scale = (flags >>> 16) & 0xFF;
+      // Reconstruct as JS number (lossy for very large decimals)
+      let val = (Math.abs(hi) * 4294967296 + (mid >>> 0)) * 4294967296 + (lo >>> 0);
+      val /= Math.pow(10, scale);
+      return neg ? -val : val;
+    }
+    readChar() { return String.fromCharCode(this.readUInt16()); }
+    readBytes(n) { this.ensure(n); const s = this.buf.slice(this.off, this.off + n); this.off += n; return s; }
+    readGuid() {
+      const b = this.readBytes(16);
+      const h = Array.from(b, x => x.toString(16).padStart(2, '0')).join('');
+      return h.slice(0,8)+'-'+h.slice(8,12)+'-'+h.slice(12,16)+'-'+h.slice(16,20)+'-'+h.slice(20);
+    }
+    readIdentifier() {
+      // 16 bytes: hi LE (8) + lo LE (8) — base-37 encoded
+      const hiLo = this.readUInt64();
+      const loLo = this.readUInt64();
+      return decodeIdentifier(hiLo, loLo);
+    }
+    skip(n) { this.off += n; }
+  }
+
+  // ────────── SpanWriter ──────────
+
+  class SpanWriter {
+    constructor(initialSize) {
+      this.capacity = initialSize || 256;
+      this.buf = new ArrayBuffer(this.capacity);
+      this.u8 = new Uint8Array(this.buf);
+      this.dv = new DataView(this.buf);
+      this.off = 0;
+    }
+    ensure(n) {
+      if (this.off + n <= this.capacity) return;
+      while (this.off + n > this.capacity) this.capacity *= 2;
+      const nb = new ArrayBuffer(this.capacity);
+      new Uint8Array(nb).set(this.u8.subarray(0, this.off));
+      this.buf = nb; this.u8 = new Uint8Array(nb); this.dv = new DataView(nb);
+    }
+    writeByte(v) { this.ensure(1); this.dv.setUint8(this.off++, v); }
+    writeSByte(v) { this.ensure(1); this.dv.setInt8(this.off++, v); }
+    writeBool(v) { this.writeByte(v ? 1 : 0); }
+    writeInt16(v) { this.ensure(2); this.dv.setInt16(this.off, v, true); this.off += 2; }
+    writeUInt16(v) { this.ensure(2); this.dv.setUint16(this.off, v, true); this.off += 2; }
+    writeInt32(v) { this.ensure(4); this.dv.setInt32(this.off, v, true); this.off += 4; }
+    writeUInt32(v) { this.ensure(4); this.dv.setUint32(this.off, v, true); this.off += 4; }
+    writeInt64(v) {
+      this.ensure(8);
+      const big = BigInt(v);
+      this.dv.setUint32(this.off, Number(big & 0xFFFFFFFFn), true);
+      this.dv.setInt32(this.off + 4, Number(big >> 32n), true);
+      this.off += 8;
+    }
+    writeUInt64(v) {
+      this.ensure(8);
+      const big = BigInt(v);
+      this.dv.setUint32(this.off, Number(big & 0xFFFFFFFFn), true);
+      this.dv.setUint32(this.off + 4, Number((big >> 32n) & 0xFFFFFFFFn), true);
+      this.off += 8;
+    }
+    writeFloat32(v) { this.ensure(4); this.dv.setFloat32(this.off, v, true); this.off += 4; }
+    writeFloat64(v) { this.ensure(8); this.dv.setFloat64(this.off, v, true); this.off += 8; }
+    writeDecimal(v) {
+      // Approximate: encode as 4xInt32 matching .NET decimal layout
+      const neg = v < 0; const abs = Math.abs(v);
+      const str = abs.toFixed(10); const dot = str.indexOf('.');
+      const scale = dot >= 0 ? str.length - dot - 1 : 0;
+      let int = BigInt(str.replace('.', ''));
+      while (int > 0n && int % 10n === 0n && scale > 0) int /= 10n; // normalize
+      const lo = Number(int & 0xFFFFFFFFn);
+      const mid = Number((int >> 32n) & 0xFFFFFFFFn);
+      const hi = Number((int >> 64n) & 0xFFFFFFFFn);
+      const flags = (scale << 16) | (neg ? 0x80000000 : 0);
+      this.writeInt32(lo); this.writeInt32(mid); this.writeInt32(hi); this.writeInt32(flags);
+    }
+    writeChar(v) { this.writeUInt16(typeof v === 'string' ? v.charCodeAt(0) : v); }
+    writeBytes(bytes) { this.ensure(bytes.length); this.u8.set(bytes, this.off); this.off += bytes.length; }
+    writeGuid(str) {
+      const hex = str.replace(/-/g, '');
+      const b = new Uint8Array(16);
+      for (let i = 0; i < 16; i++) b[i] = parseInt(hex.substr(i*2, 2), 16);
+      this.writeBytes(b);
+    }
+    writeString(s) {
+      if (s === null || s === undefined) { this.writeInt32(-1); return; }
+      const bytes = utf8.encode(s);
+      this.writeInt32(bytes.length);
+      if (bytes.length > 0) this.writeBytes(bytes);
+    }
+    writeIdentifier(str) {
+      const [hi, lo] = encodeIdentifier(str);
+      this.writeUInt64(hi); this.writeUInt64(lo);
+    }
+    toUint8Array() { return new Uint8Array(this.buf, 0, this.off); }
+  }
+
+  // ────────── IdentifierValue codec ──────────
+
+  const ID_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-';
+  const ID_MAX_LEN = 25;
+
+  function decodeIdentifier(hi, lo) {
+    if (hi === 0n && lo === 0n) return '';
+    const length = Number((hi >> 59n) & 0x1Fn);
+    if (length === 0 || length > ID_MAX_LEN) return '';
+    hi = hi & 0x07FFFFFFFFFFFFFFn;
+    const chars = [];
+    for (let i = length - 1; i >= 0; i--) {
+      // divide 128-bit by 37
+      const qHi = hi / 37n; const rHi = hi % 37n;
+      const combined1 = (rHi << 32n) | (lo >> 32n);
+      const qMid = combined1 / 37n; const rMid = combined1 % 37n;
+      const combined2 = (rMid << 32n) | (lo & 0xFFFFFFFFn);
+      const qLo = combined2 / 37n; const remainder = combined2 % 37n;
+      chars[i] = ID_ALPHABET[Number(remainder)];
+      hi = qHi; lo = (qMid << 32n) | qLo;
+    }
+    return chars.join('');
+  }
+
+  function encodeIdentifier(str) {
+    if (!str || str.length === 0) return [0n, 0n];
+    const norm = str.toUpperCase().replace(/[^A-Z0-9-]/g, '');
+    if (norm.length > ID_MAX_LEN) throw new Error('Identifier too long');
+    let hi = 0n, lo = 0n;
+    for (let i = 0; i < norm.length; i++) {
+      const idx = ID_ALPHABET.indexOf(norm[i]);
+      if (idx < 0) throw new Error(`Invalid char '${norm[i]}'`);
+      // multiply 128-bit by 37 and add
+      const loCarry = (lo * 37n) >> 64n;
+      lo = (lo * 37n) & 0xFFFFFFFFFFFFFFFFn;
+      hi = hi * 37n + loCarry;
+      lo = lo + BigInt(idx);
+      if (lo > 0xFFFFFFFFFFFFFFFFn) { hi++; lo = lo & 0xFFFFFFFFFFFFFFFFn; }
+    }
+    hi |= BigInt(norm.length) << 59n;
+    return [hi, lo];
+  }
+
+  // ────────── HMAC-SHA256 signing ──────────
+
+  async function computeSignature(payload) {
+    // Sign header fields + payload after signature (skip the 32-byte signature slot)
+    const parts = new Uint8Array(payload.length - SIG_SIZE);
+    parts.set(payload.subarray(0, HDR_FIELDS));
+    parts.set(payload.subarray(HDR_SIZE), HDR_FIELDS);
+    const sig = await crypto.subtle.sign('HMAC', _cryptoKey, parts);
+    return new Uint8Array(sig);
+  }
+
+  async function signPayload(payload) {
+    const sig = await computeSignature(payload);
+    payload.set(sig, HDR_FIELDS);
+  }
+
+  async function verifySignature(payload) {
+    const expected = await computeSignature(payload);
+    const actual = payload.subarray(HDR_FIELDS, HDR_SIZE);
+    if (expected.length !== actual.length) return false;
+    let ok = true;
+    for (let i = 0; i < expected.length; i++) ok = ok && (expected[i] === actual[i]);
+    return ok;
+  }
+
+  // ────────── Schema cache ──────────
+
+  const _schemas = {}; // slug → { version, members: [{name, ordinal, wireType, isNullable, enumUnderlying}] }
+
+  async function fetchSchema(slug, apiRoot) {
+    if (_schemas[slug]) return _schemas[slug];
+    const url = (apiRoot || '/api/') + '_binary/' + slug + '/_schema';
+    const r = await fetch(url);
+    if (!r.ok) throw new Error(`Schema fetch failed: ${r.status}`);
+    const schema = await r.json();
+    _schemas[slug] = schema;
+    return schema;
+  }
+
+  function getCachedSchema(slug) { return _schemas[slug] || null; }
+
+  // ────────── Deserialize ──────────
+
+  function readFieldValue(reader, member, depth) {
+    if (depth > MAX_DEPTH) throw new Error('Max depth exceeded');
+
+    if (member.isNullable) {
+      if (reader.readByte() === 0) return null;
+    }
+
+    switch (member.wireType) {
+      case 'Bool': return reader.readBool();
+      case 'Byte': return reader.readByte();
+      case 'SByte': return reader.readSByte();
+      case 'Int16': return reader.readInt16();
+      case 'UInt16': return reader.readUInt16();
+      case 'Int32': return reader.readInt32();
+      case 'UInt32': return reader.readUInt32();
+      case 'Int64': return reader.readInt64();
+      case 'UInt64': return reader.readUInt64();
+      case 'Float32': return reader.readFloat32();
+      case 'Float64': return reader.readFloat64();
+      case 'Decimal': return reader.readDecimal();
+      case 'Char': return reader.readChar();
+      case 'String': return readString(reader);
+      case 'Guid': return reader.readGuid();
+      case 'DateTime': return readDateTime(reader);
+      case 'DateOnly': return readDateOnly(reader);
+      case 'TimeOnly': return readTimeOnly(reader);
+      case 'DateTimeOffset': return readDateTimeOffset(reader);
+      case 'TimeSpan': return reader.readInt64(); // ticks as BigInt
+      case 'Identifier': return reader.readIdentifier();
+      case 'Enum': return readEnum(reader, member);
+      default: return readString(reader); // fallback
+    }
+  }
+
+  function readString(reader) {
+    const len = reader.readInt32();
+    if (len < 0) return null;
+    if (len === 0) return '';
+    if (len > MAX_STR) throw new Error('String too long');
+    const bytes = reader.readBytes(len);
+    return utf8d.decode(bytes);
+  }
+
+  function readDateTime(reader) {
+    const ticks = reader.readInt64();
+    const kind = reader.readByte();
+    // .NET ticks → JS Date (ticks from 0001-01-01, JS from 1970-01-01)
+    const epochTicks = 621355968000000000n;
+    const ms = Number((ticks - epochTicks) / 10000n);
+    return new Date(ms);
+  }
+
+  function readDateOnly(reader) {
+    const dayNumber = reader.readInt32();
+    // .NET DateOnly.DayNumber: days from 0001-01-01
+    const ms = (dayNumber - 719162) * 86400000; // 719162 = days from 0001-01-01 to 1970-01-01
+    return new Date(ms).toISOString().slice(0, 10);
+  }
+
+  function readTimeOnly(reader) {
+    const ticks = reader.readInt64();
+    const totalSec = Number(ticks / 10000000n);
+    const h = Math.floor(totalSec / 3600);
+    const m = Math.floor((totalSec % 3600) / 60);
+    const s = totalSec % 60;
+    return `${String(h).padStart(2,'0')}:${String(m).padStart(2,'0')}:${String(s).padStart(2,'0')}`;
+  }
+
+  function readDateTimeOffset(reader) {
+    const ticks = reader.readInt64();
+    const offsetMin = reader.readInt16();
+    const epochTicks = 621355968000000000n;
+    const ms = Number((ticks - epochTicks) / 10000n);
+    return new Date(ms - offsetMin * 60000);
+  }
+
+  function readEnum(reader, member) {
+    const underlying = member.enumUnderlying || 'Int32';
+    switch (underlying) {
+      case 'Byte': return reader.readByte();
+      case 'SByte': return reader.readSByte();
+      case 'Int16': return reader.readInt16();
+      case 'UInt16': return reader.readUInt16();
+      case 'UInt32': return reader.readUInt32();
+      case 'Int64': return reader.readInt64();
+      case 'UInt64': return reader.readUInt64();
+      default: return reader.readInt32();
+    }
+  }
+
+  async function deserialize(buffer, schema) {
+    const u8 = new Uint8Array(buffer);
+    if (!await verifySignature(u8)) throw new Error('Signature mismatch');
+
+    const reader = new SpanReader(u8);
+    reader.skip(HDR_SIZE); // skip header
+
+    // Object null indicator
+    if (reader.readByte() === 0) return null;
+
+    const obj = {};
+    for (const m of schema.members) {
+      obj[m.name] = readFieldValue(reader, m, 0);
+    }
+    return obj;
+  }
+
+  async function deserializeList(buffer, schema) {
+    const u8 = new Uint8Array(buffer);
+    if (!await verifySignature(u8)) throw new Error('Signature mismatch');
+
+    const reader = new SpanReader(u8);
+    reader.skip(HDR_SIZE); // skip header
+
+    const count = reader.readInt32();
+    const items = [];
+    for (let i = 0; i < count; i++) {
+      const itemLen = reader.readInt32();
+      // Object null indicator
+      if (reader.readByte() === 0) { items.push(null); continue; }
+      const obj = {};
+      for (const m of schema.members) {
+        obj[m.name] = readFieldValue(reader, m, 0);
+      }
+      items.push(obj);
+    }
+    return items;
+  }
+
+  // ────────── Serialize ──────────
+
+  function writeFieldValue(writer, member, value, depth) {
+    if (depth > MAX_DEPTH) throw new Error('Max depth exceeded');
+
+    if (member.isNullable) {
+      if (value === null || value === undefined) { writer.writeByte(0); return; }
+      writer.writeByte(1);
+    }
+
+    switch (member.wireType) {
+      case 'Bool': writer.writeBool(!!value); break;
+      case 'Byte': writer.writeByte(value | 0); break;
+      case 'SByte': writer.writeSByte(value | 0); break;
+      case 'Int16': writer.writeInt16(value | 0); break;
+      case 'UInt16': writer.writeUInt16(value | 0); break;
+      case 'Int32': writer.writeInt32(value | 0); break;
+      case 'UInt32': writer.writeUInt32(value >>> 0); break;
+      case 'Int64': writer.writeInt64(BigInt(value || 0)); break;
+      case 'UInt64': writer.writeUInt64(BigInt(value || 0)); break;
+      case 'Float32': writer.writeFloat32(value || 0); break;
+      case 'Float64': writer.writeFloat64(value || 0); break;
+      case 'Decimal': writer.writeDecimal(value || 0); break;
+      case 'Char': writer.writeChar(value || '\0'); break;
+      case 'String': writer.writeString(value ?? null); break;
+      case 'Guid': writer.writeGuid(value || '00000000-0000-0000-0000-000000000000'); break;
+      case 'DateTime': writeDateTime(writer, value); break;
+      case 'DateOnly': writeDateOnly(writer, value); break;
+      case 'TimeOnly': writeTimeOnly(writer, value); break;
+      case 'DateTimeOffset': writeDateTimeOffset(writer, value); break;
+      case 'TimeSpan': writer.writeInt64(BigInt(value || 0)); break;
+      case 'Identifier': writer.writeIdentifier(value || ''); break;
+      case 'Enum': writeEnum(writer, member, value); break;
+      default: writer.writeString(value != null ? String(value) : null); break;
+    }
+  }
+
+  function writeDateTime(writer, value) {
+    const d = value instanceof Date ? value : new Date(value || 0);
+    const epochTicks = 621355968000000000n;
+    const ticks = epochTicks + BigInt(d.getTime()) * 10000n;
+    writer.writeInt64(ticks);
+    writer.writeByte(1); // DateTimeKind.Utc
+  }
+
+  function writeDateOnly(writer, value) {
+    let d;
+    if (typeof value === 'string') { const parts = value.split('-'); d = new Date(Date.UTC(+parts[0], +parts[1]-1, +parts[2])); }
+    else d = value instanceof Date ? value : new Date(value || 0);
+    const dayNumber = Math.floor(d.getTime() / 86400000) + 719162;
+    writer.writeInt32(dayNumber);
+  }
+
+  function writeTimeOnly(writer, value) {
+    let ticks = 0n;
+    if (typeof value === 'string') {
+      const p = value.split(':').map(Number);
+      ticks = BigInt((p[0]||0)*3600 + (p[1]||0)*60 + (p[2]||0)) * 10000000n;
+    }
+    writer.writeInt64(ticks);
+  }
+
+  function writeDateTimeOffset(writer, value) {
+    const d = value instanceof Date ? value : new Date(value || 0);
+    const epochTicks = 621355968000000000n;
+    const ticks = epochTicks + BigInt(d.getTime()) * 10000n;
+    writer.writeInt64(ticks);
+    writer.writeInt16(0); // UTC offset
+  }
+
+  function writeEnum(writer, member, value) {
+    const v = value | 0;
+    const underlying = member.enumUnderlying || 'Int32';
+    switch (underlying) {
+      case 'Byte': writer.writeByte(v); break;
+      case 'SByte': writer.writeSByte(v); break;
+      case 'Int16': writer.writeInt16(v); break;
+      case 'UInt16': writer.writeUInt16(v); break;
+      case 'UInt32': writer.writeUInt32(v >>> 0); break;
+      case 'Int64': writer.writeInt64(BigInt(v)); break;
+      case 'UInt64': writer.writeUInt64(BigInt(v)); break;
+      default: writer.writeInt32(v); break;
+    }
+  }
+
+  async function serialize(obj, schema) {
+    const writer = new SpanWriter(256);
+    // Header
+    writer.writeInt32(MAGIC);
+    writer.writeInt32(VERSION);
+    writer.writeInt32(schema.version || 1);
+    writer.writeByte(0); // architecture (irrelevant for wire)
+    // Signature placeholder
+    for (let i = 0; i < SIG_SIZE; i++) writer.writeByte(0);
+    // Object null indicator
+    writer.writeByte(1);
+    for (const m of schema.members) {
+      writeFieldValue(writer, m, obj[m.name], 0);
+    }
+    const payload = writer.toUint8Array();
+    await signPayload(payload);
+    return payload.buffer.slice(0, payload.length);
+  }
+
+  // ────────── Public API ──────────
+
+  return {
+    setSigningKey,
+    setSigningKeyBytes,
+    fetchSchema,
+    getCachedSchema,
+    deserialize,
+    deserializeList,
+    serialize,
+    verifySignature,
+    // Expose for testing
+    SpanReader,
+    SpanWriter,
+  };
+})();

--- a/BareMetalWeb.Core/wwwroot/static/js/BareMetalRest.js
+++ b/BareMetalWeb.Core/wwwroot/static/js/BareMetalRest.js
@@ -1,26 +1,45 @@
 // BareMetalRest — lean REST client for BareMetalWeb
 // Handles CRUD, metadata fetch and 401 redirect.
+// Uses binary wire format (BSO1) for entity operations when BareMetalBinary is available.
 // API: setRoot(url), getRoot(), entity(slug), call(method, url, body)
 const BareMetalRest = (() => {
   'use strict';
   let root = '/api/';
+  let _binaryReady = false;
 
   const setRoot = r => { root = r.endsWith('/') ? r : r + '/'; };
   const getRoot = () => root;
 
+  // ── Binary bootstrap ──
+  // Fetches signing key and initialises BareMetalBinary.
+  // Called lazily on first entity() operation.
+  async function ensureBinary() {
+    if (_binaryReady || typeof BareMetalBinary === 'undefined') return;
+    try {
+      const r = await fetch(root + '_binary/_key');
+      if (r.ok) {
+        const key = await r.text();
+        await BareMetalBinary.setSigningKey(key.trim());
+        _binaryReady = true;
+      }
+    } catch { /* fall back to JSON */ }
+  }
+
+  function isBinaryAvailable() {
+    return _binaryReady && typeof BareMetalBinary !== 'undefined';
+  }
+
+  // ── JSON fallback call (unchanged) ──
   async function call(method, url, body) {
     const opts = { method, headers: {} };
     if (body !== undefined) {
       if (body instanceof FormData) {
-        opts.body = body; // Let browser set Content-Type with boundary
+        opts.body = body;
       } else {
         opts.body = JSON.stringify(body);
         opts.headers['Content-Type'] = 'application/json';
       }
     }
-    // Custom header on mutating requests — CSRF mitigation for cookie-auth APIs.
-    // Cross-origin requests with custom headers trigger CORS preflight, which the
-    // server's CORS policy blocks, preventing cross-site request forgery.
     if (method !== 'GET' && method !== 'HEAD') {
       opts.headers['X-Requested-With'] = 'BareMetalWeb';
       const csrfMeta = document.querySelector('meta[name="csrf-token"]');
@@ -33,23 +52,98 @@ const BareMetalRest = (() => {
     }
     if (!r.ok) throw new Error((await r.text()) || r.statusText);
     if (r.status === 204) return null;
-    // Only parse as JSON when the server confirms it — avoids opaque errors on HTML error pages
     const ct = r.headers.get('content-type') || '';
     if (!ct.includes('application/json')) return null;
     return r.json();
   }
 
+  // ── Binary API call ──
+  async function binaryCall(method, url, body) {
+    const opts = { method, headers: {} };
+    if (body instanceof ArrayBuffer || body instanceof Uint8Array) {
+      opts.body = body;
+      opts.headers['Content-Type'] = 'application/x-bmw-binary';
+    }
+    if (method !== 'GET' && method !== 'HEAD') {
+      opts.headers['X-Requested-With'] = 'BareMetalWeb';
+      const csrfMeta = document.querySelector('meta[name="csrf-token"]');
+      if (csrfMeta) opts.headers['X-CSRF-Token'] = csrfMeta.content;
+    }
+    const r = await fetch(url, opts);
+    if (r.status === 401) {
+      location.href = '/login?returnUrl=' + encodeURIComponent(location.href);
+      throw new Error('Unauthorized');
+    }
+    if (!r.ok) throw new Error((await r.text()) || r.statusText);
+    if (r.status === 204) return null;
+    return r.arrayBuffer();
+  }
+
   function entity(slug) {
-    const b = root + slug;
+    const jsonBase = root + slug;
+    const binBase = root + '_binary/' + slug;
+
     return {
-      list:     q          => call('GET',    b + (q ? '?' + new URLSearchParams(q) : '')),
-      get:      id         => call('GET',    `${b}/${id}`),
-      create:   data       => call('POST',   b, data),
-      update:   (id, data) => call('PUT',    `${b}/${id}`, data),
-      remove:   id         => call('DELETE', `${b}/${id}`),
-      metadata: ()         => call('GET',    `${root}metadata/${slug}`)
+      list: async (q) => {
+        await ensureBinary();
+        if (isBinaryAvailable()) {
+          try {
+            const schema = await BareMetalBinary.fetchSchema(slug, root);
+            const url = binBase + (q ? '?' + new URLSearchParams(q) : '');
+            const buf = await binaryCall('GET', url);
+            return { data: await BareMetalBinary.deserializeList(buf, schema), count: -1 };
+          } catch { /* fall back */ }
+        }
+        return call('GET', jsonBase + (q ? '?' + new URLSearchParams(q) : ''));
+      },
+      get: async (id) => {
+        await ensureBinary();
+        if (isBinaryAvailable()) {
+          try {
+            const schema = await BareMetalBinary.fetchSchema(slug, root);
+            const buf = await binaryCall('GET', `${binBase}/${id}`);
+            return BareMetalBinary.deserialize(buf, schema);
+          } catch { /* fall back */ }
+        }
+        return call('GET', `${jsonBase}/${id}`);
+      },
+      create: async (data) => {
+        await ensureBinary();
+        if (isBinaryAvailable()) {
+          try {
+            const schema = await BareMetalBinary.fetchSchema(slug, root);
+            const payload = await BareMetalBinary.serialize(data, schema);
+            const buf = await binaryCall('POST', binBase, payload);
+            return BareMetalBinary.deserialize(buf, schema);
+          } catch { /* fall back */ }
+        }
+        return call('POST', jsonBase, data);
+      },
+      update: async (id, data) => {
+        await ensureBinary();
+        if (isBinaryAvailable()) {
+          try {
+            const schema = await BareMetalBinary.fetchSchema(slug, root);
+            const payload = await BareMetalBinary.serialize(data, schema);
+            const buf = await binaryCall('PUT', `${binBase}/${id}`, payload);
+            return BareMetalBinary.deserialize(buf, schema);
+          } catch { /* fall back */ }
+        }
+        return call('PUT', `${jsonBase}/${id}`, data);
+      },
+      remove: async (id) => {
+        await ensureBinary();
+        if (isBinaryAvailable()) {
+          try {
+            await binaryCall('DELETE', `${binBase}/${id}`);
+            return null;
+          } catch { /* fall back */ }
+        }
+        return call('DELETE', `${jsonBase}/${id}`);
+      },
+      metadata: () => call('GET', `${root}metadata/${slug}`)
     };
   }
 
-  return { setRoot, getRoot, entity, call };
+  return { setRoot, getRoot, entity, call, ensureBinary, isBinaryAvailable };
 })();

--- a/BareMetalWeb.Data/BinaryObjectSerializer.cs
+++ b/BareMetalWeb.Data/BinaryObjectSerializer.cs
@@ -50,6 +50,9 @@ public sealed class BinaryObjectSerializer : ISchemaAwareObjectSerializer
 
     private readonly byte[] _signingKey;
 
+    /// <summary>Returns a copy of the signing key for use by other serializers (e.g. MetadataWireSerializer).</summary>
+    public byte[] GetSigningKeyCopy() => (byte[])_signingKey.Clone();
+
     public BinaryObjectSerializer()
         : this(LoadOrCreateSigningKey(DefaultSigningKeyPath))
     {

--- a/BareMetalWeb.Data/MetadataWireSerializer.cs
+++ b/BareMetalWeb.Data/MetadataWireSerializer.cs
@@ -1,0 +1,696 @@
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace BareMetalWeb.Data;
+
+/// <summary>
+/// Metadata-driven binary serializer for wire transport.
+/// Uses precompiled <see cref="FieldPlan"/> arrays built once at startup from
+/// entity metadata — zero reflection at serialize/deserialize time.
+///
+/// Wire format: BSO1 header (45 bytes) + fields in ordinal order.
+/// Compatible with <see cref="BinaryObjectSerializer"/> binary layout.
+/// </summary>
+public sealed class MetadataWireSerializer
+{
+    private const int Magic = 0x314F5342; // "BSO1"
+    private const int CurrentVersion = 3;
+    private const int SignatureSize = 32;
+    private const int HeaderFieldsSize = 4 + 4 + 4 + 1; // magic + version + schema + arch
+    private const int HeaderSize = HeaderFieldsSize + SignatureSize;
+    private const int MaxDepth = 64;
+    private const int MaxStringBytes = 4 * 1024 * 1024;
+    private const int MaxCollectionLength = 1_000_000;
+    private static readonly byte[] SignaturePlaceholder = new byte[SignatureSize];
+    private static readonly Encoding Utf8 = Encoding.UTF8;
+
+    private readonly byte[] _signingKey;
+
+    // Cached field plans per CLR type — built once, reused forever
+    private static readonly ConcurrentDictionary<Type, FieldPlan[]> PlanCache = new();
+
+    public MetadataWireSerializer(byte[] signingKey)
+    {
+        if (signingKey is null || signingKey.Length != SignatureSize)
+            throw new ArgumentException($"Signing key must be {SignatureSize} bytes.");
+        _signingKey = signingKey;
+    }
+
+    /// <summary>
+    /// Precompiled per-field serialization plan. Built once from metadata,
+    /// stored in ordinal-sorted array. No reflection at runtime.
+    /// </summary>
+    public sealed class FieldPlan
+    {
+        public required string Name { get; init; }
+        public required int Ordinal { get; init; }
+        public required WireFieldType WireType { get; init; }
+        public required bool IsNullable { get; init; }
+        public required Func<object, object?> Getter { get; init; }
+        public required Action<object, object?> Setter { get; init; }
+        // For enum fields: the underlying wire type (Int32, Byte, etc.)
+        public WireFieldType EnumUnderlying { get; init; }
+        // For collection fields: element wire type
+        public WireFieldType ElementWireType { get; init; }
+        // CLR type for object creation during deserialization
+        public required Type ClrType { get; init; }
+    }
+
+    /// <summary>
+    /// Compact field type enum for wire format. Avoids System.TypeCode dependency
+    /// and maps directly to binary read/write operations.
+    /// </summary>
+    public enum WireFieldType : byte
+    {
+        Bool = 1,
+        Byte = 2,
+        SByte = 3,
+        Int16 = 4,
+        UInt16 = 5,
+        Int32 = 6,
+        UInt32 = 7,
+        Int64 = 8,
+        UInt64 = 9,
+        Float32 = 10,
+        Float64 = 11,
+        Decimal = 12,
+        Char = 13,
+        String = 20,
+        Guid = 21,
+        DateTime = 22,
+        DateOnly = 23,
+        TimeOnly = 24,
+        DateTimeOffset = 25,
+        TimeSpan = 26,
+        Enum = 30,
+        Identifier = 40, // IdentifierValue — 16 bytes (hi LE, lo LE)
+        Object = 50,
+    }
+
+    // ────────────── Plan building ──────────────
+
+    /// <summary>
+    /// Builds a FieldPlan[] from entity metadata. Call once at startup per type.
+    /// Plans are sorted by field name (ordinal) to match BinaryObjectSerializer member order.
+    /// </summary>
+    public static FieldPlan[] BuildPlan(Type entityType, IReadOnlyList<FieldPlanDescriptor> fields)
+    {
+        return PlanCache.GetOrAdd(entityType, _ =>
+        {
+            var plans = new FieldPlan[fields.Count];
+            for (int i = 0; i < fields.Count; i++)
+            {
+                var f = fields[i];
+                plans[i] = new FieldPlan
+                {
+                    Name = f.Name,
+                    Ordinal = i,
+                    WireType = f.WireType,
+                    IsNullable = f.IsNullable,
+                    Getter = f.Getter,
+                    Setter = f.Setter,
+                    EnumUnderlying = f.EnumUnderlying,
+                    ElementWireType = f.ElementWireType,
+                    ClrType = f.ClrType,
+                };
+            }
+            return plans;
+        });
+    }
+
+    /// <summary>
+    /// Descriptor passed in from the metadata layer to build a FieldPlan.
+    /// The metadata layer resolves CLR PropertyInfo → WireFieldType once.
+    /// </summary>
+    public sealed class FieldPlanDescriptor
+    {
+        public required string Name { get; init; }
+        public required WireFieldType WireType { get; init; }
+        public required bool IsNullable { get; init; }
+        public required Func<object, object?> Getter { get; init; }
+        public required Action<object, object?> Setter { get; init; }
+        public required Type ClrType { get; init; }
+        public WireFieldType EnumUnderlying { get; init; }
+        public WireFieldType ElementWireType { get; init; }
+    }
+
+    /// <summary>
+    /// Resolves a CLR property type to a WireFieldType. Called once per field at plan-build time.
+    /// </summary>
+    public static (WireFieldType wireType, bool isNullable, WireFieldType enumUnderlying) ResolveWireType(Type propertyType)
+    {
+        var nullable = Nullable.GetUnderlyingType(propertyType);
+        var isNullable = nullable != null || !propertyType.IsValueType;
+        var effective = nullable ?? propertyType;
+
+        if (effective.IsEnum)
+        {
+            var underlying = Enum.GetUnderlyingType(effective);
+            return (WireFieldType.Enum, isNullable, MapPrimitiveType(underlying));
+        }
+
+        if (effective == typeof(string)) return (WireFieldType.String, true, default);
+        if (effective == typeof(bool)) return (WireFieldType.Bool, isNullable, default);
+        if (effective == typeof(byte)) return (WireFieldType.Byte, isNullable, default);
+        if (effective == typeof(sbyte)) return (WireFieldType.SByte, isNullable, default);
+        if (effective == typeof(short)) return (WireFieldType.Int16, isNullable, default);
+        if (effective == typeof(ushort)) return (WireFieldType.UInt16, isNullable, default);
+        if (effective == typeof(int)) return (WireFieldType.Int32, isNullable, default);
+        if (effective == typeof(uint)) return (WireFieldType.UInt32, isNullable, default);
+        if (effective == typeof(long)) return (WireFieldType.Int64, isNullable, default);
+        if (effective == typeof(ulong)) return (WireFieldType.UInt64, isNullable, default);
+        if (effective == typeof(float)) return (WireFieldType.Float32, isNullable, default);
+        if (effective == typeof(double)) return (WireFieldType.Float64, isNullable, default);
+        if (effective == typeof(decimal)) return (WireFieldType.Decimal, isNullable, default);
+        if (effective == typeof(char)) return (WireFieldType.Char, isNullable, default);
+        if (effective == typeof(Guid)) return (WireFieldType.Guid, isNullable, default);
+        if (effective == typeof(DateTime)) return (WireFieldType.DateTime, isNullable, default);
+        if (effective == typeof(System.DateOnly)) return (WireFieldType.DateOnly, isNullable, default);
+        if (effective == typeof(System.TimeOnly)) return (WireFieldType.TimeOnly, isNullable, default);
+        if (effective == typeof(DateTimeOffset)) return (WireFieldType.DateTimeOffset, isNullable, default);
+        if (effective == typeof(TimeSpan)) return (WireFieldType.TimeSpan, isNullable, default);
+        if (effective == typeof(IdentifierValue)) return (WireFieldType.Identifier, isNullable, default);
+
+        return (WireFieldType.Object, isNullable, default);
+    }
+
+    private static WireFieldType MapPrimitiveType(Type t)
+    {
+        if (t == typeof(int)) return WireFieldType.Int32;
+        if (t == typeof(byte)) return WireFieldType.Byte;
+        if (t == typeof(short)) return WireFieldType.Int16;
+        if (t == typeof(long)) return WireFieldType.Int64;
+        if (t == typeof(uint)) return WireFieldType.UInt32;
+        if (t == typeof(ushort)) return WireFieldType.UInt16;
+        if (t == typeof(ulong)) return WireFieldType.UInt64;
+        if (t == typeof(sbyte)) return WireFieldType.SByte;
+        return WireFieldType.Int32;
+    }
+
+    // ────────────── Serialization (write) ──────────────
+
+    /// <summary>
+    /// Serializes an entity to a signed binary payload using the precompiled field plan.
+    /// Writes directly to an IBufferWriter — zero intermediate copies.
+    /// </summary>
+    public int Serialize(object entity, FieldPlan[] plan, int schemaVersion, IBufferWriter<byte> output)
+    {
+        var data = Serialize(entity, plan, schemaVersion);
+        var dest = output.GetSpan(data.Length);
+        data.CopyTo(dest);
+        output.Advance(data.Length);
+        return data.Length;
+    }
+
+    /// <summary>
+    /// Serializes an entity to a new byte[]. Writes to owned buffer and signs in-place.
+    /// </summary>
+    public byte[] Serialize(object entity, FieldPlan[] plan, int schemaVersion)
+    {
+        var buffer = new ArrayBufferWriter<byte>(256);
+        var writer = new SpanWriter(buffer);
+        WriteHeader(ref writer, schemaVersion);
+        WriteFields(ref writer, entity, plan);
+        writer.Commit();
+
+        // Copy to owned array and sign in-place
+        var result = buffer.WrittenSpan.ToArray();
+        SignPayload(result);
+        return result;
+    }
+
+    /// <summary>
+    /// Serializes a list of entities for wire transport.
+    /// Format: [BSO1 header][Int32 count][per item: Int32 len + payload bytes]
+    /// Returns a signed byte[] that can be written to the response body.
+    /// </summary>
+    public byte[] SerializeList(IEnumerable items, FieldPlan[] plan, int schemaVersion, int count)
+    {
+        var buffer = new ArrayBufferWriter<byte>(256 + count * 64);
+        var writer = new SpanWriter(buffer);
+
+        // List envelope header
+        WriteHeader(ref writer, schemaVersion);
+        writer.WriteInt32(count);
+        writer.Commit();
+
+        foreach (var item in items)
+        {
+            if (item is null) continue;
+            // Serialize item fields to a temp buffer to get the length
+            var itemBuf = new ArrayBufferWriter<byte>(128);
+            var itemWriter = new SpanWriter(itemBuf);
+            WriteFields(ref itemWriter, item, plan);
+            int itemLen = itemWriter.Commit();
+
+            // Write length-prefix + payload into main buffer
+            var lenWriter = new SpanWriter(buffer);
+            lenWriter.WriteInt32(itemLen);
+            lenWriter.Commit();
+            var payload = itemBuf.WrittenSpan;
+            var dest = buffer.GetSpan(payload.Length);
+            payload.CopyTo(dest);
+            buffer.Advance(payload.Length);
+        }
+
+        // Copy to owned array and sign in-place
+        var result = buffer.WrittenSpan.ToArray();
+        SignPayload(result);
+        return result;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void WriteHeader(ref SpanWriter writer, int schemaVersion)
+    {
+        writer.WriteInt32(Magic);
+        writer.WriteInt32(CurrentVersion);
+        writer.WriteInt32(schemaVersion);
+        writer.WriteByte((byte)BinaryArchitectureMapper.Current);
+        writer.WriteBytes(SignaturePlaceholder);
+    }
+
+    private static void WriteFields(ref SpanWriter writer, object entity, FieldPlan[] plan)
+    {
+        // Reference type null indicator
+        writer.WriteByte(1); // entity is never null here
+
+        for (int i = 0; i < plan.Length; i++)
+        {
+            var fp = plan[i];
+            var value = fp.Getter(entity);
+            WriteFieldValue(ref writer, fp, value, 0);
+        }
+    }
+
+    private static void WriteFieldValue(ref SpanWriter writer, FieldPlan fp, object? value, int depth)
+    {
+        if (depth > MaxDepth)
+            throw new InvalidOperationException("Max serialization depth exceeded.");
+
+        if (fp.IsNullable)
+        {
+            if (value is null)
+            {
+                writer.WriteByte(0);
+                return;
+            }
+            writer.WriteByte(1);
+        }
+
+        switch (fp.WireType)
+        {
+            case WireFieldType.Enum:
+                WriteEnumValue(ref writer, fp.EnumUnderlying, value);
+                break;
+            case WireFieldType.String:
+                WriteString(ref writer, value as string);
+                break;
+            case WireFieldType.Bool:
+                writer.WriteBoolean((bool)(value ?? false));
+                break;
+            case WireFieldType.Byte:
+                writer.WriteByte((byte)(value ?? (byte)0));
+                break;
+            case WireFieldType.SByte:
+                writer.WriteSByte((sbyte)(value ?? (sbyte)0));
+                break;
+            case WireFieldType.Int16:
+                writer.WriteInt16((short)(value ?? (short)0));
+                break;
+            case WireFieldType.UInt16:
+                writer.WriteUInt16((ushort)(value ?? (ushort)0));
+                break;
+            case WireFieldType.Int32:
+                writer.WriteInt32((int)(value ?? 0));
+                break;
+            case WireFieldType.UInt32:
+                writer.WriteUInt32((uint)(value ?? 0u));
+                break;
+            case WireFieldType.Int64:
+                writer.WriteInt64((long)(value ?? 0L));
+                break;
+            case WireFieldType.UInt64:
+                writer.WriteUInt64((ulong)(value ?? 0UL));
+                break;
+            case WireFieldType.Float32:
+                writer.WriteSingle((float)(value ?? 0f));
+                break;
+            case WireFieldType.Float64:
+                writer.WriteDouble((double)(value ?? 0d));
+                break;
+            case WireFieldType.Decimal:
+                writer.WriteDecimal((decimal)(value ?? 0m));
+                break;
+            case WireFieldType.Char:
+                writer.WriteChar((char)(value ?? '\0'));
+                break;
+            case WireFieldType.Guid:
+            {
+                var guid = (Guid)(value ?? Guid.Empty);
+                Span<byte> buf = stackalloc byte[16];
+                guid.TryWriteBytes(buf);
+                writer.WriteBytes(buf);
+                break;
+            }
+            case WireFieldType.DateTime:
+            {
+                var dt = (DateTime)(value ?? default(DateTime));
+                writer.WriteInt64(dt.Ticks);
+                writer.WriteByte((byte)dt.Kind);
+                break;
+            }
+            case WireFieldType.DateOnly:
+            {
+                var d = (System.DateOnly)(value ?? default(System.DateOnly));
+                writer.WriteInt32(d.DayNumber);
+                break;
+            }
+            case WireFieldType.TimeOnly:
+            {
+                var t = (System.TimeOnly)(value ?? default(System.TimeOnly));
+                writer.WriteInt64(t.Ticks);
+                break;
+            }
+            case WireFieldType.DateTimeOffset:
+            {
+                var dto = (DateTimeOffset)(value ?? default(DateTimeOffset));
+                writer.WriteInt64(dto.Ticks);
+                writer.WriteInt16((short)dto.Offset.TotalMinutes);
+                break;
+            }
+            case WireFieldType.TimeSpan:
+            {
+                var ts = (TimeSpan)(value ?? default(TimeSpan));
+                writer.WriteInt64(ts.Ticks);
+                break;
+            }
+            case WireFieldType.Identifier:
+            {
+                var id = (IdentifierValue)(value ?? IdentifierValue.Empty);
+                Span<byte> buf = stackalloc byte[16];
+                id.WriteTo(buf);
+                writer.WriteBytes(buf);
+                break;
+            }
+            default:
+                // Fallback: write as UTF-8 string via ToString()
+                WriteString(ref writer, value?.ToString());
+                break;
+        }
+    }
+
+    private static void WriteEnumValue(ref SpanWriter writer, WireFieldType underlying, object? value)
+    {
+        if (value is null) { writer.WriteInt32(0); return; }
+        switch (underlying)
+        {
+            case WireFieldType.Byte: writer.WriteByte(Convert.ToByte(value)); break;
+            case WireFieldType.SByte: writer.WriteSByte(Convert.ToSByte(value)); break;
+            case WireFieldType.Int16: writer.WriteInt16(Convert.ToInt16(value)); break;
+            case WireFieldType.UInt16: writer.WriteUInt16(Convert.ToUInt16(value)); break;
+            case WireFieldType.Int32: writer.WriteInt32(Convert.ToInt32(value)); break;
+            case WireFieldType.UInt32: writer.WriteUInt32(Convert.ToUInt32(value)); break;
+            case WireFieldType.Int64: writer.WriteInt64(Convert.ToInt64(value)); break;
+            case WireFieldType.UInt64: writer.WriteUInt64(Convert.ToUInt64(value)); break;
+            default: writer.WriteInt32(Convert.ToInt32(value)); break;
+        }
+    }
+
+    private static void WriteString(ref SpanWriter writer, string? value)
+    {
+        if (value is null) { writer.WriteInt32(-1); return; }
+        var byteCount = Utf8.GetByteCount(value);
+        writer.WriteInt32(byteCount);
+        if (byteCount == 0) return;
+
+        if (byteCount <= 512)
+        {
+            Span<byte> buf = stackalloc byte[byteCount];
+            Utf8.GetBytes(value, buf);
+            writer.WriteBytes(buf);
+        }
+        else
+        {
+            var rented = ArrayPool<byte>.Shared.Rent(byteCount);
+            try
+            {
+                var span = rented.AsSpan(0, byteCount);
+                Utf8.GetBytes(value, span);
+                writer.WriteBytes(span);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(rented);
+            }
+        }
+    }
+
+    // ────────────── Deserialization (read) ──────────────
+
+    /// <summary>
+    /// Deserializes a signed binary payload into an entity using the precompiled field plan.
+    /// </summary>
+    public object Deserialize(ReadOnlySpan<byte> data, FieldPlan[] plan, Type entityType)
+    {
+        ValidateSignature(data);
+        var reader = new SpanReader(data);
+
+        // Skip header
+        reader.ReadInt32(); // magic
+        reader.ReadInt32(); // version
+        reader.ReadInt32(); // schema version
+        reader.ReadByte();  // architecture
+        Span<byte> sigBuf = stackalloc byte[SignatureSize];
+        reader.ReadBytes(sigBuf); // signature
+
+        return ReadEntity(ref reader, plan, entityType);
+    }
+
+    private static object ReadEntity(ref SpanReader reader, FieldPlan[] plan, Type entityType)
+    {
+        var hasValue = reader.ReadByte();
+        if (hasValue == 0)
+            throw new InvalidOperationException("Null entity in binary payload.");
+
+        var instance = Activator.CreateInstance(entityType)
+            ?? throw new InvalidOperationException($"Cannot create instance of {entityType.Name}.");
+
+        for (int i = 0; i < plan.Length; i++)
+        {
+            var fp = plan[i];
+            var value = ReadFieldValue(ref reader, fp, 0);
+            if (value is not null || !fp.ClrType.IsValueType)
+                fp.Setter(instance, value);
+        }
+
+        return instance;
+    }
+
+    private static object? ReadFieldValue(ref SpanReader reader, FieldPlan fp, int depth)
+    {
+        if (depth > MaxDepth)
+            throw new InvalidOperationException("Max deserialization depth exceeded.");
+
+        if (fp.IsNullable)
+        {
+            var hasValue = reader.ReadByte();
+            if (hasValue == 0) return null;
+        }
+
+        switch (fp.WireType)
+        {
+            case WireFieldType.Enum:
+                return ReadEnumValue(ref reader, fp);
+            case WireFieldType.String:
+                return ReadString(ref reader);
+            case WireFieldType.Bool:
+                return reader.ReadBoolean();
+            case WireFieldType.Byte:
+                return reader.ReadByte();
+            case WireFieldType.SByte:
+                return reader.ReadSByte();
+            case WireFieldType.Int16:
+                return reader.ReadInt16();
+            case WireFieldType.UInt16:
+                return reader.ReadUInt16();
+            case WireFieldType.Int32:
+                return reader.ReadInt32();
+            case WireFieldType.UInt32:
+                return reader.ReadUInt32();
+            case WireFieldType.Int64:
+                return reader.ReadInt64();
+            case WireFieldType.UInt64:
+                return reader.ReadUInt64();
+            case WireFieldType.Float32:
+                return reader.ReadSingle();
+            case WireFieldType.Float64:
+                return reader.ReadDouble();
+            case WireFieldType.Decimal:
+                return reader.ReadDecimal();
+            case WireFieldType.Char:
+                return reader.ReadChar();
+            case WireFieldType.Guid:
+            {
+                Span<byte> buf = stackalloc byte[16];
+                reader.ReadBytes(buf);
+                return new Guid(buf);
+            }
+            case WireFieldType.DateTime:
+            {
+                var ticks = reader.ReadInt64();
+                var kind = (DateTimeKind)reader.ReadByte();
+                return new DateTime(ticks, kind);
+            }
+            case WireFieldType.DateOnly:
+                return System.DateOnly.FromDayNumber(reader.ReadInt32());
+            case WireFieldType.TimeOnly:
+                return new System.TimeOnly(reader.ReadInt64());
+            case WireFieldType.DateTimeOffset:
+            {
+                var ticks = reader.ReadInt64();
+                var offsetMin = reader.ReadInt16();
+                return new DateTimeOffset(ticks, TimeSpan.FromMinutes(offsetMin));
+            }
+            case WireFieldType.TimeSpan:
+                return new TimeSpan(reader.ReadInt64());
+            case WireFieldType.Identifier:
+            {
+                Span<byte> buf = stackalloc byte[16];
+                reader.ReadBytes(buf);
+                return IdentifierValue.ReadFrom(buf);
+            }
+            default:
+                // Fallback: read as string
+                return ReadString(ref reader);
+        }
+    }
+
+    private static object ReadEnumValue(ref SpanReader reader, FieldPlan fp)
+    {
+        object raw = fp.EnumUnderlying switch
+        {
+            WireFieldType.Byte => reader.ReadByte(),
+            WireFieldType.SByte => reader.ReadSByte(),
+            WireFieldType.Int16 => reader.ReadInt16(),
+            WireFieldType.UInt16 => reader.ReadUInt16(),
+            WireFieldType.Int32 => reader.ReadInt32(),
+            WireFieldType.UInt32 => reader.ReadUInt32(),
+            WireFieldType.Int64 => reader.ReadInt64(),
+            WireFieldType.UInt64 => reader.ReadUInt64(),
+            _ => reader.ReadInt32(),
+        };
+        return Enum.ToObject(fp.ClrType, raw);
+    }
+
+    private static string? ReadString(ref SpanReader reader)
+    {
+        var byteCount = reader.ReadInt32();
+        if (byteCount < 0) return null;
+        if (byteCount == 0) return string.Empty;
+        if (byteCount > MaxStringBytes)
+            throw new InvalidOperationException($"String length {byteCount} exceeds max {MaxStringBytes}.");
+
+        if (byteCount <= 512)
+        {
+            Span<byte> buf = stackalloc byte[byteCount];
+            reader.ReadBytes(buf);
+            return Utf8.GetString(buf);
+        }
+
+        var rented = ArrayPool<byte>.Shared.Rent(byteCount);
+        try
+        {
+            var span = rented.AsSpan(0, byteCount);
+            reader.ReadBytes(span);
+            return Utf8.GetString(span);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(rented);
+        }
+    }
+
+    // ────────────── HMAC signing ──────────────
+
+    private void SignPayload(Span<byte> payload)
+    {
+        if (payload.Length < HeaderSize) return;
+        Span<byte> sig = stackalloc byte[SignatureSize];
+        ComputeSignature(payload, sig);
+        sig.CopyTo(payload.Slice(HeaderFieldsSize, SignatureSize));
+    }
+
+    private void ComputeSignature(ReadOnlySpan<byte> payload, Span<byte> destination)
+    {
+        using var hmac = IncrementalHash.CreateHMAC(HashAlgorithmName.SHA256, _signingKey);
+        hmac.AppendData(payload.Slice(0, HeaderFieldsSize));
+        hmac.AppendData(payload.Slice(HeaderFieldsSize + SignatureSize));
+        hmac.GetHashAndReset(destination);
+    }
+
+    private void ValidateSignature(ReadOnlySpan<byte> payload)
+    {
+        if (payload.Length < HeaderSize)
+            throw new InvalidOperationException("Payload too short for signed header.");
+
+        var magic = BinaryPrimitives.ReadInt32LittleEndian(payload.Slice(0, 4));
+        if (magic != Magic)
+            throw new InvalidOperationException("Invalid binary payload magic.");
+
+        Span<byte> expected = stackalloc byte[SignatureSize];
+        ComputeSignature(payload, expected);
+        var actual = payload.Slice(HeaderFieldsSize, SignatureSize);
+        if (!CryptographicOperations.FixedTimeEquals(expected, actual))
+            throw new InvalidOperationException("Payload signature mismatch.");
+    }
+
+    // ────────────── Schema descriptor for client ──────────────
+
+    /// <summary>
+    /// Builds a JSON-serializable schema descriptor for the JS client.
+    /// The client uses this to build its own field plan for deserialization.
+    /// </summary>
+    public static WireSchemaDescriptor BuildSchemaDescriptor(string slug, int schemaVersion, FieldPlan[] plan)
+    {
+        var members = new WireMemberDescriptor[plan.Length];
+        for (int i = 0; i < plan.Length; i++)
+        {
+            var fp = plan[i];
+            members[i] = new WireMemberDescriptor
+            {
+                Name = fp.Name,
+                Ordinal = fp.Ordinal,
+                WireType = fp.WireType.ToString(),
+                IsNullable = fp.IsNullable,
+                EnumUnderlying = fp.WireType == WireFieldType.Enum ? fp.EnumUnderlying.ToString() : null,
+            };
+        }
+        return new WireSchemaDescriptor
+        {
+            Slug = slug,
+            Version = schemaVersion,
+            Members = members,
+        };
+    }
+
+    public sealed class WireSchemaDescriptor
+    {
+        public required string Slug { get; init; }
+        public required int Version { get; init; }
+        public required WireMemberDescriptor[] Members { get; init; }
+    }
+
+    public sealed class WireMemberDescriptor
+    {
+        public required string Name { get; init; }
+        public required int Ordinal { get; init; }
+        public required string WireType { get; init; }
+        public required bool IsNullable { get; init; }
+        public string? EnumUnderlying { get; init; }
+    }
+}

--- a/BareMetalWeb.Data/PropertyAccessorFactory.cs
+++ b/BareMetalWeb.Data/PropertyAccessorFactory.cs
@@ -8,7 +8,7 @@ namespace BareMetalWeb.Data;
 /// <see cref="Expression"/> trees, eliminating per-call <see cref="PropertyInfo.GetValue"/> /
 /// <see cref="PropertyInfo.SetValue"/> reflection overhead.
 /// </summary>
-internal static class PropertyAccessorFactory
+public static class PropertyAccessorFactory
 {
     /// <summary>
     /// Returns a compiled <see cref="Func{Object, Object}"/> that reads the property value from a

--- a/BareMetalWeb.Host/BareMetalWebExtensions.cs
+++ b/BareMetalWeb.Host/BareMetalWebExtensions.cs
@@ -43,6 +43,10 @@ public static class BareMetalWebExtensions
         // Data store
         ISchemaAwareObjectSerializer serializer = BinaryObjectSerializer.CreateDefault(dataRoot);
         IDataQueryEvaluator queryEvaluator = new DataQueryEvaluator();
+
+        // Initialize binary wire API with the same signing key
+        if (serializer is BinaryObjectSerializer bos)
+            BinaryApiHandlers.Initialize(bos.GetSigningKeyCopy());
         try { _ = Assembly.Load("BareMetalWeb.UserClasses"); } catch { }
         DataEntityRegistry.RegisterAllEntities();
         DataEntityRegistry.RegisterVirtualEntitiesFromFile(
@@ -168,6 +172,7 @@ public static class BareMetalWebExtensions
         appInfo.RegisterEntityMetadataRoute(pageInfoFactory);  // must be before RegisterApiRoutes
         appInfo.RegisterRuntimeApiRoutes(pageInfoFactory);       // /meta/entity/{name}, POST /query, POST /intent
         appInfo.RegisterLookupApiRoutes(pageInfoFactory);       // must be before RegisterApiRoutes
+        appInfo.RegisterBinaryApiRoutes(pageInfoFactory);       // binary wire-format API
         appInfo.RegisterApiRoutes(routeHandlers, pageInfoFactory);
         appInfo.RegisterVNextRoutes(pageInfoFactory, templateStore);
         appInfo.RegisterReportRoutes(pageInfoFactory);

--- a/BareMetalWeb.Host/BinaryApiHandlers.cs
+++ b/BareMetalWeb.Host/BinaryApiHandlers.cs
@@ -1,0 +1,368 @@
+using System.Buffers;
+using System.Collections.Concurrent;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using BareMetalWeb.Core;
+using BareMetalWeb.Data;
+
+namespace BareMetalWeb.Host;
+
+/// <summary>
+/// Binary wire-format API handlers.
+/// Serve entities as BSO1 binary payloads — metadata-driven, zero-reflection at request time.
+/// JSON fallback at /api/_lookup/ remains for service-to-service callers.
+/// </summary>
+public static class BinaryApiHandlers
+{
+    private static MetadataWireSerializer? _serializer;
+    private static byte[]? _signingKeyRaw;
+    private static readonly ConcurrentDictionary<string, MetadataWireSerializer.FieldPlan[]> _plans = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly ConcurrentDictionary<string, MetadataWireSerializer.WireSchemaDescriptor> _schemas = new(StringComparer.OrdinalIgnoreCase);
+
+    private const string BinaryContentType = "application/x-bmw-binary";
+
+    /// <summary>
+    /// Initialise the binary API subsystem with the shared signing key.
+    /// Call once at startup after data store creation.
+    /// </summary>
+    public static void Initialize(byte[] signingKey)
+    {
+        _signingKeyRaw = (byte[])signingKey.Clone();
+        _serializer = new MetadataWireSerializer(signingKey);
+    }
+
+    // ────────────── Helpers ──────────────
+
+    private static MetadataWireSerializer.FieldPlan[] GetOrBuildPlan(DataEntityMetadata meta)
+    {
+        return _plans.GetOrAdd(meta.Slug, _ => BuildPlanFromMetadata(meta));
+    }
+
+    private static MetadataWireSerializer.FieldPlan[] BuildPlanFromMetadata(DataEntityMetadata meta)
+    {
+        // Build a lookup from metadata fields for getter/setter reuse
+        var metaFieldsByName = meta.Fields.ToDictionary(f => f.Name, StringComparer.Ordinal);
+
+        // Collect ALL public properties on the CLR type — same set the BinaryObjectSerializer uses.
+        // Sort by name (Ordinal compare) to match binary serializer member ordering.
+        var props = meta.Type.GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance)
+            .OrderBy(p => p.Name, StringComparer.Ordinal)
+            .ToArray();
+
+        var descriptors = new List<MetadataWireSerializer.FieldPlanDescriptor>(props.Length);
+        foreach (var prop in props)
+        {
+            if (!prop.CanRead || !prop.CanWrite) continue;
+
+            var (wireType, isNullable, enumUnderlying) = MetadataWireSerializer.ResolveWireType(prop.PropertyType);
+            var effectiveType = Nullable.GetUnderlyingType(prop.PropertyType) ?? prop.PropertyType;
+
+            // Reuse pre-compiled delegates from metadata when available
+            Func<object, object?> getter;
+            Action<object, object?> setter;
+            if (metaFieldsByName.TryGetValue(prop.Name, out var fieldMeta))
+            {
+                getter = fieldMeta.GetValueFn;
+                setter = fieldMeta.SetValueFn;
+            }
+            else
+            {
+                getter = PropertyAccessorFactory.BuildGetter(prop);
+                setter = PropertyAccessorFactory.BuildSetter(prop);
+            }
+
+            descriptors.Add(new MetadataWireSerializer.FieldPlanDescriptor
+            {
+                Name = prop.Name,
+                WireType = wireType,
+                IsNullable = isNullable,
+                Getter = getter,
+                Setter = setter,
+                ClrType = effectiveType,
+                EnumUnderlying = enumUnderlying,
+            });
+        }
+
+        return MetadataWireSerializer.BuildPlan(meta.Type, descriptors);
+    }
+
+    private static MetadataWireSerializer.WireSchemaDescriptor GetOrBuildSchema(DataEntityMetadata meta)
+    {
+        return _schemas.GetOrAdd(meta.Slug, _ =>
+        {
+            var plan = GetOrBuildPlan(meta);
+            return MetadataWireSerializer.BuildSchemaDescriptor(meta.Slug, 1, plan);
+        });
+    }
+
+    // ────────────── Route handlers ──────────────
+
+    /// <summary>
+    /// GET /api/_binary/_key
+    /// Returns the HMAC signing key (base64) for authenticated users.
+    /// The client needs this to sign/verify binary payloads.
+    /// </summary>
+    public static async ValueTask KeyHandler(HttpContext context)
+    {
+        // Require authentication — only logged-in users get the signing key
+        var user = await UserAuth.GetRequestUserAsync(context, context.RequestAborted);
+        if (user == null)
+        {
+            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            return;
+        }
+
+        if (_signingKeyRaw == null)
+        {
+            await WriteError(context, (500, "Binary API not initialized."));
+            return;
+        }
+
+        context.Response.ContentType = "text/plain";
+        await context.Response.WriteAsync(Convert.ToBase64String(_signingKeyRaw), context.RequestAborted);
+    }
+
+    /// <summary>
+    /// GET /api/_binary/{type}/_schema
+    /// Returns JSON schema descriptor so the JS client can build its own field plan.
+    /// </summary>
+    public static async ValueTask SchemaHandler(HttpContext context)
+    {
+        var (meta, _, error) = await ValidateAsync(context);
+        if (meta == null) { await WriteError(context, error!.Value); return; }
+
+        var schema = GetOrBuildSchema(meta);
+        context.Response.ContentType = "application/json";
+        await JsonSerializer.SerializeAsync(context.Response.Body, schema, JsonOpts, context.RequestAborted);
+    }
+
+    /// <summary>
+    /// GET /api/_binary/{type}
+    /// Returns binary-encoded entity list.
+    /// </summary>
+    public static async ValueTask ListHandler(HttpContext context)
+    {
+        var (meta, _, error) = await ValidateAsync(context);
+        if (meta == null) { await WriteError(context, error!.Value); return; }
+        if (_serializer == null) { await WriteError(context, (500, "Binary API not initialized.")); return; }
+
+        try
+        {
+            var queryDef = LookupApiHandlers.BuildQueryFromRequest(context, meta);
+            var entities = await meta.Handlers.QueryAsync(queryDef, context.RequestAborted);
+            var list = entities.Cast<object>().ToList();
+
+            var plan = GetOrBuildPlan(meta);
+            var payload = _serializer.SerializeList(list, plan, 1, list.Count);
+
+            context.Response.ContentType = BinaryContentType;
+            context.Response.ContentLength = payload.Length;
+            await context.Response.Body.WriteAsync(payload, context.RequestAborted);
+        }
+        catch (Exception)
+        {
+            await WriteError(context, (500, "Error querying entities."));
+        }
+    }
+
+    /// <summary>
+    /// GET /api/_binary/{type}/{id}
+    /// Returns a single binary-encoded entity.
+    /// </summary>
+    public static async ValueTask GetHandler(HttpContext context)
+    {
+        var (meta, _, error) = await ValidateAsync(context);
+        if (meta == null) { await WriteError(context, error!.Value); return; }
+        if (_serializer == null) { await WriteError(context, (500, "Binary API not initialized.")); return; }
+
+        var idStr = GetRouteValue(context, "id");
+        if (string.IsNullOrWhiteSpace(idStr) || !uint.TryParse(idStr, out var id))
+        {
+            await WriteError(context, (400, "Invalid entity ID."));
+            return;
+        }
+
+        try
+        {
+            var entity = await meta.Handlers.LoadAsync(id, context.RequestAborted);
+            if (entity == null) { await WriteError(context, (404, "Entity not found.")); return; }
+
+            var plan = GetOrBuildPlan(meta);
+            var payload = _serializer.Serialize(entity, plan, 1);
+
+            context.Response.ContentType = BinaryContentType;
+            context.Response.ContentLength = payload.Length;
+            await context.Response.Body.WriteAsync(payload, context.RequestAborted);
+        }
+        catch (Exception)
+        {
+            await WriteError(context, (500, "Error loading entity."));
+        }
+    }
+
+    /// <summary>
+    /// POST /api/_binary/{type}
+    /// Accepts a binary-encoded entity, saves it, returns the saved entity as binary.
+    /// </summary>
+    public static async ValueTask CreateHandler(HttpContext context)
+    {
+        var (meta, _, error) = await ValidateAsync(context);
+        if (meta == null) { await WriteError(context, error!.Value); return; }
+        if (_serializer == null) { await WriteError(context, (500, "Binary API not initialized.")); return; }
+
+        try
+        {
+            var body = await ReadBodyAsync(context);
+            var plan = GetOrBuildPlan(meta);
+            var entity = _serializer.Deserialize(body.Span, plan, meta.Type);
+
+            await DataScaffold.SaveAsync(meta, entity, context.RequestAborted);
+
+            var payload = _serializer.Serialize(entity, plan, 1);
+            context.Response.StatusCode = StatusCodes.Status201Created;
+            context.Response.ContentType = BinaryContentType;
+            context.Response.ContentLength = payload.Length;
+            await context.Response.Body.WriteAsync(payload, context.RequestAborted);
+        }
+        catch (Exception)
+        {
+            await WriteError(context, (500, "Error creating entity."));
+        }
+    }
+
+    /// <summary>
+    /// PUT /api/_binary/{type}/{id}
+    /// Accepts a binary-encoded entity, updates it.
+    /// </summary>
+    public static async ValueTask UpdateHandler(HttpContext context)
+    {
+        var (meta, _, error) = await ValidateAsync(context);
+        if (meta == null) { await WriteError(context, error!.Value); return; }
+        if (_serializer == null) { await WriteError(context, (500, "Binary API not initialized.")); return; }
+
+        var idStr = GetRouteValue(context, "id");
+        if (string.IsNullOrWhiteSpace(idStr) || !uint.TryParse(idStr, out var id))
+        {
+            await WriteError(context, (400, "Invalid entity ID."));
+            return;
+        }
+
+        try
+        {
+            var body = await ReadBodyAsync(context);
+            var plan = GetOrBuildPlan(meta);
+            var entity = _serializer.Deserialize(body.Span, plan, meta.Type);
+
+            // Ensure key matches URL
+            if (entity is BaseDataObject bdo && bdo.Key != id)
+                bdo.Key = id;
+
+            await DataScaffold.SaveAsync(meta, entity, context.RequestAborted);
+
+            var payload = _serializer.Serialize(entity, plan, 1);
+            context.Response.ContentType = BinaryContentType;
+            context.Response.ContentLength = payload.Length;
+            await context.Response.Body.WriteAsync(payload, context.RequestAborted);
+        }
+        catch (Exception)
+        {
+            await WriteError(context, (500, "Error updating entity."));
+        }
+    }
+
+    /// <summary>
+    /// DELETE /api/_binary/{type}/{id}
+    /// Deletes an entity by key.
+    /// </summary>
+    public static async ValueTask DeleteHandler(HttpContext context)
+    {
+        var (meta, _, error) = await ValidateAsync(context);
+        if (meta == null) { await WriteError(context, error!.Value); return; }
+
+        var idStr = GetRouteValue(context, "id");
+        if (string.IsNullOrWhiteSpace(idStr) || !uint.TryParse(idStr, out var id))
+        {
+            await WriteError(context, (400, "Invalid entity ID."));
+            return;
+        }
+
+        try
+        {
+            await meta.Handlers.DeleteAsync(id, context.RequestAborted);
+            context.Response.StatusCode = StatusCodes.Status204NoContent;
+        }
+        catch (Exception)
+        {
+            await WriteError(context, (500, "Error deleting entity."));
+        }
+    }
+
+    // ────────────── Shared utilities ──────────────
+
+    private static async ValueTask<(DataEntityMetadata? Meta, string TypeSlug, (int StatusCode, string Message)? Error)> ValidateAsync(HttpContext context)
+    {
+        var typeSlug = GetRouteValue(context, "type") ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(typeSlug))
+            return (null, typeSlug, (400, "Entity type not specified."));
+
+        if (!DataScaffold.TryGetEntity(typeSlug, out var meta))
+            return (null, typeSlug, (404, $"Unknown entity type '{typeSlug}'."));
+
+        // Permission check
+        var permissionsNeeded = meta!.Permissions?.Trim();
+        if (!string.IsNullOrWhiteSpace(permissionsNeeded)
+            && !string.Equals(permissionsNeeded, "Public", StringComparison.OrdinalIgnoreCase))
+        {
+            var user = await UserAuth.GetRequestUserAsync(context, context.RequestAborted);
+            if (user == null && !string.Equals(permissionsNeeded, "AnonymousOnly", StringComparison.OrdinalIgnoreCase))
+                return (null, typeSlug, (403, "Access denied."));
+            if (user != null)
+            {
+                if (string.Equals(permissionsNeeded, "AnonymousOnly", StringComparison.OrdinalIgnoreCase))
+                    return (null, typeSlug, (403, "Access denied."));
+                if (!string.Equals(permissionsNeeded, "Authenticated", StringComparison.OrdinalIgnoreCase))
+                {
+                    var userPerms = new HashSet<string>(user.Permissions ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
+                    var required = permissionsNeeded.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                    if (required.Length > 0 && !required.All(userPerms.Contains))
+                        return (null, typeSlug, (403, "Access denied."));
+                }
+            }
+        }
+
+        return (meta, typeSlug, null);
+    }
+
+    private static string? GetRouteValue(HttpContext context, string key)
+    {
+        var pageContext = context.GetPageContext();
+        if (pageContext == null) return null;
+        for (int i = 0; i < pageContext.PageMetaDataKeys.Length; i++)
+        {
+            if (string.Equals(pageContext.PageMetaDataKeys[i], key, StringComparison.OrdinalIgnoreCase))
+                return pageContext.PageMetaDataValues[i];
+        }
+        return null;
+    }
+
+    private static async ValueTask<ReadOnlyMemory<byte>> ReadBodyAsync(HttpContext context)
+    {
+        using var ms = new MemoryStream();
+        await context.Request.Body.CopyToAsync(ms, context.RequestAborted);
+        return ms.ToArray();
+    }
+
+    private static async ValueTask WriteError(HttpContext context, (int StatusCode, string Message) error)
+    {
+        context.Response.StatusCode = error.StatusCode;
+        context.Response.ContentType = "application/json";
+        await JsonSerializer.SerializeAsync(context.Response.Body,
+            new { error = error.Message, status = error.StatusCode }, JsonOpts, context.RequestAborted);
+    }
+
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false,
+    };
+}

--- a/BareMetalWeb.Host/JsBundleService.cs
+++ b/BareMetalWeb.Host/JsBundleService.cs
@@ -46,6 +46,7 @@ public static class JsBundleService
         "bootstrap.bundle.min.js",
         "BareMetalRouting.js",
         "BareMetalRest.js",
+        "BareMetalBinary.js",
         "BareMetalBind.js",
         "BareMetalTemplate.js",
         "BareMetalRendering.js",

--- a/BareMetalWeb.Host/LookupApiHandlers.cs
+++ b/BareMetalWeb.Host/LookupApiHandlers.cs
@@ -376,7 +376,7 @@ public static class LookupApiHandlers
         return null;
     }
 
-    private static QueryDefinition BuildQueryFromRequest(HttpContext context, DataEntityMetadata meta)
+    internal static QueryDefinition BuildQueryFromRequest(HttpContext context, DataEntityMetadata meta)
     {
         var queryDef = new QueryDefinition();
 

--- a/BareMetalWeb.Host/RouteRegistrationExtensions.cs
+++ b/BareMetalWeb.Host/RouteRegistrationExtensions.cs
@@ -467,6 +467,24 @@ public static class RouteRegistrationExtensions
     }
 
     /// <summary>
+    /// Register binary wire-format API routes.
+    /// These serve BSO1-encoded payloads for the JS client and CLI — no JSON.
+    /// </summary>
+    public static void RegisterBinaryApiRoutes(
+        this IBareWebHost host,
+        IPageInfoFactory pageInfoFactory)
+    {
+        var raw = pageInfoFactory.RawPage("Public", false);
+        host.RegisterRoute("GET /api/_binary/_key", new RouteHandlerData(raw, BinaryApiHandlers.KeyHandler));
+        host.RegisterRoute("GET /api/_binary/{type}/_schema", new RouteHandlerData(raw, BinaryApiHandlers.SchemaHandler));
+        host.RegisterRoute("GET /api/_binary/{type}/{id}", new RouteHandlerData(raw, BinaryApiHandlers.GetHandler));
+        host.RegisterRoute("GET /api/_binary/{type}", new RouteHandlerData(raw, BinaryApiHandlers.ListHandler));
+        host.RegisterRoute("POST /api/_binary/{type}", new RouteHandlerData(raw, BinaryApiHandlers.CreateHandler));
+        host.RegisterRoute("PUT /api/_binary/{type}/{id}", new RouteHandlerData(raw, BinaryApiHandlers.UpdateHandler));
+        host.RegisterRoute("DELETE /api/_binary/{type}/{id}", new RouteHandlerData(raw, BinaryApiHandlers.DeleteHandler));
+    }
+
+    /// <summary>
     /// Register RESTful API routes for entity operations.
     /// </summary>
     public static void RegisterApiRoutes(


### PR DESCRIPTION
## Binary Wire API

Adds BSO1 binary wire format API for client UI and CLI, alongside existing JSON API (retained for service-to-service with service principals per issue #579).

### Architecture

**Server-side — zero-reflection serialization:**
- `MetadataWireSerializer.cs` — builds `FieldPlan[]` once at startup from `DataEntityMetadata`. Each plan entry stores the `WireFieldType`, nullable flag, and pre-compiled getter/setter delegates. No reflection at request time.
- `BinaryApiHandlers.cs` — CRUD at `/api/_binary/{type}/...`:
  - `GET /_schema` — JSON schema descriptor for JS client
  - `GET /_key` — HMAC signing key (authenticated users only)
  - `GET/POST/PUT/DELETE` — binary entity operations
- Signing key shared with existing `BinaryObjectSerializer` via `GetSigningKeyCopy()`

**Client-side — DataView zero-copy reads:**
- `BareMetalBinary.js` — JS port: SpanReader/SpanWriter via DataView, HMAC-SHA256 via Web Crypto, IdentifierValue base-37 codec, all wire types (DateTime, DateOnly, TimeOnly, Decimal, Guid, Enum, etc.)
- `BareMetalRest.js` — auto-prefers binary with JSON fallback. Bootstrap fetches key on first `entity()` call.

### Wire Format
```
Single: [BSO1 header 45B][null-indicator 1B][field values in name-sorted order]
List:   [BSO1 header 45B][Int32 count][per item: Int32 len + field bytes]
```

### Testing
All 1,969 tests pass. No existing tests broken.

Relates to #579 (runtime metadata compilation spec)