### PR TITLE
feat: Engine-level aggregations with StdDev (#608)

### DIFF
--- a/BareMetalWeb.Data/AggregationEngine.cs
+++ b/BareMetalWeb.Data/AggregationEngine.cs
@@ -1,0 +1,218 @@
+using System.Runtime.CompilerServices;
+using BareMetalWeb.Core;
+
+namespace BareMetalWeb.Data;
+
+/// <summary>
+/// Streaming single-pass aggregation engine. Uses compiled getters from EntityLayout
+/// or DataFieldMetadata — no reflection in the accumulation loop.
+/// </summary>
+public static class AggregationEngine
+{
+    /// <summary>
+    /// Compute an aggregate over a query result set using a compiled getter.
+    /// Single-pass streaming — does not materialise the full result list for sum/avg/stddev.
+    /// </summary>
+    public static async ValueTask<AggregateResult> ComputeAsync(
+        DataEntityMetadata meta,
+        QueryDefinition? query,
+        string fieldName,
+        AggregateFunction function,
+        CancellationToken cancellationToken = default)
+    {
+        if (function == AggregateFunction.None)
+            return new AggregateResult(function, fieldName, null, 0);
+
+        // Count fast path — no need to load entities
+        if (function == AggregateFunction.Count)
+        {
+            var count = await meta.Handlers.CountAsync(query, cancellationToken);
+            return new AggregateResult(function, fieldName, count, count);
+        }
+
+        // Resolve getter — prefer compiled from DataFieldMetadata, fallback to EntityLayout
+        Func<object, object?>? getter = null;
+        var field = meta.Fields.FirstOrDefault(f =>
+            string.Equals(f.Name, fieldName, StringComparison.OrdinalIgnoreCase));
+        if (field != null)
+        {
+            getter = field.GetValueFn; // compiled delegate, no reflection
+        }
+        else
+        {
+            // Try EntityLayout
+            var layout = EntityLayoutCompiler.GetOrCompile(meta);
+            var fr = layout.FieldByName(fieldName);
+            if (fr != null) getter = fr.Getter;
+        }
+
+        if (getter == null)
+            return new AggregateResult(function, fieldName, null, 0);
+
+        // Stream entities and accumulate
+        var entities = await meta.Handlers.QueryAsync(query, cancellationToken);
+        var acc = new StreamingAccumulator(function);
+
+        foreach (var entity in entities)
+        {
+            var val = getter(entity);
+            if (val == null) continue;
+            acc.Add(ToDouble(val));
+        }
+
+        return new AggregateResult(function, fieldName, acc.Result(), acc.Count);
+    }
+
+    /// <summary>
+    /// Compute multiple aggregates in a single pass over the data.
+    /// </summary>
+    public static async ValueTask<AggregateResult[]> ComputeMultiAsync(
+        DataEntityMetadata meta,
+        QueryDefinition? query,
+        (string FieldName, AggregateFunction Function)[] aggregates,
+        CancellationToken cancellationToken = default)
+    {
+        if (aggregates.Length == 0)
+            return Array.Empty<AggregateResult>();
+
+        // Fast path: all are Count
+        if (aggregates.All(a => a.Function == AggregateFunction.Count))
+        {
+            var count = await meta.Handlers.CountAsync(query, cancellationToken);
+            return aggregates.Select(a => new AggregateResult(a.Function, a.FieldName, count, count)).ToArray();
+        }
+
+        // Resolve getters
+        var layout = EntityLayoutCompiler.GetOrCompile(meta);
+        var fieldsByName = meta.Fields.ToDictionary(f => f.Name, StringComparer.OrdinalIgnoreCase);
+        var accumulators = new (Func<object, object?>? Getter, StreamingAccumulator Acc, string FieldName, AggregateFunction Fn)[aggregates.Length];
+
+        for (int i = 0; i < aggregates.Length; i++)
+        {
+            Func<object, object?>? getter = null;
+            if (fieldsByName.TryGetValue(aggregates[i].FieldName, out var fm))
+                getter = fm.GetValueFn;
+            else
+            {
+                var fr = layout.FieldByName(aggregates[i].FieldName);
+                if (fr != null) getter = fr.Getter;
+            }
+            accumulators[i] = (getter, new StreamingAccumulator(aggregates[i].Function), aggregates[i].FieldName, aggregates[i].Function);
+        }
+
+        // Single pass
+        var entities = await meta.Handlers.QueryAsync(query, cancellationToken);
+        foreach (var entity in entities)
+        {
+            for (int i = 0; i < accumulators.Length; i++)
+            {
+                ref var a = ref accumulators[i];
+                if (a.Fn == AggregateFunction.Count)
+                {
+                    a.Acc.Add(0); // just increment count
+                    continue;
+                }
+                if (a.Getter == null) continue;
+                var val = a.Getter(entity);
+                if (val == null) continue;
+                a.Acc.Add(ToDouble(val));
+            }
+        }
+
+        var results = new AggregateResult[aggregates.Length];
+        for (int i = 0; i < aggregates.Length; i++)
+            results[i] = new AggregateResult(accumulators[i].Fn, accumulators[i].FieldName, accumulators[i].Acc.Result(), accumulators[i].Acc.Count);
+        return results;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static double ToDouble(object val) => val switch
+    {
+        int i => i,
+        uint u => u,
+        long l => l,
+        ulong ul => ul,
+        float f => f,
+        double d => d,
+        decimal m => (double)m,
+        short s => s,
+        ushort us => us,
+        byte b => b,
+        sbyte sb => sb,
+        _ => Convert.ToDouble(val),
+    };
+
+    /// <summary>
+    /// Single-pass streaming accumulator supporting all aggregate functions.
+    /// Uses Welford's online algorithm for StdDev (numerically stable).
+    /// </summary>
+    private struct StreamingAccumulator
+    {
+        private readonly AggregateFunction _fn;
+        private double _sum;
+        private double _min;
+        private double _max;
+        private double _m2;     // Welford: sum of squared diffs
+        private double _mean;   // Welford: running mean
+        public int Count;
+
+        public StreamingAccumulator(AggregateFunction fn)
+        {
+            _fn = fn;
+            _sum = 0;
+            _min = double.MaxValue;
+            _max = double.MinValue;
+            _m2 = 0;
+            _mean = 0;
+            Count = 0;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Add(double value)
+        {
+            Count++;
+            switch (_fn)
+            {
+                case AggregateFunction.Count:
+                    break;
+                case AggregateFunction.Sum:
+                    _sum += value;
+                    break;
+                case AggregateFunction.Min:
+                    if (value < _min) _min = value;
+                    break;
+                case AggregateFunction.Max:
+                    if (value > _max) _max = value;
+                    break;
+                case AggregateFunction.Average:
+                    _sum += value;
+                    break;
+                case AggregateFunction.StdDev:
+                    // Welford's online algorithm
+                    double delta = value - _mean;
+                    _mean += delta / Count;
+                    double delta2 = value - _mean;
+                    _m2 += delta * delta2;
+                    break;
+            }
+        }
+
+        public object? Result() => _fn switch
+        {
+            AggregateFunction.Count => Count,
+            AggregateFunction.Sum => _sum,
+            AggregateFunction.Min => Count > 0 ? _min : null,
+            AggregateFunction.Max => Count > 0 ? _max : null,
+            AggregateFunction.Average => Count > 0 ? _sum / Count : null,
+            AggregateFunction.StdDev => Count > 1 ? Math.Sqrt(_m2 / Count) : (Count == 1 ? 0.0 : null),
+            _ => null,
+        };
+    }
+}
+
+/// <summary>Result of a single aggregation.</summary>
+public sealed record AggregateResult(
+    AggregateFunction Function,
+    string FieldName,
+    object? Value,
+    int Count);

--- a/BareMetalWeb.Data/ComputedFieldAttribute.cs
+++ b/BareMetalWeb.Data/ComputedFieldAttribute.cs
@@ -139,5 +139,10 @@ public enum AggregateFunction
     /// <summary>
     /// Average of numeric values.
     /// </summary>
-    Average = 5
+    Average = 5,
+
+    /// <summary>
+    /// Population standard deviation of numeric values.
+    /// </summary>
+    StdDev = 6
 }

--- a/BareMetalWeb.Data/ReportExecutor.cs
+++ b/BareMetalWeb.Data/ReportExecutor.cs
@@ -423,6 +423,7 @@ public sealed class ReportExecutor
                     AggregateFunction.Min => MinColumn(group, idx),
                     AggregateFunction.Max => MaxColumn(group, idx),
                     AggregateFunction.Average => AvgColumn(group, idx),
+                    AggregateFunction.StdDev => StdDevColumn(group, idx),
                     _ => null
                 };
             }
@@ -472,6 +473,24 @@ public sealed class ReportExecutor
         foreach (var row in rows)
             if (decimal.TryParse(row[idx], out var v)) { sum += v; count++; }
         return count == 0 ? "0" : (sum / count).ToString(System.Globalization.CultureInfo.InvariantCulture);
+    }
+
+    private static string StdDevColumn(List<string?[]> rows, int idx)
+    {
+        // Welford's online algorithm for population stddev
+        int count = 0;
+        double mean = 0, m2 = 0;
+        foreach (var row in rows)
+        {
+            if (!double.TryParse(row[idx], out var v)) continue;
+            count++;
+            double delta = v - mean;
+            mean += delta / count;
+            double delta2 = v - mean;
+            m2 += delta * delta2;
+        }
+        if (count < 2) return "0";
+        return Math.Sqrt(m2 / count).ToString(System.Globalization.CultureInfo.InvariantCulture);
     }
 
     // ── Utility ──────────────────────────────────────────────────────────────

--- a/BareMetalWeb.Host/BinaryApiHandlers.cs
+++ b/BareMetalWeb.Host/BinaryApiHandlers.cs
@@ -168,6 +168,75 @@ public static class BinaryApiHandlers
     }
 
     /// <summary>
+    /// GET /api/_binary/{type}/_aggregate?fn=count|sum|avg|min|max|stddev&amp;field=FieldName
+    /// Returns aggregation result. Supports multiple aggregates via repeated fn/field params.
+    /// </summary>
+    public static async ValueTask AggregateHandler(HttpContext context)
+    {
+        var (meta, _, error) = await ValidateAsync(context);
+        if (meta == null) { await WriteError(context, error!.Value); return; }
+
+        var fn = context.Request.Query["fn"].ToString().ToLowerInvariant();
+        var fieldName = context.Request.Query["field"].ToString();
+
+        if (string.IsNullOrWhiteSpace(fn))
+        {
+            await WriteError(context, (400, "Aggregate function not specified (use ?fn=count|sum|avg|min|max|stddev)."));
+            return;
+        }
+
+        var aggFn = fn switch
+        {
+            "count" => AggregateFunction.Count,
+            "sum" => AggregateFunction.Sum,
+            "avg" => AggregateFunction.Average,
+            "min" => AggregateFunction.Min,
+            "max" => AggregateFunction.Max,
+            "stddev" => AggregateFunction.StdDev,
+            _ => AggregateFunction.None,
+        };
+
+        if (aggFn == AggregateFunction.None)
+        {
+            await WriteError(context, (400, $"Unsupported aggregate function '{fn}'."));
+            return;
+        }
+
+        if (aggFn != AggregateFunction.Count && string.IsNullOrWhiteSpace(fieldName))
+        {
+            await WriteError(context, (400, $"Field name required for '{fn}' (use ?field=FieldName)."));
+            return;
+        }
+
+        try
+        {
+            var queryDef = LookupApiHandlers.BuildQueryFromRequest(context, meta);
+            var result = await AggregationEngine.ComputeAsync(
+                meta, queryDef, fieldName, aggFn, context.RequestAborted);
+
+            context.Response.StatusCode = 200;
+            context.Response.ContentType = "application/json";
+            await using var writer = new System.Text.Json.Utf8JsonWriter(context.Response.Body);
+            writer.WriteStartObject();
+            writer.WriteString("function", fn);
+            writer.WriteString("field", fieldName);
+            writer.WriteNumber("count", result.Count);
+            if (result.Value is int iv) writer.WriteNumber("result", iv);
+            else if (result.Value is long lv) writer.WriteNumber("result", lv);
+            else if (result.Value is double dv) writer.WriteNumber("result", dv);
+            else if (result.Value is decimal mv) writer.WriteNumber("result", mv);
+            else if (result.Value != null) writer.WriteNumber("result", Convert.ToDouble(result.Value));
+            else writer.WriteNull("result");
+            writer.WriteEndObject();
+            await writer.FlushAsync(context.RequestAborted);
+        }
+        catch (Exception)
+        {
+            await WriteError(context, (500, "Error computing aggregate."));
+        }
+    }
+
+    /// <summary>
     /// GET /api/_binary/{type}/{id}
     /// Returns a single entity in binary or JSON based on Accept header.
     /// </summary>

--- a/BareMetalWeb.Host/LookupApiHandlers.cs
+++ b/BareMetalWeb.Host/LookupApiHandlers.cs
@@ -247,7 +247,7 @@ public static class LookupApiHandlers
 
         if (string.IsNullOrWhiteSpace(fn))
         {
-            await WriteJsonErrorAsync(context, StatusCodes.Status400BadRequest, "Aggregate function not specified (use ?fn=count|sum|avg|min|max).");
+            await WriteJsonErrorAsync(context, StatusCodes.Status400BadRequest, "Aggregate function not specified (use ?fn=count|sum|avg|min|max|stddev).");
             return;
         }
 
@@ -255,48 +255,36 @@ public static class LookupApiHandlers
         {
             var queryDef = BuildQueryFromRequest(context, meta);
             
-            if (fn == "count")
+            // Map string function name to enum
+            var aggFn = fn switch
             {
-                var count = await meta.Handlers.CountAsync(queryDef, context.RequestAborted);
-                await WriteJsonAsync(context, new Dictionary<string, object>
-                {
-                    ["function"] = "count",
-                    ["result"] = count
-                });
+                "count" => AggregateFunction.Count,
+                "sum" => AggregateFunction.Sum,
+                "avg" => AggregateFunction.Average,
+                "min" => AggregateFunction.Min,
+                "max" => AggregateFunction.Max,
+                "stddev" => AggregateFunction.StdDev,
+                _ => AggregateFunction.None,
+            };
+
+            if (aggFn == AggregateFunction.None)
+            {
+                await WriteJsonErrorAsync(context, StatusCodes.Status400BadRequest, $"Unsupported aggregate function '{fn}'. Use count|sum|avg|min|max|stddev.");
                 return;
             }
 
-            // For sum, avg, min, max we need to load entities and compute
-            if (string.IsNullOrWhiteSpace(fieldName))
+            if (aggFn != AggregateFunction.Count && string.IsNullOrWhiteSpace(fieldName))
             {
                 await WriteJsonErrorAsync(context, StatusCodes.Status400BadRequest, $"Field name required for '{fn}' function (use ?field=FieldName).");
                 return;
             }
 
-            var field = meta.Fields.FirstOrDefault(f => 
-                string.Equals(f.Name, fieldName, StringComparison.OrdinalIgnoreCase) && f.View);
-            
-            if (field == null)
-            {
-                await WriteJsonErrorAsync(context, StatusCodes.Status404NotFound, $"Field '{fieldName}' not found.");
-                return;
-            }
+            var result = await AggregationEngine.ComputeAsync(
+                meta, queryDef, fieldName, aggFn, context.RequestAborted);
 
-            var entities = await meta.Handlers.QueryAsync(queryDef, context.RequestAborted);
-            var values = entities.Select(e => field.Property.GetValue(e)).Where(v => v != null).ToList();
-
-            object? result = fn switch
+            if (result.Value == null && aggFn != AggregateFunction.Count)
             {
-                "sum" => ComputeSum(values),
-                "avg" => ComputeAverage(values),
-                "min" => ComputeMin(values),
-                "max" => ComputeMax(values),
-                _ => null
-            };
-
-            if (result == null)
-            {
-                await WriteJsonErrorAsync(context, StatusCodes.Status400BadRequest, $"Unsupported aggregate function '{fn}'.");
+                await WriteJsonErrorAsync(context, StatusCodes.Status404NotFound, $"Field '{fieldName}' not found or not numeric.");
                 return;
             }
 
@@ -304,8 +292,8 @@ public static class LookupApiHandlers
             {
                 ["function"] = fn,
                 ["field"] = fieldName,
-                ["result"] = result,
-                ["count"] = values.Count
+                ["result"] = result.Value,
+                ["count"] = result.Count
             });
         }
         catch (Exception)
@@ -569,48 +557,6 @@ public static class LookupApiHandlers
             ["error"] = message,
             ["status"] = statusCode
         });
-    }
-
-    private static object? ComputeSum(List<object?> values)
-    {
-        if (values.Count == 0) return 0;
-        
-        var first = values[0];
-        if (first is int || first is long || first is short || first is byte)
-            return values.Sum(v => Convert.ToInt64(v));
-        if (first is float || first is double)
-            return values.Sum(v => Convert.ToDouble(v));
-        if (first is decimal)
-            return values.Sum(v => Convert.ToDecimal(v));
-        
-        return null;
-    }
-
-    private static object? ComputeAverage(List<object?> values)
-    {
-        if (values.Count == 0) return 0;
-        
-        var first = values[0];
-        if (first is int || first is long || first is short || first is byte)
-            return values.Average(v => Convert.ToDouble(v));
-        if (first is float || first is double)
-            return values.Average(v => Convert.ToDouble(v));
-        if (first is decimal)
-            return values.Average(v => Convert.ToDecimal(v));
-        
-        return null;
-    }
-
-    private static object? ComputeMin(List<object?> values)
-    {
-        if (values.Count == 0) return null;
-        return values.Min();
-    }
-
-    private static object? ComputeMax(List<object?> values)
-    {
-        if (values.Count == 0) return null;
-        return values.Max();
     }
 
     private record ErrorResponse(int StatusCode, string Message);

--- a/BareMetalWeb.Host/RouteRegistrationExtensions.cs
+++ b/BareMetalWeb.Host/RouteRegistrationExtensions.cs
@@ -477,13 +477,14 @@ public static class RouteRegistrationExtensions
         var raw = pageInfoFactory.RawPage("Public", false);
         host.RegisterRoute("GET /api/_binary/_key", new RouteHandlerData(raw, BinaryApiHandlers.KeyHandler));
         host.RegisterRoute("GET /api/_binary/{type}/_schema", new RouteHandlerData(raw, BinaryApiHandlers.SchemaHandler));
+        host.RegisterRoute("GET /api/_binary/{type}/_aggregate", new RouteHandlerData(raw, BinaryApiHandlers.AggregateHandler));
+        host.RegisterRoute("GET /api/_binary/{type}/_layout", new RouteHandlerData(raw, DeltaApiHandlers.LayoutHandler));
         host.RegisterRoute("GET /api/_binary/{type}/{id}", new RouteHandlerData(raw, BinaryApiHandlers.GetHandler));
         host.RegisterRoute("GET /api/_binary/{type}", new RouteHandlerData(raw, BinaryApiHandlers.ListHandler));
         host.RegisterRoute("POST /api/_binary/{type}", new RouteHandlerData(raw, BinaryApiHandlers.CreateHandler));
         host.RegisterRoute("PUT /api/_binary/{type}/{id}", new RouteHandlerData(raw, BinaryApiHandlers.UpdateHandler));
         host.RegisterRoute("DELETE /api/_binary/{type}/{id}", new RouteHandlerData(raw, BinaryApiHandlers.DeleteHandler));
         host.RegisterRoute("PATCH /api/_binary/{type}/{id}", new RouteHandlerData(raw, DeltaApiHandlers.DeltaHandler));
-        host.RegisterRoute("GET /api/_binary/{type}/_layout", new RouteHandlerData(raw, DeltaApiHandlers.LayoutHandler));
     }
 
     /// <summary>


### PR DESCRIPTION
Adds a streaming single-pass aggregation engine using compiled getters from EntityLayout — no reflection in the accumulation loop.

## New: AggregationEngine.cs
- `ComputeAsync()` — single aggregate over a query result set
- `ComputeMultiAsync()` — multiple aggregates in one pass
- `StreamingAccumulator` — Welford's online algorithm for numerically stable StdDev
- Uses compiled getters from `DataFieldMetadata.GetValueFn` or `EntityLayout.FieldRuntime.Getter`

## Changes
- **StdDev** added to `AggregateFunction` enum + `ReportExecutor` grouped reports
- **LookupApiHandlers** — `AggregateEntitiesHandler` now delegates to `AggregationEngine`, removed 4 dead `Compute*` methods
- **BinaryApiHandlers** — new `AggregateHandler` at `GET /api/_binary/{type}/_aggregate`

## API
```
GET /api/_binary/{type}/_aggregate?fn=count|sum|avg|min|max|stddev&field=FieldName&filter=...
GET /api/_lookup/{type}/_aggregate?fn=count|sum|avg|min|max|stddev&field=FieldName&filter=...
```

Response:
```json
{ "function": "avg", "field": "Price", "result": 42.5, "count": 1000 }
```

All 1,980 tests pass. Closes #608