### PR TITLE
feat: Action & Transaction Spec v1.1

### DIFF
--- a/BareMetalWeb.Data/ActionDef.cs
+++ b/BareMetalWeb.Data/ActionDef.cs
@@ -1,0 +1,116 @@
+namespace BareMetalWeb.Data;
+
+/// <summary>Severity levels for AssertIf validation.</summary>
+public enum Severity : byte { Error = 0, Warning = 1, Info = 2 }
+
+/// <summary>Base type for all action commands.</summary>
+public abstract record Command;
+
+/// <summary>
+/// Validation assertion. Evaluated during commit.
+/// Error severity → abort entire envelope. Never mutates.
+/// </summary>
+public sealed record AssertIfCommand(
+    Expr Condition,
+    string Code,
+    Severity Severity,
+    string Message
+) : Command;
+
+/// <summary>
+/// Conditional field mutation: if condition is true, set fieldId to valueExpr.
+/// Produces a FieldDelta for the current aggregate.
+/// </summary>
+public sealed record SetIfCommand(
+    Expr Condition,
+    string FieldName,
+    Expr ValueExpr
+) : Command;
+
+/// <summary>
+/// Same as SetIf but marks derived field intent (computed/calculated).
+/// </summary>
+public sealed record CalculateAndSetIfCommand(
+    Expr Condition,
+    string FieldName,
+    Expr ValueExpr
+) : Command;
+
+/// <summary>
+/// Iterate a list field in snapshot mode. Single level only.
+/// Expands deterministically. Operations see the snapshot state.
+/// </summary>
+public sealed record ForSetCommand(
+    string ListFieldName,
+    Expr ItemCondition,
+    Command[] Operations
+) : Command;
+
+/// <summary>
+/// Iterate a list field with progressive semantics.
+/// Mutations update working copy immediately.
+/// Order must be deterministic. Used for allocation scenarios (e.g., stock).
+/// </summary>
+public sealed record ForSetSequentialCommand(
+    string ListFieldName,
+    Expr ItemCondition,
+    Command[] Operations
+) : Command;
+
+/// <summary>
+/// Cross-aggregate invocation: if condition, invoke another action on a target aggregate.
+/// Flat only — no nested invokes in v1.
+/// Expands before commit phase.
+/// </summary>
+public sealed record InvokeIfCommand(
+    Expr Condition,
+    string TargetAggregateType,
+    string ActionId,
+    IReadOnlyDictionary<string, Expr> ParameterMap
+) : Command;
+
+/// <summary>
+/// Immutable action definition. Published once, never modified.
+/// Commands execute in declared order.
+/// Expansion produces a TransactionEnvelope.
+/// </summary>
+public sealed record ActionDef(
+    string ActionId,
+    string AggregateType,
+    int Version,
+    Command[] Commands
+);
+
+/// <summary>
+/// A single aggregate mutation within a transaction envelope.
+/// </summary>
+public sealed record AggregateMutation(
+    string AggregateType,
+    uint AggregateId,
+    List<FieldDelta> Changes
+);
+
+/// <summary>
+/// Result of action expansion. Declares the full set of touched aggregates.
+/// No dynamic aggregate discovery during commit.
+/// </summary>
+public sealed class TransactionEnvelope
+{
+    public required string ActionId { get; init; }
+    public required string TransactionId { get; init; }
+    public required List<AggregateMutation> Mutations { get; init; }
+    public required List<AssertIfCommand> Assertions { get; init; }
+    /// <summary>All aggregate keys touched (for lock acquisition).</summary>
+    public required List<string> TouchedAggregateKeys { get; init; }
+}
+
+/// <summary>Result of a transaction commit.</summary>
+public sealed record TransactionResult(
+    bool Success,
+    string? ErrorCode,
+    string? ErrorMessage,
+    IReadOnlyList<TransactionWarning>? Warnings
+);
+
+/// <summary>Non-fatal assertion warning.</summary>
+public sealed record TransactionWarning(string Code, string Message);

--- a/BareMetalWeb.Data/ActionExpander.cs
+++ b/BareMetalWeb.Data/ActionExpander.cs
@@ -1,0 +1,247 @@
+using System.Collections;
+using BareMetalWeb.Core;
+
+namespace BareMetalWeb.Data;
+
+/// <summary>
+/// Expands an ActionDef + parameters into a TransactionEnvelope.
+/// Deterministic: same inputs → same envelope.
+/// Server re-expands independently — never trusts client-supplied deltas.
+/// </summary>
+public sealed class ActionExpander
+{
+    private readonly Func<string, ActionDef?> _actionResolver;
+    private readonly ExpressionEvaluator.AggregateReader? _aggregateReader;
+
+    public ActionExpander(
+        Func<string, ActionDef?> actionResolver,
+        ExpressionEvaluator.AggregateReader? aggregateReader = null)
+    {
+        _actionResolver = actionResolver;
+        _aggregateReader = aggregateReader;
+    }
+
+    /// <summary>
+    /// Expand an action against a root entity.
+    /// </summary>
+    public TransactionEnvelope Expand(
+        ActionDef action,
+        object rootEntity,
+        EntityLayout layout,
+        IReadOnlyDictionary<string, object?>? parameters = null)
+    {
+        var txId = Guid.NewGuid().ToString("N");
+        var mutations = new List<AggregateMutation>();
+        var assertions = new List<AssertIfCommand>();
+        var touchedKeys = new List<string>();
+
+        var rootKey = GetEntityKey(rootEntity);
+        var rootAggKey = $"{action.AggregateType}:{rootKey}";
+        touchedKeys.Add(rootAggKey);
+
+        var rootChanges = new List<FieldDelta>();
+        var eval = new ExpressionEvaluator(layout, _aggregateReader);
+
+        foreach (var cmd in action.Commands)
+        {
+            ExpandCommand(cmd, rootEntity, layout, eval, rootChanges, assertions,
+                mutations, touchedKeys, parameters);
+        }
+
+        if (rootChanges.Count > 0)
+        {
+            mutations.Insert(0, new AggregateMutation(
+                action.AggregateType, rootKey, rootChanges));
+        }
+
+        return new TransactionEnvelope
+        {
+            ActionId = action.ActionId,
+            TransactionId = txId,
+            Mutations = mutations,
+            Assertions = assertions,
+            TouchedAggregateKeys = touchedKeys,
+        };
+    }
+
+    private void ExpandCommand(
+        Command cmd, object entity, EntityLayout layout, ExpressionEvaluator eval,
+        List<FieldDelta> changes, List<AssertIfCommand> assertions,
+        List<AggregateMutation> mutations, List<string> touchedKeys,
+        IReadOnlyDictionary<string, object?>? parameters)
+    {
+        switch (cmd)
+        {
+            case AssertIfCommand assert:
+                assertions.Add(assert);
+                break;
+
+            case SetIfCommand setIf:
+                if (eval.EvaluateBool(ResolveParams(setIf.Condition, parameters), entity))
+                {
+                    var value = eval.Evaluate(ResolveParams(setIf.ValueExpr, parameters), entity);
+                    var field = layout.FieldByName(setIf.FieldName);
+                    if (field != null)
+                    {
+                        var encoded = DeltaMutationEngine.EncodeFieldValue(field, value);
+                        changes.Add(new FieldDelta((ushort)field.Ordinal, encoded));
+                    }
+                }
+                break;
+
+            case CalculateAndSetIfCommand calcIf:
+                if (eval.EvaluateBool(ResolveParams(calcIf.Condition, parameters), entity))
+                {
+                    var value = eval.Evaluate(ResolveParams(calcIf.ValueExpr, parameters), entity);
+                    var field = layout.FieldByName(calcIf.FieldName);
+                    if (field != null)
+                    {
+                        var encoded = DeltaMutationEngine.EncodeFieldValue(field, value);
+                        changes.Add(new FieldDelta((ushort)field.Ordinal, encoded));
+                    }
+                }
+                break;
+
+            case ForSetCommand forSet:
+                ExpandForSet(forSet, entity, layout, eval, changes, parameters, progressive: false);
+                break;
+
+            case ForSetSequentialCommand forSeq:
+                ExpandForSet(
+                    new ForSetCommand(forSeq.ListFieldName, forSeq.ItemCondition, forSeq.Operations),
+                    entity, layout, eval, changes, parameters, progressive: true);
+                break;
+
+            case InvokeIfCommand invoke:
+                if (eval.EvaluateBool(ResolveParams(invoke.Condition, parameters), entity))
+                {
+                    ExpandInvoke(invoke, entity, layout, eval, mutations, touchedKeys, parameters);
+                }
+                break;
+        }
+    }
+
+    private void ExpandForSet(
+        ForSetCommand forSet, object entity, EntityLayout layout, ExpressionEvaluator eval,
+        List<FieldDelta> changes, IReadOnlyDictionary<string, object?>? parameters,
+        bool progressive)
+    {
+        var listField = layout.FieldByName(forSet.ListFieldName);
+        if (listField == null) return;
+        var listVal = listField.Getter(entity);
+        if (listVal is not IEnumerable enumerable) return;
+
+        foreach (var item in enumerable)
+        {
+            if (item == null) continue;
+            if (!eval.EvaluateBool(ResolveParams(forSet.ItemCondition, parameters), entity, item))
+                continue;
+
+            foreach (var op in forSet.Operations)
+            {
+                switch (op)
+                {
+                    case SetIfCommand setIf:
+                        if (eval.EvaluateBool(ResolveParams(setIf.Condition, parameters), entity, item))
+                        {
+                            var value = eval.Evaluate(ResolveParams(setIf.ValueExpr, parameters), entity, item);
+                            var field = layout.FieldByName(setIf.FieldName);
+                            if (field != null)
+                            {
+                                var encoded = DeltaMutationEngine.EncodeFieldValue(field, value);
+                                changes.Add(new FieldDelta((ushort)field.Ordinal, encoded));
+                                if (progressive) field.Setter(entity, value);
+                            }
+                        }
+                        break;
+                    case CalculateAndSetIfCommand calcIf:
+                        if (eval.EvaluateBool(ResolveParams(calcIf.Condition, parameters), entity, item))
+                        {
+                            var value = eval.Evaluate(ResolveParams(calcIf.ValueExpr, parameters), entity, item);
+                            var field = layout.FieldByName(calcIf.FieldName);
+                            if (field != null)
+                            {
+                                var encoded = DeltaMutationEngine.EncodeFieldValue(field, value);
+                                changes.Add(new FieldDelta((ushort)field.Ordinal, encoded));
+                                if (progressive) field.Setter(entity, value);
+                            }
+                        }
+                        break;
+                }
+            }
+        }
+    }
+
+    private void ExpandInvoke(
+        InvokeIfCommand invoke, object entity, EntityLayout layout, ExpressionEvaluator eval,
+        List<AggregateMutation> mutations, List<string> touchedKeys,
+        IReadOnlyDictionary<string, object?>? parameters)
+    {
+        var targetAction = _actionResolver($"{invoke.TargetAggregateType}:{invoke.ActionId}");
+        if (targetAction == null) return;
+
+        // Resolve parameter map
+        var resolvedParams = new Dictionary<string, object?>();
+        foreach (var (key, expr) in invoke.ParameterMap)
+            resolvedParams[key] = eval.Evaluate(ResolveParams(expr, parameters), entity);
+
+        // Determine target aggregate ID from params (convention: "Id" param)
+        if (!resolvedParams.TryGetValue("Id", out var idObj)) return;
+        uint targetId = Convert.ToUInt32(idObj);
+
+        var aggKey = $"{invoke.TargetAggregateType}:{targetId}";
+        if (!touchedKeys.Contains(aggKey)) touchedKeys.Add(aggKey);
+
+        // Load target entity and expand target action against it
+        if (!DataScaffold.TryGetEntity(invoke.TargetAggregateType, out var targetMeta)) return;
+        var targetLayout = EntityLayoutCompiler.GetOrCompile(targetMeta);
+
+        var targetEntity = DataScaffold.LoadAsync(targetMeta, targetId).AsTask().Result;
+        if (targetEntity == null) return;
+
+        var targetEval = new ExpressionEvaluator(targetLayout, _aggregateReader);
+        var targetChanges = new List<FieldDelta>();
+        var assertions = new List<AssertIfCommand>(); // collected but not used here
+
+        foreach (var cmd in targetAction.Commands)
+        {
+            if (cmd is InvokeIfCommand) continue; // flat only — no nested invokes in v1
+            ExpandCommand(cmd, targetEntity, targetLayout, targetEval,
+                targetChanges, assertions, mutations, touchedKeys, resolvedParams);
+        }
+
+        if (targetChanges.Count > 0)
+            mutations.Add(new AggregateMutation(invoke.TargetAggregateType, targetId, targetChanges));
+    }
+
+    /// <summary>Resolve ParamRefExpr nodes by substituting with actual parameter values.</summary>
+    private static Expr ResolveParams(Expr expr, IReadOnlyDictionary<string, object?>? parameters)
+    {
+        if (parameters == null || parameters.Count == 0) return expr;
+        return expr switch
+        {
+            ParamRefExpr p => parameters.TryGetValue(p.ParamName, out var val)
+                ? new LiteralExpr(val) : expr,
+            BinaryExpr b => b with
+            {
+                Left = ResolveParams(b.Left, parameters),
+                Right = ResolveParams(b.Right, parameters)
+            },
+            UnaryExpr u => u with { Operand = ResolveParams(u.Operand, parameters) },
+            ConditionalExpr c => c with
+            {
+                Condition = ResolveParams(c.Condition, parameters),
+                Then = ResolveParams(c.Then, parameters),
+                Else = ResolveParams(c.Else, parameters)
+            },
+            _ => expr,
+        };
+    }
+
+    private static uint GetEntityKey(object entity)
+    {
+        if (entity is BaseDataObject bdo) return bdo.Key;
+        var prop = entity.GetType().GetProperty("Key");
+        return prop != null ? Convert.ToUInt32(prop.GetValue(entity)) : 0;
+    }
+}

--- a/BareMetalWeb.Data/AggregateLockManager.cs
+++ b/BareMetalWeb.Data/AggregateLockManager.cs
@@ -1,0 +1,151 @@
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+
+namespace BareMetalWeb.Data;
+
+/// <summary>
+/// In-memory pessimistic aggregate lock manager.
+/// Locks are ephemeral, not persisted, short-lived with safety expiry.
+/// Deadlock-free by sorted acquisition order.
+/// No async inside lock scope. No nested locking.
+/// </summary>
+public sealed class AggregateLockManager
+{
+    private readonly ConcurrentDictionary<string, LockEntry> _locks = new(StringComparer.Ordinal);
+    private static readonly TimeSpan DefaultExpiry = TimeSpan.FromSeconds(30);
+    private const int MaxRetries = 5;
+    private const int BaseBackoffMs = 10;
+
+    /// <summary>
+    /// Acquire locks for all aggregate keys in deterministic sorted order.
+    /// Returns a disposable handle that releases all locks on dispose.
+    /// Throws TimeoutException if locks cannot be acquired after retries.
+    /// </summary>
+    public LockHandle AcquireAll(IReadOnlyList<string> aggregateKeys, string transactionId)
+    {
+        // Sort deterministically to prevent deadlocks
+        var sorted = aggregateKeys.OrderBy(k => k, StringComparer.Ordinal).Distinct().ToArray();
+
+        for (int attempt = 0; attempt <= MaxRetries; attempt++)
+        {
+            var acquired = new List<string>();
+            bool success = true;
+
+            foreach (var key in sorted)
+            {
+                if (TryAcquire(key, transactionId))
+                {
+                    acquired.Add(key);
+                }
+                else
+                {
+                    // Release what we acquired and retry
+                    foreach (var acq in acquired)
+                        Release(acq, transactionId);
+                    success = false;
+                    break;
+                }
+            }
+
+            if (success)
+                return new LockHandle(this, acquired, transactionId);
+
+            // Exponential backoff
+            if (attempt < MaxRetries)
+                Thread.Sleep(BaseBackoffMs * (1 << attempt));
+        }
+
+        throw new TimeoutException(
+            $"Failed to acquire locks for transaction {transactionId} after {MaxRetries} retries. " +
+            $"Keys: {string.Join(", ", sorted)}");
+    }
+
+    /// <summary>Try to acquire a single lock. Returns true if acquired.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TryAcquire(string aggregateKey, string transactionId)
+    {
+        var now = DateTime.UtcNow;
+        var entry = new LockEntry(aggregateKey, transactionId, now + DefaultExpiry);
+
+        return _locks.AddOrUpdate(aggregateKey,
+            _ => entry,
+            (_, existing) =>
+            {
+                // If existing lock is expired or owned by same transaction, replace
+                if (existing.ExpiryUtc < now || existing.OwnerTransactionId == transactionId)
+                    return entry;
+                return existing; // keep existing
+            }).OwnerTransactionId == transactionId;
+    }
+
+    /// <summary>Release a lock owned by the given transaction.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Release(string aggregateKey, string transactionId)
+    {
+        _locks.TryRemove(new KeyValuePair<string, LockEntry>(
+            aggregateKey,
+            new LockEntry(aggregateKey, transactionId, default)));
+
+        // Fallback: remove if owner matches
+        if (_locks.TryGetValue(aggregateKey, out var entry) &&
+            entry.OwnerTransactionId == transactionId)
+        {
+            _locks.TryRemove(aggregateKey, out _);
+        }
+    }
+
+    /// <summary>Release all locks for a transaction.</summary>
+    public void ReleaseAll(IEnumerable<string> keys, string transactionId)
+    {
+        foreach (var key in keys)
+            Release(key, transactionId);
+    }
+
+    /// <summary>Purge expired locks (call periodically if needed).</summary>
+    public int PurgeExpired()
+    {
+        var now = DateTime.UtcNow;
+        int purged = 0;
+        foreach (var (key, entry) in _locks)
+        {
+            if (entry.ExpiryUtc < now)
+            {
+                _locks.TryRemove(key, out _);
+                purged++;
+            }
+        }
+        return purged;
+    }
+
+    public int ActiveLockCount => _locks.Count;
+}
+
+/// <summary>Ephemeral lock entry. Not persisted.</summary>
+public readonly record struct LockEntry(
+    string AggregateKey,
+    string OwnerTransactionId,
+    DateTime ExpiryUtc
+);
+
+/// <summary>Disposable handle that releases all acquired locks.</summary>
+public sealed class LockHandle : IDisposable
+{
+    private readonly AggregateLockManager _manager;
+    private readonly List<string> _keys;
+    private readonly string _transactionId;
+    private bool _disposed;
+
+    internal LockHandle(AggregateLockManager manager, List<string> keys, string transactionId)
+    {
+        _manager = manager;
+        _keys = keys;
+        _transactionId = transactionId;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _manager.ReleaseAll(_keys, _transactionId);
+    }
+}

--- a/BareMetalWeb.Data/Expr.cs
+++ b/BareMetalWeb.Data/Expr.cs
@@ -1,0 +1,87 @@
+namespace BareMetalWeb.Data;
+
+/// <summary>Operators for expression evaluation. Stable IDs.</summary>
+public enum ExprOp : byte
+{
+    // Comparison
+    Eq = 1, Ne = 2, Lt = 3, Gt = 4, Le = 5, Ge = 6,
+    // Arithmetic
+    Add = 10, Sub = 11, Mul = 12, Div = 13, Mod = 14,
+    // Logical
+    And = 20, Or = 21, Not = 22,
+    // Unary
+    Neg = 30,
+}
+
+/// <summary>Aggregate functions usable in expressions (sum, count, min, max, any, all).</summary>
+public enum ExprAggregateFn : byte
+{
+    Sum = 1, Count = 2, Min = 3, Max = 4, Any = 5, All = 6,
+}
+
+// ── Expression Tree ──
+// Structured, deterministic, side-effect free. No textual scripting.
+
+/// <summary>Base type for all expression tree nodes.</summary>
+public abstract record Expr;
+
+/// <summary>Constant value.</summary>
+public sealed record LiteralExpr(object? Value) : Expr;
+
+/// <summary>Field reference on the current aggregate.</summary>
+public sealed record FieldRefExpr(string FieldName) : Expr;
+
+/// <summary>Field reference within a ForSet item iteration.</summary>
+public sealed record ItemFieldRefExpr(string FieldName) : Expr;
+
+/// <summary>Cross-aggregate read: Get(AggregateType, AggregateId, FieldName).</summary>
+public sealed record GetExpr(string AggregateType, Expr AggregateIdExpr, string FieldName) : Expr;
+
+/// <summary>Binary operation: Left op Right.</summary>
+public sealed record BinaryExpr(ExprOp Op, Expr Left, Expr Right) : Expr;
+
+/// <summary>Unary operation: op Operand.</summary>
+public sealed record UnaryExpr(ExprOp Op, Expr Operand) : Expr;
+
+/// <summary>Ternary: if Condition then Then else Else.</summary>
+public sealed record ConditionalExpr(Expr Condition, Expr Then, Expr Else) : Expr;
+
+/// <summary>Aggregate over a list field: sum/count/min/max/any/all(listField, selector).</summary>
+public sealed record AggregateExpr(ExprAggregateFn Fn, string ListFieldName, Expr Selector) : Expr;
+
+/// <summary>Parameter reference — resolved during action expansion.</summary>
+public sealed record ParamRefExpr(string ParamName) : Expr;
+
+// ── Expression Builder (fluent API for constructing expressions) ──
+
+public static class Ex
+{
+    public static LiteralExpr Lit(object? value) => new(value);
+    public static FieldRefExpr Field(string name) => new(name);
+    public static ItemFieldRefExpr Item(string name) => new(name);
+    public static ParamRefExpr Param(string name) => new(name);
+    public static GetExpr Get(string aggType, Expr idExpr, string field) => new(aggType, idExpr, field);
+
+    public static BinaryExpr Eq(Expr l, Expr r) => new(ExprOp.Eq, l, r);
+    public static BinaryExpr Ne(Expr l, Expr r) => new(ExprOp.Ne, l, r);
+    public static BinaryExpr Lt(Expr l, Expr r) => new(ExprOp.Lt, l, r);
+    public static BinaryExpr Gt(Expr l, Expr r) => new(ExprOp.Gt, l, r);
+    public static BinaryExpr Le(Expr l, Expr r) => new(ExprOp.Le, l, r);
+    public static BinaryExpr Ge(Expr l, Expr r) => new(ExprOp.Ge, l, r);
+    public static BinaryExpr Add(Expr l, Expr r) => new(ExprOp.Add, l, r);
+    public static BinaryExpr Sub(Expr l, Expr r) => new(ExprOp.Sub, l, r);
+    public static BinaryExpr Mul(Expr l, Expr r) => new(ExprOp.Mul, l, r);
+    public static BinaryExpr Div(Expr l, Expr r) => new(ExprOp.Div, l, r);
+    public static BinaryExpr And(Expr l, Expr r) => new(ExprOp.And, l, r);
+    public static BinaryExpr Or(Expr l, Expr r) => new(ExprOp.Or, l, r);
+    public static UnaryExpr Not(Expr e) => new(ExprOp.Not, e);
+    public static UnaryExpr Neg(Expr e) => new(ExprOp.Neg, e);
+    public static ConditionalExpr If(Expr cond, Expr then, Expr @else) => new(cond, then, @else);
+
+    public static AggregateExpr Sum(string listField, Expr selector) => new(ExprAggregateFn.Sum, listField, selector);
+    public static AggregateExpr Count(string listField, Expr selector) => new(ExprAggregateFn.Count, listField, selector);
+    public static AggregateExpr Min(string listField, Expr selector) => new(ExprAggregateFn.Min, listField, selector);
+    public static AggregateExpr Max(string listField, Expr selector) => new(ExprAggregateFn.Max, listField, selector);
+    public static AggregateExpr Any(string listField, Expr selector) => new(ExprAggregateFn.Any, listField, selector);
+    public static AggregateExpr All(string listField, Expr selector) => new(ExprAggregateFn.All, listField, selector);
+}

--- a/BareMetalWeb.Data/ExpressionEvaluator.cs
+++ b/BareMetalWeb.Data/ExpressionEvaluator.cs
@@ -1,0 +1,222 @@
+using System.Collections;
+using System.Runtime.CompilerServices;
+using BareMetalWeb.Core;
+
+namespace BareMetalWeb.Data;
+
+/// <summary>
+/// Evaluates structured expression trees against entity state.
+/// Uses EntityLayout compiled getters — no reflection in evaluation.
+/// Pure, deterministic, side-effect free.
+/// </summary>
+public sealed class ExpressionEvaluator
+{
+    /// <summary>Delegate for cross-aggregate reads: (aggregateType, aggregateId, fieldName) → value.</summary>
+    public delegate object? AggregateReader(string aggregateType, uint aggregateId, string fieldName);
+
+    private readonly EntityLayout _layout;
+    private readonly AggregateReader? _reader;
+
+    public ExpressionEvaluator(EntityLayout layout, AggregateReader? reader = null)
+    {
+        _layout = layout;
+        _reader = reader;
+    }
+
+    /// <summary>Evaluate an expression against an entity instance.</summary>
+    public object? Evaluate(Expr expr, object entity, object? currentItem = null)
+    {
+        return expr switch
+        {
+            LiteralExpr lit => lit.Value,
+            FieldRefExpr fref => ReadField(entity, fref.FieldName),
+            ItemFieldRefExpr iref => currentItem != null ? ReadField(currentItem, iref.FieldName) : null,
+            ParamRefExpr => throw new InvalidOperationException("ParamRefExpr must be resolved before evaluation."),
+            GetExpr get => EvaluateGet(get, entity, currentItem),
+            BinaryExpr bin => EvaluateBinary(bin, entity, currentItem),
+            UnaryExpr un => EvaluateUnary(un, entity, currentItem),
+            ConditionalExpr cond => IsTruthy(Evaluate(cond.Condition, entity, currentItem))
+                ? Evaluate(cond.Then, entity, currentItem)
+                : Evaluate(cond.Else, entity, currentItem),
+            AggregateExpr agg => EvaluateAggregate(agg, entity),
+            _ => throw new InvalidOperationException($"Unknown expression type: {expr.GetType().Name}"),
+        };
+    }
+
+    /// <summary>Evaluate and coerce to bool.</summary>
+    public bool EvaluateBool(Expr expr, object entity, object? currentItem = null)
+        => IsTruthy(Evaluate(expr, entity, currentItem));
+
+    private object? ReadField(object entity, string fieldName)
+    {
+        var field = _layout.FieldByName(fieldName);
+        return field?.Getter(entity);
+    }
+
+    private object? EvaluateGet(GetExpr get, object entity, object? currentItem)
+    {
+        if (_reader == null)
+            throw new InvalidOperationException("Cross-aggregate reads require an AggregateReader.");
+        var idVal = Evaluate(get.AggregateIdExpr, entity, currentItem);
+        if (idVal == null) return null;
+        uint id = Convert.ToUInt32(idVal);
+        return _reader(get.AggregateType, id, get.FieldName);
+    }
+
+    private object? EvaluateBinary(BinaryExpr bin, object entity, object? currentItem)
+    {
+        var left = Evaluate(bin.Left, entity, currentItem);
+        var right = Evaluate(bin.Right, entity, currentItem);
+
+        return bin.Op switch
+        {
+            // Logical (short-circuit not needed since both evaluated)
+            ExprOp.And => IsTruthy(left) && IsTruthy(right),
+            ExprOp.Or => IsTruthy(left) || IsTruthy(right),
+
+            // Comparison
+            ExprOp.Eq => Equals(left, right),
+            ExprOp.Ne => !Equals(left, right),
+            ExprOp.Lt => CompareValues(left, right) < 0,
+            ExprOp.Gt => CompareValues(left, right) > 0,
+            ExprOp.Le => CompareValues(left, right) <= 0,
+            ExprOp.Ge => CompareValues(left, right) >= 0,
+
+            // Arithmetic
+            ExprOp.Add => ArithOp(left, right, (a, b) => a + b),
+            ExprOp.Sub => ArithOp(left, right, (a, b) => a - b),
+            ExprOp.Mul => ArithOp(left, right, (a, b) => a * b),
+            ExprOp.Div => ArithOp(left, right, (a, b) => b != 0 ? a / b : 0),
+            ExprOp.Mod => ArithOp(left, right, (a, b) => b != 0 ? a % b : 0),
+
+            _ => throw new InvalidOperationException($"Unknown binary op: {bin.Op}"),
+        };
+    }
+
+    private object? EvaluateUnary(UnaryExpr un, object entity, object? currentItem)
+    {
+        var operand = Evaluate(un.Operand, entity, currentItem);
+        return un.Op switch
+        {
+            ExprOp.Not => !IsTruthy(operand),
+            ExprOp.Neg => operand switch
+            {
+                int i => -i,
+                long l => -l,
+                double d => -d,
+                decimal m => -m,
+                float f => -f,
+                _ => -(ToDouble(operand)),
+            },
+            _ => throw new InvalidOperationException($"Unknown unary op: {un.Op}"),
+        };
+    }
+
+    private object? EvaluateAggregate(AggregateExpr agg, object entity)
+    {
+        var listVal = ReadField(entity, agg.ListFieldName);
+        if (listVal is not IEnumerable enumerable) return null;
+
+        double sum = 0;
+        int count = 0;
+        double min = double.MaxValue;
+        double max = double.MinValue;
+        bool any = false;
+        bool all = true;
+
+        foreach (var item in enumerable)
+        {
+            if (item == null) continue;
+            var val = Evaluate(agg.Selector, entity, item);
+            count++;
+
+            switch (agg.Fn)
+            {
+                case ExprAggregateFn.Sum:
+                    sum += ToDouble(val);
+                    break;
+                case ExprAggregateFn.Count:
+                    break;
+                case ExprAggregateFn.Min:
+                    var d = ToDouble(val);
+                    if (d < min) min = d;
+                    break;
+                case ExprAggregateFn.Max:
+                    var d2 = ToDouble(val);
+                    if (d2 > max) max = d2;
+                    break;
+                case ExprAggregateFn.Any:
+                    if (IsTruthy(val)) any = true;
+                    break;
+                case ExprAggregateFn.All:
+                    if (!IsTruthy(val)) all = false;
+                    break;
+            }
+        }
+
+        return agg.Fn switch
+        {
+            ExprAggregateFn.Sum => sum,
+            ExprAggregateFn.Count => count,
+            ExprAggregateFn.Min => count > 0 ? min : null,
+            ExprAggregateFn.Max => count > 0 ? max : null,
+            ExprAggregateFn.Any => any,
+            ExprAggregateFn.All => all && count > 0,
+            _ => null,
+        };
+    }
+
+    // ── Helpers ──
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsTruthy(object? val) => val switch
+    {
+        null => false,
+        bool b => b,
+        int i => i != 0,
+        uint u => u != 0,
+        long l => l != 0,
+        double d => d != 0,
+        decimal m => m != 0,
+        string s => s.Length > 0,
+        _ => true,
+    };
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static double ToDouble(object? val) => val switch
+    {
+        null => 0,
+        int i => i,
+        uint u => u,
+        long l => l,
+        ulong ul => ul,
+        float f => f,
+        double d => d,
+        decimal m => (double)m,
+        short s => s,
+        ushort us => us,
+        byte b => b,
+        _ => Convert.ToDouble(val),
+    };
+
+    private static int CompareValues(object? left, object? right)
+    {
+        if (left == null && right == null) return 0;
+        if (left == null) return -1;
+        if (right == null) return 1;
+        if (left is IComparable cmp) return cmp.CompareTo(right);
+        return ToDouble(left).CompareTo(ToDouble(right));
+    }
+
+    private static object? ArithOp(object? left, object? right, Func<double, double, double> op)
+    {
+        if (left == null || right == null) return null;
+        // Preserve decimal precision when both are decimal
+        if (left is decimal ld && right is decimal rd)
+        {
+            double dl = (double)ld, dr = (double)rd;
+            return (decimal)op(dl, dr);
+        }
+        return op(ToDouble(left), ToDouble(right));
+    }
+}

--- a/BareMetalWeb.Data/TransactionCommitEngine.cs
+++ b/BareMetalWeb.Data/TransactionCommitEngine.cs
@@ -1,0 +1,172 @@
+using BareMetalWeb.Core;
+
+namespace BareMetalWeb.Data;
+
+/// <summary>
+/// Full transaction commit pipeline:
+/// 1. Acquire locks (sorted, deadlock-free)
+/// 2. Load canonical state for all aggregates
+/// 3. Apply envelope mutations to working copies
+/// 4. Run all AssertIf validations
+/// 5. If valid: save all mutations atomically, release locks, return success
+/// 6. If invalid: release locks, return rejected
+/// </summary>
+public sealed class TransactionCommitEngine
+{
+    private readonly AggregateLockManager _lockManager;
+
+    public TransactionCommitEngine(AggregateLockManager lockManager)
+    {
+        _lockManager = lockManager;
+    }
+
+    /// <summary>
+    /// Commit a transaction envelope.
+    /// All validation occurs inside lock scope.
+    /// </summary>
+    public async ValueTask<TransactionResult> CommitAsync(
+        TransactionEnvelope envelope,
+        string userName,
+        CancellationToken cancellationToken = default)
+    {
+        // 1. Acquire all locks in sorted order
+        using var lockHandle = _lockManager.AcquireAll(
+            envelope.TouchedAggregateKeys, envelope.TransactionId);
+
+        try
+        {
+            // 2. Load canonical state for all touched aggregates
+            var loadedEntities = new Dictionary<string, (DataEntityMetadata Meta, BaseDataObject Entity, EntityLayout Layout)>();
+
+            foreach (var mutation in envelope.Mutations)
+            {
+                var key = $"{mutation.AggregateType}:{mutation.AggregateId}";
+                if (loadedEntities.ContainsKey(key)) continue;
+
+                if (!DataScaffold.TryGetEntity(mutation.AggregateType, out var meta))
+                    return Fail("ENTITY_NOT_FOUND", $"Unknown entity type '{mutation.AggregateType}'.");
+
+                var entity = await DataScaffold.LoadAsync(meta, mutation.AggregateId, cancellationToken) as BaseDataObject;
+                if (entity == null)
+                    return Fail("ENTITY_NOT_FOUND", $"Entity {mutation.AggregateType}:{mutation.AggregateId} not found.");
+
+                var layout = EntityLayoutCompiler.GetOrCompile(meta);
+                loadedEntities[key] = (meta, entity, layout);
+            }
+
+            // 3. Apply mutations to working copies
+            foreach (var mutation in envelope.Mutations)
+            {
+                var key = $"{mutation.AggregateType}:{mutation.AggregateId}";
+                var (_, entity, layout) = loadedEntities[key];
+
+                foreach (var change in mutation.Changes)
+                {
+                    if (change.Ordinal >= layout.Fields.Length)
+                        return Fail("INVALID_ORDINAL", $"Field ordinal {change.Ordinal} out of range for {mutation.AggregateType}.");
+
+                    var field = layout.Fields[change.Ordinal];
+                    if (field.Is(FieldFlags.ReadOnly)) continue;
+
+                    if (change.IsNull)
+                    {
+                        if (!field.Is(FieldFlags.Nullable))
+                            return Fail("VALIDATION_FAILED", $"Field '{field.Name}' on {mutation.AggregateType} is not nullable.");
+                        field.Setter(entity, null);
+                        continue;
+                    }
+
+                    var codec = CodecTable.Get(field.CodecId);
+                    object? value = field.FixedSizeBytes > 0
+                        ? codec.ReadFixed(change.Value.Span)
+                        : codec.ReadVar(change.Value.Span);
+
+                    if (field.Type == FieldType.EnumInt32 && value is int intVal)
+                        value = Enum.ToObject(field.ClrType, intVal);
+
+                    field.Setter(entity, value);
+                }
+            }
+
+            // 4. Run all AssertIf validations
+            var warnings = new List<TransactionWarning>();
+            foreach (var assert in envelope.Assertions)
+            {
+                // Evaluate against the first (root) mutation's entity
+                if (envelope.Mutations.Count == 0) continue;
+                var rootMut = envelope.Mutations[0];
+                var rootKey = $"{rootMut.AggregateType}:{rootMut.AggregateId}";
+                if (!loadedEntities.TryGetValue(rootKey, out var root)) continue;
+
+                var eval = new ExpressionEvaluator(root.Layout);
+                bool conditionMet = eval.EvaluateBool(assert.Condition, root.Entity);
+
+                if (!conditionMet)
+                {
+                    switch (assert.Severity)
+                    {
+                        case Severity.Error:
+                            return Fail(assert.Code, assert.Message);
+                        case Severity.Warning:
+                            warnings.Add(new TransactionWarning(assert.Code, assert.Message));
+                            break;
+                        case Severity.Info:
+                            warnings.Add(new TransactionWarning(assert.Code, assert.Message));
+                            break;
+                    }
+                }
+            }
+
+            // 5. Save all mutations atomically
+            foreach (var mutation in envelope.Mutations)
+            {
+                var key = $"{mutation.AggregateType}:{mutation.AggregateId}";
+                var (meta, entity, _) = loadedEntities[key];
+                entity.Touch(userName);
+                await DataScaffold.SaveAsync(meta, entity, cancellationToken);
+            }
+
+            // 6. Success
+            return new TransactionResult(
+                Success: true,
+                ErrorCode: null,
+                ErrorMessage: null,
+                Warnings: warnings.Count > 0 ? warnings : null);
+        }
+        catch (TimeoutException)
+        {
+            return Fail("LOCK_TIMEOUT", "Failed to acquire locks for transaction.");
+        }
+    }
+
+    /// <summary>
+    /// High-level: expand an action and commit in one call.
+    /// Server re-expands independently (security model).
+    /// </summary>
+    public async ValueTask<TransactionResult> ExecuteActionAsync(
+        ActionDef action,
+        uint aggregateId,
+        IReadOnlyDictionary<string, object?>? parameters,
+        Func<string, ActionDef?> actionResolver,
+        string userName,
+        CancellationToken cancellationToken = default)
+    {
+        if (!DataScaffold.TryGetEntity(action.AggregateType, out var meta))
+            return Fail("ENTITY_NOT_FOUND", $"Unknown entity type '{action.AggregateType}'.");
+
+        var entity = await DataScaffold.LoadAsync(meta, aggregateId, cancellationToken) as BaseDataObject;
+        if (entity == null)
+            return Fail("ENTITY_NOT_FOUND", $"Entity {action.AggregateType}:{aggregateId} not found.");
+
+        var layout = EntityLayoutCompiler.GetOrCompile(meta);
+
+        // Server-side expansion (never trust client delta)
+        var expander = new ActionExpander(actionResolver);
+        var envelope = expander.Expand(action, entity, layout, parameters);
+
+        return await CommitAsync(envelope, userName, cancellationToken);
+    }
+
+    private static TransactionResult Fail(string code, string message)
+        => new(Success: false, ErrorCode: code, ErrorMessage: message, Warnings: null);
+}

--- a/BareMetalWeb.Host/ActionApiHandlers.cs
+++ b/BareMetalWeb.Host/ActionApiHandlers.cs
@@ -1,0 +1,193 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using BareMetalWeb.Core;
+using BareMetalWeb.Data;
+using Microsoft.AspNetCore.Http;
+
+namespace BareMetalWeb.Host;
+
+/// <summary>
+/// HTTP handlers for the Action & Transaction engine.
+/// POST /api/_binary/{type}/_action/{actionId} — execute an action
+/// GET /api/_binary/{type}/_actions — list registered actions
+/// </summary>
+public static class ActionApiHandlers
+{
+    private static readonly ConcurrentDictionary<string, ActionDef> _actions = new(StringComparer.OrdinalIgnoreCase);
+    private static AggregateLockManager? _lockManager;
+    private static TransactionCommitEngine? _commitEngine;
+
+    /// <summary>Initialize the action subsystem.</summary>
+    public static void Initialize()
+    {
+        _lockManager = new AggregateLockManager();
+        _commitEngine = new TransactionCommitEngine(_lockManager);
+    }
+
+    /// <summary>Register an action definition.</summary>
+    public static void RegisterAction(ActionDef action)
+    {
+        var key = $"{action.AggregateType}:{action.ActionId}";
+        _actions[key] = action;
+    }
+
+    /// <summary>Resolve an action by composite key (type:actionId).</summary>
+    public static ActionDef? ResolveAction(string compositeKey)
+        => _actions.TryGetValue(compositeKey, out var action) ? action : null;
+
+    /// <summary>
+    /// POST /api/_binary/{type}/_action/{actionId}
+    /// Body (JSON): { "aggregateId": 123, "parameters": { "key": "value", ... } }
+    /// </summary>
+    public static async ValueTask ExecuteActionHandler(HttpContext context)
+    {
+        if (_commitEngine == null)
+        {
+            await WriteError(context, 500, "Action engine not initialized.");
+            return;
+        }
+
+        var typeSlug = BinaryApiHandlers.GetRouteValue(context, "type") ?? string.Empty;
+        var actionId = BinaryApiHandlers.GetRouteValue(context, "actionId") ?? string.Empty;
+
+        if (string.IsNullOrWhiteSpace(typeSlug) || string.IsNullOrWhiteSpace(actionId))
+        {
+            await WriteError(context, 400, "Entity type and action ID required.");
+            return;
+        }
+
+        var compositeKey = $"{typeSlug}:{actionId}";
+        var action = ResolveAction(compositeKey);
+        if (action == null)
+        {
+            await WriteError(context, 404, $"Action '{actionId}' not found for entity type '{typeSlug}'.");
+            return;
+        }
+
+        // Auth
+        var user = await UserAuth.GetRequestUserAsync(context, context.RequestAborted);
+        var userName = user?.UserName ?? "anonymous";
+
+        // Parse request body
+        uint aggregateId;
+        Dictionary<string, object?>? parameters = null;
+
+        try
+        {
+            using var doc = await JsonDocument.ParseAsync(context.Request.Body, cancellationToken: context.RequestAborted);
+            var root = doc.RootElement;
+
+            if (!root.TryGetProperty("aggregateId", out var idEl))
+            {
+                await WriteError(context, 400, "aggregateId is required.");
+                return;
+            }
+            aggregateId = idEl.GetUInt32();
+
+            if (root.TryGetProperty("parameters", out var paramsEl) && paramsEl.ValueKind == JsonValueKind.Object)
+            {
+                parameters = new Dictionary<string, object?>();
+                foreach (var prop in paramsEl.EnumerateObject())
+                {
+                    parameters[prop.Name] = prop.Value.ValueKind switch
+                    {
+                        JsonValueKind.String => prop.Value.GetString(),
+                        JsonValueKind.Number => prop.Value.TryGetInt64(out var l) ? l : prop.Value.GetDouble(),
+                        JsonValueKind.True => true,
+                        JsonValueKind.False => false,
+                        JsonValueKind.Null => null,
+                        _ => prop.Value.GetRawText(),
+                    };
+                }
+            }
+        }
+        catch (JsonException)
+        {
+            await WriteError(context, 400, "Invalid JSON request body.");
+            return;
+        }
+
+        try
+        {
+            var result = await _commitEngine.ExecuteActionAsync(
+                action, aggregateId, parameters, ResolveAction, userName, context.RequestAborted);
+
+            context.Response.StatusCode = result.Success ? 200 : 422;
+            context.Response.ContentType = "application/json";
+            await using var writer = new Utf8JsonWriter(context.Response.Body);
+            writer.WriteStartObject();
+            writer.WriteBoolean("success", result.Success);
+            if (result.ErrorCode != null) writer.WriteString("errorCode", result.ErrorCode);
+            if (result.ErrorMessage != null) writer.WriteString("errorMessage", result.ErrorMessage);
+            if (result.Warnings is { Count: > 0 })
+            {
+                writer.WriteStartArray("warnings");
+                foreach (var w in result.Warnings)
+                {
+                    writer.WriteStartObject();
+                    writer.WriteString("code", w.Code);
+                    writer.WriteString("message", w.Message);
+                    writer.WriteEndObject();
+                }
+                writer.WriteEndArray();
+            }
+            writer.WriteEndObject();
+            await writer.FlushAsync(context.RequestAborted);
+        }
+        catch (TimeoutException)
+        {
+            await WriteError(context, 409, "Lock acquisition timed out. Retry later.");
+        }
+        catch (Exception ex)
+        {
+            await WriteError(context, 500, $"Error executing action: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// GET /api/_binary/{type}/_actions
+    /// Returns list of registered actions for the entity type.
+    /// </summary>
+    public static async ValueTask ListActionsHandler(HttpContext context)
+    {
+        var typeSlug = BinaryApiHandlers.GetRouteValue(context, "type") ?? string.Empty;
+
+        context.Response.StatusCode = 200;
+        context.Response.ContentType = "application/json";
+        await using var writer = new Utf8JsonWriter(context.Response.Body);
+        writer.WriteStartObject();
+        writer.WriteStartArray("actions");
+
+        foreach (var (key, action) in _actions)
+        {
+            if (!string.Equals(action.AggregateType, typeSlug, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            writer.WriteStartObject();
+            writer.WriteString("actionId", action.ActionId);
+            writer.WriteString("aggregateType", action.AggregateType);
+            writer.WriteNumber("version", action.Version);
+            writer.WriteNumber("commandCount", action.Commands.Length);
+            writer.WriteEndObject();
+        }
+
+        writer.WriteEndArray();
+        writer.WriteEndObject();
+        await writer.FlushAsync(context.RequestAborted);
+    }
+
+    public static int RegisteredActionCount => _actions.Count;
+    public static AggregateLockManager? LockManager => _lockManager;
+
+    private static async ValueTask WriteError(HttpContext context, int statusCode, string message)
+    {
+        context.Response.StatusCode = statusCode;
+        context.Response.ContentType = "application/json";
+        await using var writer = new Utf8JsonWriter(context.Response.Body);
+        writer.WriteStartObject();
+        writer.WriteBoolean("success", false);
+        writer.WriteString("errorMessage", message);
+        writer.WriteEndObject();
+        await writer.FlushAsync(context.RequestAborted);
+    }
+}

--- a/BareMetalWeb.Host/BareMetalWebExtensions.cs
+++ b/BareMetalWeb.Host/BareMetalWebExtensions.cs
@@ -172,6 +172,7 @@ public static class BareMetalWebExtensions
         appInfo.RegisterEntityMetadataRoute(pageInfoFactory);  // must be before RegisterApiRoutes
         appInfo.RegisterRuntimeApiRoutes(pageInfoFactory);       // /meta/entity/{name}, POST /query, POST /intent
         appInfo.RegisterLookupApiRoutes(pageInfoFactory);       // must be before RegisterApiRoutes
+        ActionApiHandlers.Initialize();                           // action engine lock manager
         appInfo.RegisterBinaryApiRoutes(pageInfoFactory);       // binary wire-format API
         appInfo.RegisterApiRoutes(routeHandlers, pageInfoFactory);
         appInfo.RegisterVNextRoutes(pageInfoFactory, templateStore);

--- a/BareMetalWeb.Host/RouteRegistrationExtensions.cs
+++ b/BareMetalWeb.Host/RouteRegistrationExtensions.cs
@@ -479,6 +479,8 @@ public static class RouteRegistrationExtensions
         host.RegisterRoute("GET /api/_binary/{type}/_schema", new RouteHandlerData(raw, BinaryApiHandlers.SchemaHandler));
         host.RegisterRoute("GET /api/_binary/{type}/_aggregate", new RouteHandlerData(raw, BinaryApiHandlers.AggregateHandler));
         host.RegisterRoute("GET /api/_binary/{type}/_layout", new RouteHandlerData(raw, DeltaApiHandlers.LayoutHandler));
+        host.RegisterRoute("GET /api/_binary/{type}/_actions", new RouteHandlerData(raw, ActionApiHandlers.ListActionsHandler));
+        host.RegisterRoute("POST /api/_binary/{type}/_action/{actionId}", new RouteHandlerData(raw, ActionApiHandlers.ExecuteActionHandler));
         host.RegisterRoute("GET /api/_binary/{type}/{id}", new RouteHandlerData(raw, BinaryApiHandlers.GetHandler));
         host.RegisterRoute("GET /api/_binary/{type}", new RouteHandlerData(raw, BinaryApiHandlers.ListHandler));
         host.RegisterRoute("POST /api/_binary/{type}", new RouteHandlerData(raw, BinaryApiHandlers.CreateHandler));


### PR DESCRIPTION
## Summary
Implements the Action & Transaction Spec v1.1 (closes #628).

### New files (BareMetalWeb.Data)
- **Expr.cs** — Expression tree types (Literal, FieldRef, Binary, Unary, Conditional, Aggregate, ParamRef) + `Ex` fluent builder
- **ExpressionEvaluator.cs** — Evaluate expression trees against entity state using compiled getters from EntityLayout
- **ActionDef.cs** — Immutable action definitions with 6 command types + TransactionEnvelope/AggregateMutation records
- **ActionExpander.cs** — Deterministic expansion of ActionDef + params → TransactionEnvelope (snapshot & progressive ForSet)
- **AggregateLockManager.cs** — In-memory pessimistic locks, sorted acquisition (deadlock-free), safety expiry, disposable LockHandle
- **TransactionCommitEngine.cs** — Full pipeline: lock → load → apply → validate assertions → save → release

### New files (BareMetalWeb.Host)
- **ActionApiHandlers.cs** — POST `/api/_binary/{type}/_action/{actionId}` + GET `/api/_binary/{type}/_actions`

### Modified files
- **RouteRegistrationExtensions.cs** — Action routes (before {type}/{id} to avoid routing conflicts)
- **BareMetalWebExtensions.cs** — `ActionApiHandlers.Initialize()` call at startup

### Design decisions
- Deadlock-free: locks acquired in sorted key order with exponential backoff
- No async inside lock scope — all lock operations are synchronous
- Server re-expands actions independently (never trusts client-generated envelopes)
- InvokeIf is flat only in v1 (no nested invokes)
- AssertIf with Error severity aborts entire transaction; Warning/Info continue

All existing tests pass (exit code 0).