### PR TITLE
feat: Report filters as dropdowns above report

### DIFF
--- a/BareMetalWeb.Data/ReportModels.cs
+++ b/BareMetalWeb.Data/ReportModels.cs
@@ -34,8 +34,13 @@ public sealed class ReportParameter
 {
     public string Name { get; set; } = string.Empty;
     public string Label { get; set; } = string.Empty;
+    /// <summary>Parameter input type: string, date, number, select.</summary>
     public string Type { get; set; } = "string";
     public string DefaultValue { get; set; } = string.Empty;
+    /// <summary>Static options for dropdown (Type=select). Each entry is "value|label" or just "value".</summary>
+    public List<string>? Options { get; set; }
+    /// <summary>Dynamic dropdown source: "entitySlug.fieldName" — distinct values loaded at render time.</summary>
+    public string? FieldSource { get; set; }
 }
 
 /// <summary>The output of a report execution — column headers and data rows.</summary>

--- a/BareMetalWeb.Host/ReportHtmlRenderer.cs
+++ b/BareMetalWeb.Host/ReportHtmlRenderer.cs
@@ -64,23 +64,83 @@ public static class ReportHtmlRenderer
             Write(writer, "</p>");
         }
 
-        // Parameter form (if any)
+        // Parameter form (if any) — rendered as a dropdown bar above the report
         if (parameters != null && parameters.Count > 0)
         {
-            Write(writer, "<form class=\"row g-3 mb-4\" method=\"get\">");
+            Write(writer, "<div class=\"card bg-body-tertiary mb-4\"><div class=\"card-body py-2\">");
+            Write(writer, "<form class=\"row g-2 align-items-end\" method=\"get\">");
             foreach (var p in parameters)
             {
-                Write(writer, "<div class=\"col-auto\"><label class=\"form-label fw-semibold\">");
-                WriteEncoded(writer, p.Label);
-                Write(writer, "</label><input type=\"text\" class=\"form-control\" name=\"");
-                WriteEncoded(writer, p.Name);
-                Write(writer, "\" value=\"");
                 var val = parameterValues != null && parameterValues.TryGetValue(p.Name, out var pv) ? pv : p.DefaultValue;
-                WriteEncoded(writer, val);
-                Write(writer, "\"></div>");
+                Write(writer, "<div class=\"col-auto\"><label class=\"form-label fw-semibold mb-1 small\">");
+                WriteEncoded(writer, p.Label);
+                Write(writer, "</label>");
+
+                var isDropdown = p.Type == "select" || p.Options is { Count: > 0 } || !string.IsNullOrEmpty(p.FieldSource);
+
+                if (isDropdown)
+                {
+                    Write(writer, "<select class=\"form-select form-select-sm\" name=\"");
+                    WriteEncoded(writer, p.Name);
+                    Write(writer, "\">");
+                    Write(writer, "<option value=\"\">— All —</option>");
+                    if (p.Options is { Count: > 0 })
+                    {
+                        foreach (var opt in p.Options)
+                        {
+                            var parts = opt.Split('|', 2);
+                            var optVal = parts[0];
+                            var optLabel = parts.Length > 1 ? parts[1] : parts[0];
+                            Write(writer, "<option value=\"");
+                            WriteEncoded(writer, optVal);
+                            Write(writer, "\"");
+                            if (string.Equals(optVal, val, StringComparison.OrdinalIgnoreCase))
+                                Write(writer, " selected");
+                            Write(writer, ">");
+                            WriteEncoded(writer, optLabel);
+                            Write(writer, "</option>");
+                        }
+                    }
+                    else if (!string.IsNullOrEmpty(p.FieldSource))
+                    {
+                        // Dynamic options loaded server-side at render time
+                        var distinctValues = ResolveDistinctValues(p.FieldSource);
+                        foreach (var dv in distinctValues)
+                        {
+                            Write(writer, "<option value=\"");
+                            WriteEncoded(writer, dv);
+                            Write(writer, "\"");
+                            if (string.Equals(dv, val, StringComparison.OrdinalIgnoreCase))
+                                Write(writer, " selected");
+                            Write(writer, ">");
+                            WriteEncoded(writer, dv);
+                            Write(writer, "</option>");
+                        }
+                    }
+                    Write(writer, "</select>");
+                }
+                else
+                {
+                    var inputType = p.Type switch
+                    {
+                        "date" => "date",
+                        "number" => "number",
+                        "datetime" => "datetime-local",
+                        _ => "text"
+                    };
+                    Write(writer, "<input type=\"");
+                    Write(writer, inputType);
+                    Write(writer, "\" class=\"form-control form-control-sm\" name=\"");
+                    WriteEncoded(writer, p.Name);
+                    Write(writer, "\" value=\"");
+                    WriteEncoded(writer, val);
+                    Write(writer, "\">");
+                }
+
+                Write(writer, "</div>");
             }
-            Write(writer, "<div class=\"col-auto align-self-end\"><button type=\"submit\" class=\"btn btn-primary\"><i class=\"bi bi-play-fill\"></i> Run Report</button></div>");
-            Write(writer, "</form>");
+            Write(writer, "<div class=\"col-auto\"><button type=\"submit\" class=\"btn btn-primary btn-sm\"><i class=\"bi bi-funnel-fill\"></i> Filter</button></div>");
+            Write(writer, "</form></div></div>");
         }
 
         // Results table
@@ -244,5 +304,44 @@ public static class ReportHtmlRenderer
     {
         if (string.IsNullOrEmpty(text)) return;
         Write(writer, WebUtility.HtmlEncode(text));
+    }
+
+    /// <summary>
+    /// Resolves distinct field values for a dynamic dropdown.
+    /// FieldSource format: "entitySlug.fieldName"
+    /// </summary>
+    internal static IReadOnlyList<string> ResolveDistinctValues(string fieldSource)
+    {
+        var dot = fieldSource.IndexOf('.');
+        if (dot < 0) return Array.Empty<string>();
+
+        var entitySlug = fieldSource[..dot];
+        var fieldName = fieldSource[(dot + 1)..];
+
+        if (!BareMetalWeb.Core.DataScaffold.TryGetEntity(entitySlug, out var meta))
+            return Array.Empty<string>();
+
+        var field = meta.Fields.FirstOrDefault(f =>
+            string.Equals(f.Name, fieldName, StringComparison.OrdinalIgnoreCase));
+        if (field == null) return Array.Empty<string>();
+
+        // Load all records and extract distinct non-null values
+        var getter = field.GetValueFn;
+        if (getter == null) return Array.Empty<string>();
+
+        var distinct = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+        var allItems = meta.Handlers.QueryAsync(null, CancellationToken.None).AsTask().GetAwaiter().GetResult();
+        foreach (var item in allItems)
+        {
+            var val = getter(item);
+            if (val != null)
+            {
+                var str = val.ToString();
+                if (!string.IsNullOrWhiteSpace(str))
+                    distinct.Add(str);
+            }
+        }
+
+        return distinct.ToArray();
     }
 }

--- a/BareMetalWeb.Host/RouteRegistrationExtensions.cs
+++ b/BareMetalWeb.Host/RouteRegistrationExtensions.cs
@@ -1470,6 +1470,21 @@ public static class RouteRegistrationExtensions
                 context.Response.ContentType = "application/json";
                 await context.Response.WriteAsync(JsonSerializer.Serialize(json, new JsonSerializerOptions { WriteIndented = false }));
             }));
+
+        // GET /api/reports/_distinct/{entity}/{field} — distinct field values for dropdown population
+        host.RegisterRoute("GET /api/reports/_distinct/{entity}/{field}", new RouteHandlerData(
+            pageInfoFactory.RawPage("admin", false),
+            async context =>
+            {
+                var entitySlug = GetRouteParam(context, "entity") ?? string.Empty;
+                var fieldName = GetRouteParam(context, "field") ?? string.Empty;
+
+                var values = ReportHtmlRenderer.ResolveDistinctValues($"{entitySlug}.{fieldName}");
+
+                context.Response.StatusCode = 200;
+                context.Response.ContentType = "application/json";
+                await context.Response.WriteAsync(JsonSerializer.Serialize(values, new JsonSerializerOptions { WriteIndented = false }));
+            }));
     }
 
     private static string CsvCell(string value)


### PR DESCRIPTION
## Summary
Implements proper report filters shown as a dropdown bar above the report (closes #637).

### Changes

**ReportModels.cs** — Extended `ReportParameter`:
- `Options`: Static list for dropdown (`"value|label"` or `"value"` format)
- `FieldSource`: Dynamic dropdown source (`"entitySlug.fieldName"`) — loads distinct values at render time
- `Type`: Now respected — `date` → date picker, `number` → number input, `select` → dropdown

**ReportHtmlRenderer.cs** — New filter bar:
- Rendered as a card above the report results
- `<select>` dropdowns for params with Options or FieldSource
- `— All —` default option for dropdowns
- Type-appropriate inputs (date, number, datetime-local, text)
- `ResolveDistinctValues()`: loads distinct non-null field values from entity data using compiled getters

**RouteRegistrationExtensions.cs** — New endpoint:
- `GET /api/reports/_distinct/{entity}/{field}` — returns distinct field values as JSON array for client-side dropdown population

### Usage
```json
{
  "parameters": [
    { "name": "status", "label": "Status", "type": "select",
      "options": ["Open|Open", "Closed|Closed", "Pending|Pending"] },
    { "name": "customer", "label": "Customer", "type": "select",
      "fieldSource": "customers.Name" },
    { "name": "fromDate", "label": "From", "type": "date", "defaultValue": "2026-01-01" }
  ]
}
```

Build succeeds (0 errors), all tests pass.