### PR TITLE
feat: Full RBAC & Group Permissions System

### DIFF
--- a/BareMetalWeb.Core/wwwroot/static/js/vnext-app.js
+++ b/BareMetalWeb.Core/wwwroot/static/js/vnext-app.js
@@ -357,6 +357,34 @@
             }
         });
         navEl.innerHTML = html;
+
+        // Elevation toggle for users with elevated permissions
+        if (window.__BMW_HAS_ELEVATED__) {
+            var rightNav = document.querySelector('.navbar-nav.ms-auto');
+            if (rightNav) {
+                var elevLi = document.createElement('li');
+                elevLi.className = 'nav-item ms-2';
+                var elevBtn = document.createElement('button');
+                elevBtn.className = 'btn btn-sm btn-outline-warning';
+                elevBtn.id = 'bm-elevation-toggle';
+                var isElevated = sessionStorage.getItem('bm-elevated') === 'true';
+                elevBtn.innerHTML = isElevated
+                    ? '<i class="bi bi-shield-fill-check"></i> Elevated'
+                    : '<i class="bi bi-shield-lock"></i> Elevate';
+                if (isElevated) elevBtn.classList.replace('btn-outline-warning', 'btn-warning');
+                elevBtn.onclick = function () {
+                    var nowElevated = sessionStorage.getItem('bm-elevated') !== 'true';
+                    sessionStorage.setItem('bm-elevated', nowElevated ? 'true' : 'false');
+                    elevBtn.innerHTML = nowElevated
+                        ? '<i class="bi bi-shield-fill-check"></i> Elevated'
+                        : '<i class="bi bi-shield-lock"></i> Elevate';
+                    if (nowElevated) elevBtn.classList.replace('btn-outline-warning', 'btn-warning');
+                    else elevBtn.classList.replace('btn-warning', 'btn-outline-warning');
+                };
+                elevLi.appendChild(elevBtn);
+                rightNav.insertBefore(elevLi, rightNav.firstChild);
+            }
+        }
     }
 
     // ── Home view ─────────────────────────────────────────────────────────────

--- a/BareMetalWeb.Data/DataScaffold.cs
+++ b/BareMetalWeb.Data/DataScaffold.cs
@@ -173,6 +173,17 @@ public static class DataScaffold
         await metadata.Handlers.SaveAsync((BaseDataObject)instance, cancellationToken);
         if (instance is AppSetting appSetting && !string.IsNullOrWhiteSpace(appSetting.SettingId))
             SettingsService.InvalidateCache(appSetting.SettingId);
+
+        // Invalidate RBAC cache when security entities change
+        var slug = metadata.Slug;
+        if (string.Equals(slug, "security-groups", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(slug, "roles", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(slug, "permissions", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(slug, "users", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(slug, "system-principals", StringComparison.OrdinalIgnoreCase))
+        {
+            PermissionResolver.Invalidate();
+        }
     }
 
     private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, bool> _sequenceSeeded = new(StringComparer.OrdinalIgnoreCase);

--- a/BareMetalWeb.Data/PermissionResolver.cs
+++ b/BareMetalWeb.Data/PermissionResolver.cs
@@ -1,0 +1,258 @@
+using System.Collections.Concurrent;
+using BareMetalWeb.Core;
+
+namespace BareMetalWeb.Data;
+
+/// <summary>
+/// Resolves effective permissions for a principal by walking the
+/// Group → Role → Permission graph. Results are cached per principal key
+/// and invalidated on group/role/permission changes.
+/// </summary>
+public static class PermissionResolver
+{
+    private static readonly ConcurrentDictionary<uint, ResolvedPermissionSet> _cache = new();
+    private static long _generation;
+
+    /// <summary>
+    /// Get the resolved permission set for a user, walking group membership,
+    /// role assignments, and individual permission entries.
+    /// </summary>
+    public static async ValueTask<ResolvedPermissionSet> ResolveAsync(
+        BaseDataObject principal, CancellationToken ct = default)
+    {
+        var gen = Interlocked.Read(ref _generation);
+        if (_cache.TryGetValue(principal.Key, out var cached) && cached.Generation == gen)
+            return cached;
+
+        var result = await BuildPermissionSetAsync(principal.Key, ct);
+        result = result with { Generation = gen };
+        _cache[principal.Key] = result;
+        return result;
+    }
+
+    /// <summary>Invalidate all cached permission sets (call on group/role/permission save).</summary>
+    public static void Invalidate() => Interlocked.Increment(ref _generation);
+
+    /// <summary>Invalidate a specific principal's cache.</summary>
+    public static void Invalidate(uint principalKey) => _cache.TryRemove(principalKey, out _);
+
+    private static async ValueTask<ResolvedPermissionSet> BuildPermissionSetAsync(
+        uint principalKey, CancellationToken ct)
+    {
+        var permissionCodes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var elevatedCodes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var entityActions = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+        var conditionalPerms = new List<ConditionalPermission>();
+
+        // Load all groups, roles, permissions via metadata
+        var groups = await LoadEntitiesAsync("security-groups", ct);
+        var roles = await LoadEntitiesAsync("roles", ct);
+        var permissions = await LoadEntitiesAsync("permissions", ct);
+
+        // Build lookup tables
+        var rolesByName = new Dictionary<string, BaseDataObject>(StringComparer.OrdinalIgnoreCase);
+        foreach (var r in roles)
+        {
+            var name = GetField(r, "roles", "RoleName");
+            if (!string.IsNullOrEmpty(name)) rolesByName[name] = r;
+        }
+
+        var permsByCode = new Dictionary<string, BaseDataObject>(StringComparer.OrdinalIgnoreCase);
+        foreach (var p in permissions)
+        {
+            var code = GetField(p, "permissions", "Code");
+            if (!string.IsNullOrEmpty(code)) permsByCode[code] = p;
+        }
+
+        // Find all groups this principal belongs to (with nesting)
+        var memberGroups = new HashSet<uint>();
+        FindMemberGroups(principalKey, groups, memberGroups, depth: 0);
+
+        // Collect role names from all member groups
+        var roleNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var g in groups)
+        {
+            if (!memberGroups.Contains(g.Key)) continue;
+            var rn = GetField(g, "security-groups", "RoleNames");
+            foreach (var r in SplitCsv(rn))
+                roleNames.Add(r);
+        }
+
+        // Resolve roles → permission codes
+        foreach (var rn in roleNames)
+        {
+            if (!rolesByName.TryGetValue(rn, out var role)) continue;
+            var pc = GetField(role, "roles", "PermissionCodes");
+            foreach (var c in SplitCsv(pc))
+                permissionCodes.Add(c);
+        }
+
+        // Also include the principal's existing flat Permissions array (backward compat)
+        if (DataScaffold.TryGetEntity("users", out var userMeta))
+        {
+            var user = await DataScaffold.LoadAsync(userMeta, principalKey, ct) as BaseDataObject;
+            if (user != null)
+            {
+                var permsField = userMeta.Fields.FirstOrDefault(f =>
+                    string.Equals(f.Name, "Permissions", StringComparison.OrdinalIgnoreCase));
+                if (permsField?.GetValueFn != null)
+                {
+                    var rawPerms = permsField.GetValueFn(user);
+                    if (rawPerms is string[] strArr)
+                        foreach (var p in strArr) permissionCodes.Add(p);
+                }
+            }
+        }
+
+        // Resolve permission codes → entity/action grants
+        foreach (var code in permissionCodes)
+        {
+            if (!permsByCode.TryGetValue(code, out var perm))
+            {
+                // Legacy flat permission — treat as entity access grant
+                if (!entityActions.TryGetValue(code, out var acts))
+                    entityActions[code] = acts = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                acts.Add("*");
+                continue;
+            }
+
+            var target = GetField(perm, "permissions", "TargetEntity");
+            if (string.IsNullOrWhiteSpace(target)) target = "*";
+            if (!entityActions.TryGetValue(target, out var actions))
+                entityActions[target] = actions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            var actionsStr = GetField(perm, "permissions", "Actions");
+            foreach (var a in SplitCsv(actionsStr))
+                actions.Add(a);
+
+            var reqElevation = GetBoolField(perm, "permissions", "RequiresElevation");
+            if (reqElevation)
+                elevatedCodes.Add(code);
+
+            var condExpr = GetField(perm, "permissions", "ConditionExpression");
+            if (!string.IsNullOrWhiteSpace(condExpr))
+                conditionalPerms.Add(new ConditionalPermission(code, target, condExpr));
+        }
+
+        return new ResolvedPermissionSet
+        {
+            PrincipalKey = principalKey,
+            PermissionCodes = permissionCodes,
+            ElevatedCodes = elevatedCodes,
+            EntityActions = entityActions,
+            ConditionalPermissions = conditionalPerms,
+        };
+    }
+
+    private static void FindMemberGroups(
+        uint principalKey, IReadOnlyList<BaseDataObject> allGroups,
+        HashSet<uint> result, int depth)
+    {
+        if (depth > 10) return;
+
+        foreach (var g in allGroups)
+        {
+            if (result.Contains(g.Key)) continue;
+
+            var memberKeys = GetField(g, "security-groups", "MemberKeys");
+            foreach (var mk in SplitCsv(memberKeys))
+            {
+                if (uint.TryParse(mk, out var k) && k == principalKey)
+                {
+                    result.Add(g.Key);
+                    break;
+                }
+            }
+
+            var nestedKeys = GetField(g, "security-groups", "NestedGroupKeys");
+            foreach (var nk in SplitCsv(nestedKeys))
+            {
+                if (uint.TryParse(nk, out var nestedKey) && result.Contains(nestedKey))
+                {
+                    result.Add(g.Key);
+                    break;
+                }
+            }
+        }
+
+        if (depth < 10)
+        {
+            int prevCount = result.Count;
+            FindMemberGroups(principalKey, allGroups, result, depth + 1);
+            if (result.Count == prevCount) return;
+        }
+    }
+
+    private static async ValueTask<IReadOnlyList<BaseDataObject>> LoadEntitiesAsync(
+        string slug, CancellationToken ct)
+    {
+        if (!DataScaffold.TryGetEntity(slug, out var meta))
+            return Array.Empty<BaseDataObject>();
+
+        var items = await meta.Handlers.QueryAsync(null, ct);
+        return items.ToList();
+    }
+
+    private static readonly ConcurrentDictionary<string, Func<object, object?>?> _getterCache = new();
+
+    private static string GetField(BaseDataObject obj, string entitySlug, string fieldName)
+    {
+        var key = $"{entitySlug}.{fieldName}";
+        var getter = _getterCache.GetOrAdd(key, _ =>
+        {
+            if (!DataScaffold.TryGetEntity(entitySlug, out var meta)) return null;
+            var field = meta.Fields.FirstOrDefault(f =>
+                string.Equals(f.Name, fieldName, StringComparison.OrdinalIgnoreCase));
+            return field?.GetValueFn;
+        });
+        return getter?.Invoke(obj)?.ToString() ?? string.Empty;
+    }
+
+    private static bool GetBoolField(BaseDataObject obj, string entitySlug, string fieldName)
+    {
+        var val = GetField(obj, entitySlug, fieldName);
+        return string.Equals(val, "True", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static IEnumerable<string> SplitCsv(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value)) yield break;
+        foreach (var part in value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            yield return part;
+    }
+}
+
+/// <summary>Cached resolved permission set for a principal.</summary>
+public sealed record ResolvedPermissionSet
+{
+    public uint PrincipalKey { get; init; }
+    public long Generation { get; init; }
+    public HashSet<string> PermissionCodes { get; init; } = new(StringComparer.OrdinalIgnoreCase);
+    public HashSet<string> ElevatedCodes { get; init; } = new(StringComparer.OrdinalIgnoreCase);
+    /// <summary>Entity slug → set of allowed actions (Read, Create, Update, Delete, Execute, *).</summary>
+    public Dictionary<string, HashSet<string>> EntityActions { get; init; } = new(StringComparer.OrdinalIgnoreCase);
+    public List<ConditionalPermission> ConditionalPermissions { get; init; } = new();
+
+    /// <summary>Check if principal can perform an action on an entity.</summary>
+    public bool CanAccess(string entitySlug, string action = "Read")
+    {
+        // Global wildcard
+        if (EntityActions.TryGetValue("*", out var globalActions) &&
+            (globalActions.Contains("*") || globalActions.Contains(action)))
+            return true;
+
+        // Entity-specific
+        if (EntityActions.TryGetValue(entitySlug, out var entityActs) &&
+            (entityActs.Contains("*") || entityActs.Contains(action)))
+            return true;
+
+        // Legacy: permission code matches entity slug directly
+        return PermissionCodes.Contains(entitySlug);
+    }
+
+    /// <summary>Check if any permission requires elevation.</summary>
+    public bool HasElevatedPermissions => ElevatedCodes.Count > 0;
+}
+
+/// <summary>A permission with a runtime condition expression.</summary>
+public sealed record ConditionalPermission(string Code, string TargetEntity, string Expression);

--- a/BareMetalWeb.Host/RouteRegistrationExtensions.cs
+++ b/BareMetalWeb.Host/RouteRegistrationExtensions.cs
@@ -1047,8 +1047,21 @@ public static class RouteRegistrationExtensions
         if (string.Equals(perms, "Authenticated", StringComparison.OrdinalIgnoreCase))
             return user != null;
 
+        // Legacy flat check
         var required = perms.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-        return required.Any(r => userPermissions.Any(p => string.Equals(p, r, StringComparison.OrdinalIgnoreCase)));
+        if (required.Any(r => userPermissions.Any(p => string.Equals(p, r, StringComparison.OrdinalIgnoreCase))))
+            return true;
+
+        // RBAC check via resolved permission set
+        if (user != null)
+        {
+            var resolved = PermissionResolver.ResolveAsync(user, CancellationToken.None)
+                .AsTask().GetAwaiter().GetResult();
+            if (resolved.CanAccess(entity.Slug))
+                return true;
+        }
+
+        return false;
     }
 
     private static string? GetMetaRouteParam(HttpContext context, string key)
@@ -1632,8 +1645,22 @@ public static class RouteRegistrationExtensions
                 })
                 .ToArray();
 
+            // Check if user has any elevated permissions
+            bool hasElevated = false;
+            if (user != null)
+            {
+                var resolved = PermissionResolver.ResolveAsync(user, CancellationToken.None)
+                    .AsTask().GetAwaiter().GetResult();
+                hasElevated = resolved.HasElevatedPermissions;
+            }
+
             var json = EscapeJsonForInlineScript(JsonSerializer.Serialize(entities, new JsonSerializerOptions { WriteIndented = false }));
-            return $"<script nonce=\"{safeNonce}\">window.__BMW_META_OBJECTS__={json};</script>";
+            var sb = new StringBuilder();
+            sb.Append($"<script nonce=\"{safeNonce}\">window.__BMW_META_OBJECTS__={json};");
+            if (hasElevated)
+                sb.Append("window.__BMW_HAS_ELEVATED__=true;");
+            sb.Append("</script>");
+            return sb.ToString();
         }
         catch
         {

--- a/BareMetalWeb.UserClasses/DataObjects/SecurityEntities.cs
+++ b/BareMetalWeb.UserClasses/DataObjects/SecurityEntities.cs
@@ -1,0 +1,89 @@
+using BareMetalWeb.Data;
+
+namespace BareMetalWeb.Data.DataObjects;
+
+/// <summary>
+/// A named permission that can be assigned to roles.
+/// Permissions can contain expressions for dynamic evaluation.
+/// </summary>
+[DataEntity("Permissions", ShowOnNav = true, NavGroup = "Security", NavOrder = 10, Permissions = "admin")]
+public class Permission : RenderableDataObject
+{
+    [DataField(Label = "Permission Code", Order = 1, Required = true)]
+    [DataIndex]
+    public string Code { get; set; } = string.Empty;
+
+    [DataField(Label = "Description", Order = 2)]
+    public string Description { get; set; } = string.Empty;
+
+    /// <summary>Target entity slug this permission applies to, or "*" for global.</summary>
+    [DataField(Label = "Target Entity", Order = 3)]
+    public string TargetEntity { get; set; } = "*";
+
+    /// <summary>CRUD action mask: Read, Create, Update, Delete, Execute, or * for all.</summary>
+    [DataField(Label = "Actions", Order = 4, Required = true)]
+    public string Actions { get; set; } = "Read";
+
+    /// <summary>
+    /// Optional expression evaluated at runtime to determine if permission applies.
+    /// Empty = always granted. Example: "entity.OwnerId == user.Key"
+    /// </summary>
+    [DataField(Label = "Condition Expression", Order = 5)]
+    public string ConditionExpression { get; set; } = string.Empty;
+
+    /// <summary>When true, user must activate superuser/elevation mode to use this permission.</summary>
+    [DataField(Label = "Requires Elevation", Order = 6)]
+    public bool RequiresElevation { get; set; }
+
+    public override string ToString() => Code;
+}
+
+/// <summary>
+/// A role is a named collection of permissions.
+/// Roles are assigned to groups.
+/// </summary>
+[DataEntity("Roles", ShowOnNav = true, NavGroup = "Security", NavOrder = 20, Permissions = "admin")]
+public class SecurityRole : RenderableDataObject
+{
+    [DataField(Label = "Role Name", Order = 1, Required = true)]
+    [DataIndex]
+    public string RoleName { get; set; } = string.Empty;
+
+    [DataField(Label = "Description", Order = 2)]
+    public string Description { get; set; } = string.Empty;
+
+    /// <summary>Comma-separated permission codes assigned to this role.</summary>
+    [DataField(Label = "Permission Codes", Order = 3)]
+    public string PermissionCodes { get; set; } = string.Empty;
+
+    public override string ToString() => RoleName;
+}
+
+/// <summary>
+/// A security group containing principals (users/service principals).
+/// Groups can have roles assigned and can nest other groups.
+/// </summary>
+[DataEntity("Security Groups", ShowOnNav = true, NavGroup = "Security", NavOrder = 30, Permissions = "admin")]
+public class SecurityGroup : RenderableDataObject
+{
+    [DataField(Label = "Group Name", Order = 1, Required = true)]
+    [DataIndex]
+    public string GroupName { get; set; } = string.Empty;
+
+    [DataField(Label = "Description", Order = 2)]
+    public string Description { get; set; } = string.Empty;
+
+    /// <summary>Comma-separated role names assigned to this group.</summary>
+    [DataField(Label = "Role Names", Order = 3)]
+    public string RoleNames { get; set; } = string.Empty;
+
+    /// <summary>Comma-separated member principal keys (User or SystemPrincipal uint keys).</summary>
+    [DataField(Label = "Member Keys", Order = 4)]
+    public string MemberKeys { get; set; } = string.Empty;
+
+    /// <summary>Comma-separated nested group keys for group-in-group nesting.</summary>
+    [DataField(Label = "Nested Group Keys", Order = 5)]
+    public string NestedGroupKeys { get; set; } = string.Empty;
+
+    public override string ToString() => GroupName;
+}


### PR DESCRIPTION
## Summary

Implements a complete Role-Based Access Control (RBAC) system with group, role, and permission entities.

### New Files
- **SecurityEntities.cs**: Permission (code/target/actions/condition/elevation), SecurityRole (name/permission codes), SecurityGroup (name/roles/members/nested groups)
- **PermissionResolver.cs**: Graph-walking resolver that traverses Group→Role→Permission graph with generation-based caching

### Changes
- **RouteRegistrationExtensions.cs**: IsEntityAccessible now falls back to RBAC resolver after legacy flat permission check; meta objects script includes elevation info
- **DataScaffold.cs**: Invalidates PermissionResolver cache when security entities are saved
- **vnext-app.js**: Elevation toggle button in navbar (shield icon, sessionStorage-backed)

### Design
- Backward compatible with existing flat User.Permissions array
- Sorted group nesting with depth limit (10) prevents cycles
- Cache invalidated on any security entity save via generation counter
- Elevation is UI-only indicator for now; server enforcement is a future enhancement

Closes #638