### PR TITLE
feat: Domain Event Subscription Model (Deterministic Action Hooks)

### DIFF
--- a/BareMetalWeb.Data/DataScaffold.cs
+++ b/BareMetalWeb.Data/DataScaffold.cs
@@ -184,6 +184,12 @@ public static class DataScaffold
         {
             PermissionResolver.Invalidate();
         }
+
+        // Invalidate domain event subscription cache
+        if (string.Equals(slug, "domain-event-subscriptions", StringComparison.OrdinalIgnoreCase))
+        {
+            DomainEventDispatcher.Invalidate();
+        }
     }
 
     private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, bool> _sequenceSeeded = new(StringComparer.OrdinalIgnoreCase);

--- a/BareMetalWeb.Data/DomainEventDispatcher.cs
+++ b/BareMetalWeb.Data/DomainEventDispatcher.cs
@@ -1,0 +1,261 @@
+using System.Collections.Concurrent;
+using BareMetalWeb.Core;
+
+namespace BareMetalWeb.Data;
+
+/// <summary>
+/// Evaluates domain event subscriptions after a successful commit.
+/// Subscriptions are declarative (entity + field + value → action) and
+/// fire inside the same lock scope — deterministic and replay-safe.
+///
+/// Constraints:
+/// - Flat only — event-triggered actions may NOT themselves fire events (depth=0)
+/// - No cross-aggregate arbitrary mutation — respects the lock model
+/// - No recursion or nested chains
+/// </summary>
+public static class DomainEventDispatcher
+{
+    private static volatile int _generation;
+    private static int _cachedGeneration = -1;
+    private static IReadOnlyList<SubscriptionEntry> _cachedSubscriptions = Array.Empty<SubscriptionEntry>();
+    private static readonly object _cacheLock = new();
+
+    /// <summary>Increment to invalidate subscription cache.</summary>
+    public static void Invalidate() => Interlocked.Increment(ref _generation);
+
+    /// <summary>
+    /// Evaluate all matching subscriptions for mutations that occurred in a committed envelope.
+    /// Called by TransactionCommitEngine after save, inside lock scope.
+    /// Returns fired action results (empty if no subscriptions matched).
+    /// </summary>
+    public static async ValueTask<IReadOnlyList<DomainEventResult>> DispatchAsync(
+        TransactionEnvelope envelope,
+        IReadOnlyDictionary<string, (DataEntityMetadata Meta, BaseDataObject BeforeEntity, BaseDataObject AfterEntity, EntityLayout Layout)> entityStates,
+        Func<string, ActionDef?> actionResolver,
+        TransactionCommitEngine commitEngine,
+        string userName,
+        CancellationToken ct)
+    {
+        var subscriptions = await GetSubscriptionsAsync(ct);
+        if (subscriptions.Count == 0) return Array.Empty<DomainEventResult>();
+
+        var results = new List<DomainEventResult>();
+
+        foreach (var mutation in envelope.Mutations)
+        {
+            var key = $"{mutation.AggregateType}:{mutation.AggregateId}";
+            if (!entityStates.TryGetValue(key, out var state)) continue;
+
+            // Find subscriptions for this entity type
+            var matching = FindMatchingSubscriptions(
+                subscriptions, mutation.AggregateType, state.BeforeEntity, state.AfterEntity, state.Layout);
+
+            foreach (var sub in matching)
+            {
+                var result = await FireSubscriptionAsync(
+                    sub, state, mutation, actionResolver, commitEngine, userName, ct);
+                results.Add(result);
+
+                // If any event-triggered action fails with Error, stop processing
+                // further events for this envelope (fail-fast)
+                if (!result.Success && result.IsHardFailure)
+                    return results;
+            }
+        }
+
+        return results;
+    }
+
+    private static List<SubscriptionEntry> FindMatchingSubscriptions(
+        IReadOnlyList<SubscriptionEntry> all,
+        string entitySlug,
+        BaseDataObject before,
+        BaseDataObject after,
+        EntityLayout layout)
+    {
+        var matched = new List<SubscriptionEntry>();
+
+        foreach (var sub in all)
+        {
+            if (!string.Equals(sub.SourceEntity, entitySlug, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            // No watch field = fire on any save
+            if (string.IsNullOrEmpty(sub.WatchField))
+            {
+                matched.Add(sub);
+                continue;
+            }
+
+            // Find the field in the layout
+            var fieldIdx = -1;
+            for (int i = 0; i < layout.Fields.Length; i++)
+            {
+                if (string.Equals(layout.Fields[i].Name, sub.WatchField, StringComparison.OrdinalIgnoreCase))
+                {
+                    fieldIdx = i;
+                    break;
+                }
+            }
+            if (fieldIdx < 0) continue;
+
+            var field = layout.Fields[fieldIdx];
+            var beforeVal = field.Getter(before)?.ToString() ?? string.Empty;
+            var afterVal = field.Getter(after)?.ToString() ?? string.Empty;
+
+            // Value didn't change — skip
+            if (string.Equals(beforeVal, afterVal, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            // Check FROM value constraint
+            if (!string.IsNullOrEmpty(sub.FromValue) &&
+                !string.Equals(beforeVal, sub.FromValue, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            // Check TO value constraint
+            if (!string.IsNullOrEmpty(sub.TriggerValue) &&
+                !string.Equals(afterVal, sub.TriggerValue, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            matched.Add(sub);
+        }
+
+        // Sort by priority (lower first)
+        matched.Sort((a, b) => a.Priority.CompareTo(b.Priority));
+        return matched;
+    }
+
+    private static async ValueTask<DomainEventResult> FireSubscriptionAsync(
+        SubscriptionEntry sub,
+        (DataEntityMetadata Meta, BaseDataObject BeforeEntity, BaseDataObject AfterEntity, EntityLayout Layout) state,
+        AggregateMutation sourceMutation,
+        Func<string, ActionDef?> actionResolver,
+        TransactionCommitEngine commitEngine,
+        string userName,
+        CancellationToken ct)
+    {
+        // Resolve target action
+        var action = actionResolver(sub.TargetAction);
+        if (action == null)
+            return new DomainEventResult(sub.Name, sub.TargetAction, false, "ACTION_NOT_FOUND",
+                $"Target action '{sub.TargetAction}' not found.", IsHardFailure: false);
+
+        // Resolve target aggregate key
+        uint targetKey;
+        if (string.Equals(sub.TargetResolution, "self", StringComparison.OrdinalIgnoreCase))
+        {
+            targetKey = state.AfterEntity.Key;
+        }
+        else if (sub.TargetResolution.StartsWith("field:", StringComparison.OrdinalIgnoreCase))
+        {
+            var fieldName = sub.TargetResolution[6..];
+            var fieldIdx = -1;
+            for (int i = 0; i < state.Layout.Fields.Length; i++)
+            {
+                if (string.Equals(state.Layout.Fields[i].Name, fieldName, StringComparison.OrdinalIgnoreCase))
+                {
+                    fieldIdx = i;
+                    break;
+                }
+            }
+
+            if (fieldIdx < 0)
+                return new DomainEventResult(sub.Name, sub.TargetAction, false, "FIELD_NOT_FOUND",
+                    $"Target resolution field '{fieldName}' not found.", IsHardFailure: false);
+
+            var val = state.Layout.Fields[fieldIdx].Getter(state.AfterEntity);
+            if (val is uint uintVal) targetKey = uintVal;
+            else if (uint.TryParse(val?.ToString(), out var parsed)) targetKey = parsed;
+            else
+                return new DomainEventResult(sub.Name, sub.TargetAction, false, "INVALID_TARGET",
+                    $"Could not resolve target key from field '{fieldName}'.", IsHardFailure: false);
+        }
+        else
+        {
+            return new DomainEventResult(sub.Name, sub.TargetAction, false, "INVALID_RESOLUTION",
+                $"Unknown target resolution '{sub.TargetResolution}'.", IsHardFailure: false);
+        }
+
+        // Fire the action — depth guard prevents nested event chains
+        try
+        {
+            var result = await commitEngine.ExecuteActionAsync(
+                action, targetKey, parameters: null, actionResolver, userName, ct);
+
+            return new DomainEventResult(
+                sub.Name, sub.TargetAction, result.Success,
+                result.ErrorCode, result.ErrorMessage,
+                IsHardFailure: !result.Success && result.ErrorCode != "LOCK_TIMEOUT");
+        }
+        catch (Exception ex)
+        {
+            return new DomainEventResult(sub.Name, sub.TargetAction, false, "DISPATCH_ERROR",
+                ex.Message, IsHardFailure: false);
+        }
+    }
+
+    /// <summary>Load and cache subscriptions from the data store.</summary>
+    private static async ValueTask<IReadOnlyList<SubscriptionEntry>> GetSubscriptionsAsync(CancellationToken ct)
+    {
+        var gen = _generation;
+        if (gen == _cachedGeneration) return _cachedSubscriptions;
+
+        lock (_cacheLock)
+        {
+            if (gen == _cachedGeneration) return _cachedSubscriptions;
+        }
+
+        if (!DataScaffold.TryGetEntity("domain-event-subscriptions", out var meta))
+            return Array.Empty<SubscriptionEntry>();
+
+        var items = await meta.Handlers.QueryAsync(null, ct);
+        var entries = new List<SubscriptionEntry>();
+
+        foreach (var item in items)
+        {
+            var enabled = GetField(item, meta, "Enabled");
+            if (string.Equals(enabled, "False", StringComparison.OrdinalIgnoreCase)) continue;
+
+            entries.Add(new SubscriptionEntry(
+                Name: GetField(item, meta, "Name"),
+                SourceEntity: GetField(item, meta, "SourceEntity"),
+                WatchField: GetField(item, meta, "WatchField"),
+                TriggerValue: GetField(item, meta, "TriggerValue"),
+                FromValue: GetField(item, meta, "FromValue"),
+                TargetAction: GetField(item, meta, "TargetAction"),
+                TargetResolution: GetField(item, meta, "TargetResolution"),
+                Priority: int.TryParse(GetField(item, meta, "Priority"), out var p) ? p : 100));
+        }
+
+        entries.Sort((a, b) => a.Priority.CompareTo(b.Priority));
+
+        lock (_cacheLock)
+        {
+            _cachedSubscriptions = entries;
+            _cachedGeneration = gen;
+        }
+
+        return entries;
+    }
+
+    private static string GetField(BaseDataObject obj, DataEntityMetadata meta, string fieldName)
+    {
+        var field = meta.Fields.FirstOrDefault(f =>
+            string.Equals(f.Name, fieldName, StringComparison.OrdinalIgnoreCase));
+        return field?.GetValueFn?.Invoke(obj)?.ToString() ?? string.Empty;
+    }
+
+    private sealed record SubscriptionEntry(
+        string Name, string SourceEntity, string WatchField,
+        string TriggerValue, string FromValue, string TargetAction,
+        string TargetResolution, int Priority);
+}
+
+/// <summary>Result of a domain event subscription firing.</summary>
+public sealed record DomainEventResult(
+    string SubscriptionName,
+    string TargetAction,
+    bool Success,
+    string? ErrorCode,
+    string? ErrorMessage,
+    bool IsHardFailure);

--- a/BareMetalWeb.Data/TransactionCommitEngine.cs
+++ b/BareMetalWeb.Data/TransactionCommitEngine.cs
@@ -14,20 +14,26 @@ namespace BareMetalWeb.Data;
 public sealed class TransactionCommitEngine
 {
     private readonly AggregateLockManager _lockManager;
+    private Func<string, ActionDef?>? _actionResolver;
 
     public TransactionCommitEngine(AggregateLockManager lockManager)
     {
         _lockManager = lockManager;
     }
 
+    /// <summary>Set the action resolver (called once during initialization from Host layer).</summary>
+    public void SetActionResolver(Func<string, ActionDef?> resolver) => _actionResolver = resolver;
+
     /// <summary>
     /// Commit a transaction envelope.
     /// All validation occurs inside lock scope.
+    /// Domain event subscriptions fire after save, inside the same lock scope.
     /// </summary>
     public async ValueTask<TransactionResult> CommitAsync(
         TransactionEnvelope envelope,
         string userName,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        bool allowEventDispatch = true)
     {
         // 1. Acquire all locks in sorted order
         using var lockHandle = _lockManager.AcquireAll(
@@ -52,6 +58,13 @@ public sealed class TransactionCommitEngine
 
                 var layout = EntityLayoutCompiler.GetOrCompile(meta);
                 loadedEntities[key] = (meta, entity, layout);
+            }
+
+            // Snapshot before-state for domain event detection
+            var beforeSnapshots = new Dictionary<string, BaseDataObject>();
+            foreach (var (key, (meta, entity, _)) in loadedEntities)
+            {
+                beforeSnapshots[key] = CloneEntity(entity, meta);
             }
 
             // 3. Apply mutations to working copies
@@ -126,7 +139,31 @@ public sealed class TransactionCommitEngine
                 await DataScaffold.SaveAsync(meta, entity, cancellationToken);
             }
 
-            // 6. Success
+            // 6. Dispatch domain event subscriptions (flat only — no nested events)
+            if (allowEventDispatch && _actionResolver != null)
+            {
+                var entityStates = new Dictionary<string, (DataEntityMetadata, BaseDataObject, BaseDataObject, EntityLayout)>();
+                foreach (var (key, (meta, entity, layout)) in loadedEntities)
+                {
+                    if (beforeSnapshots.TryGetValue(key, out var before))
+                        entityStates[key] = (meta, before, entity, layout);
+                }
+
+                var eventResults = await DomainEventDispatcher.DispatchAsync(
+                    envelope, entityStates, _actionResolver,
+                    this, userName, cancellationToken);
+
+                // Collect event warnings/errors
+                foreach (var er in eventResults)
+                {
+                    if (!er.Success)
+                        warnings.Add(new TransactionWarning(
+                            er.ErrorCode ?? "EVENT_FAILED",
+                            $"[Event:{er.SubscriptionName}] {er.ErrorMessage}"));
+                }
+            }
+
+            // 7. Success
             return new TransactionResult(
                 Success: true,
                 ErrorCode: null,
@@ -169,4 +206,22 @@ public sealed class TransactionCommitEngine
 
     private static TransactionResult Fail(string code, string message)
         => new(Success: false, ErrorCode: code, ErrorMessage: message, Warnings: null);
+
+    /// <summary>
+    /// Shallow clone an entity to capture before-state for event comparison.
+    /// Copies all field values via the layout getter/setter pairs.
+    /// </summary>
+    private static BaseDataObject CloneEntity(BaseDataObject source, DataEntityMetadata meta)
+    {
+        var clone = (BaseDataObject)Activator.CreateInstance(source.GetType())!;
+        clone.Key = source.Key;
+
+        var layout = EntityLayoutCompiler.GetOrCompile(meta);
+        foreach (var field in layout.Fields)
+        {
+            try { field.Setter(clone, field.Getter(source)); }
+            catch { /* skip non-clonable fields */ }
+        }
+        return clone;
+    }
 }

--- a/BareMetalWeb.Host/ActionApiHandlers.cs
+++ b/BareMetalWeb.Host/ActionApiHandlers.cs
@@ -22,6 +22,7 @@ public static class ActionApiHandlers
     {
         _lockManager = new AggregateLockManager();
         _commitEngine = new TransactionCommitEngine(_lockManager);
+        _commitEngine.SetActionResolver(ResolveAction);
     }
 
     /// <summary>Register an action definition.</summary>

--- a/BareMetalWeb.UserClasses/DataObjects/DomainEventSubscription.cs
+++ b/BareMetalWeb.UserClasses/DataObjects/DomainEventSubscription.cs
@@ -1,0 +1,71 @@
+using BareMetalWeb.Data;
+
+namespace BareMetalWeb.Data.DataObjects;
+
+/// <summary>
+/// Declarative domain event subscription: when a field on an entity
+/// transitions to a specific value, fire a registered action on a target aggregate.
+/// No scripting — deterministic, replay-safe, runs inside commit pipeline.
+/// </summary>
+[DataEntity("Domain Event Subscriptions", ShowOnNav = true, NavGroup = "Automation", NavOrder = 10, Permissions = "admin")]
+public class DomainEventSubscription : RenderableDataObject
+{
+    /// <summary>Human-readable label for this subscription.</summary>
+    [DataField(Label = "Name", Order = 1, Required = true)]
+    [DataIndex]
+    public string Name { get; set; } = string.Empty;
+
+    [DataField(Label = "Description", Order = 2)]
+    public string Description { get; set; } = string.Empty;
+
+    /// <summary>Entity slug that triggers this event (e.g. "orders").</summary>
+    [DataField(Label = "Source Entity", Order = 3, Required = true)]
+    [DataIndex]
+    public string SourceEntity { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Field name to watch for state transitions.
+    /// Empty = fire on any save of the source entity.
+    /// </summary>
+    [DataField(Label = "Watch Field", Order = 4)]
+    public string WatchField { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Value the watch field must transition TO for the event to fire.
+    /// Empty = fire on any change to the watch field.
+    /// </summary>
+    [DataField(Label = "Trigger Value", Order = 5)]
+    public string TriggerValue { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Optional: value the watch field must transition FROM.
+    /// Empty = fire regardless of previous value.
+    /// </summary>
+    [DataField(Label = "From Value", Order = 6)]
+    public string FromValue { get; set; } = string.Empty;
+
+    /// <summary>Entity slug + action ID to fire (format: "entity-slug:actionId").</summary>
+    [DataField(Label = "Target Action", Order = 7, Required = true)]
+    public string TargetAction { get; set; } = string.Empty;
+
+    /// <summary>
+    /// How to resolve the target aggregate for the action.
+    /// "self" = same aggregate that triggered the event.
+    /// "field:FieldName" = use the value of FieldName on the source entity as the target aggregate key.
+    /// </summary>
+    [DataField(Label = "Target Resolution", Order = 8)]
+    public string TargetResolution { get; set; } = "self";
+
+    /// <summary>Whether this subscription is active.</summary>
+    [DataField(Label = "Enabled", Order = 9)]
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Execution priority (lower = runs first). Subscriptions for the same
+    /// source entity are evaluated in priority order.
+    /// </summary>
+    [DataField(Label = "Priority", Order = 10)]
+    public int Priority { get; set; } = 100;
+
+    public override string ToString() => Name;
+}


### PR DESCRIPTION
Implements declarative domain event subscriptions — when a field on an entity transitions to a specific value, fire a registered action on a target aggregate.

### New Files
- **DomainEventSubscription.cs**: Entity with source entity, watch field, trigger/from values, target action, resolution strategy, priority, enabled flag
- **DomainEventDispatcher.cs**: Evaluates subscriptions after commit, fires matching actions (flat only — no nested event chains), generation-cached

### Modified Files
- **TransactionCommitEngine.cs**: Captures before-state snapshots, dispatches events after save inside lock scope, CloneEntity helper, SetActionResolver for dependency inversion
- **ActionApiHandlers.cs**: Wires action resolver into commit engine
- **DataScaffold.cs**: Cache invalidation for domain-event-subscriptions entity

### Design
- Flat only — event-triggered actions cannot fire further events (depth guard)
- Replay-safe: deterministic field comparison, no side effects
- Respects lock model (events fire inside lock scope)
- Subscription cache with generation-based invalidation

Closes #647