### PR TITLE
feat: Internal Engine Metrics & Contention Observability

### DIFF
--- a/BareMetalWeb.Data/AggregateLockManager.cs
+++ b/BareMetalWeb.Data/AggregateLockManager.cs
@@ -23,11 +23,20 @@ public sealed class AggregateLockManager
     /// </summary>
     public LockHandle AcquireAll(IReadOnlyList<string> aggregateKeys, string transactionId)
     {
+        var startTicks = EngineMetrics.StartTiming();
+        bool contended = false;
+
         // Sort deterministically to prevent deadlocks
         var sorted = aggregateKeys.OrderBy(k => k, StringComparer.Ordinal).Distinct().ToArray();
 
         for (int attempt = 0; attempt <= MaxRetries; attempt++)
         {
+            if (attempt > 0)
+            {
+                contended = true;
+                EngineMetrics.RecordCommitRetry();
+            }
+
             var acquired = new List<string>();
             bool success = true;
 
@@ -48,13 +57,17 @@ public sealed class AggregateLockManager
             }
 
             if (success)
+            {
+                EngineMetrics.RecordLockAcquire(EngineMetrics.ElapsedUs(startTicks), contended);
                 return new LockHandle(this, acquired, transactionId);
+            }
 
             // Exponential backoff
             if (attempt < MaxRetries)
                 Thread.Sleep(BaseBackoffMs * (1 << attempt));
         }
 
+        EngineMetrics.RecordLockAcquire(EngineMetrics.ElapsedUs(startTicks), true);
         throw new TimeoutException(
             $"Failed to acquire locks for transaction {transactionId} after {MaxRetries} retries. " +
             $"Keys: {string.Join(", ", sorted)}");

--- a/BareMetalWeb.Data/EngineMetrics.cs
+++ b/BareMetalWeb.Data/EngineMetrics.cs
@@ -1,0 +1,194 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+
+namespace BareMetalWeb.Data;
+
+/// <summary>
+/// Internal engine telemetry for WAL, locks, commits, and compaction.
+/// Thread-safe, lock-free counters using Interlocked operations.
+/// All latencies are recorded in microseconds (µs).
+/// </summary>
+public static class EngineMetrics
+{
+    // ── WAL append ───────────────────────────────────────────────────────────
+
+    private static long _walAppendCount;
+    private static long _walAppendTotalUs;
+    private static long _walAppendMaxUs;
+    private static long _walAppendBytesTotal;
+
+    public static void RecordWalAppend(long elapsedUs, long bytes)
+    {
+        Interlocked.Increment(ref _walAppendCount);
+        Interlocked.Add(ref _walAppendTotalUs, elapsedUs);
+        Interlocked.Add(ref _walAppendBytesTotal, bytes);
+        UpdateMax(ref _walAppendMaxUs, elapsedUs);
+    }
+
+    // ── Lock acquisition ─────────────────────────────────────────────────────
+
+    private static long _lockAcquireCount;
+    private static long _lockAcquireTotalUs;
+    private static long _lockAcquireMaxUs;
+    private static long _lockContentions;
+
+    public static void RecordLockAcquire(long elapsedUs, bool contended)
+    {
+        Interlocked.Increment(ref _lockAcquireCount);
+        Interlocked.Add(ref _lockAcquireTotalUs, elapsedUs);
+        UpdateMax(ref _lockAcquireMaxUs, elapsedUs);
+        if (contended) Interlocked.Increment(ref _lockContentions);
+    }
+
+    // ── Commit pipeline ──────────────────────────────────────────────────────
+
+    private static long _commitCount;
+    private static long _commitSuccessCount;
+    private static long _commitFailCount;
+    private static long _commitTotalUs;
+    private static long _commitMaxUs;
+    private static long _commitRetryCount;
+
+    public static void RecordCommit(long elapsedUs, bool success)
+    {
+        Interlocked.Increment(ref _commitCount);
+        Interlocked.Add(ref _commitTotalUs, elapsedUs);
+        UpdateMax(ref _commitMaxUs, elapsedUs);
+        if (success) Interlocked.Increment(ref _commitSuccessCount);
+        else Interlocked.Increment(ref _commitFailCount);
+    }
+
+    public static void RecordCommitRetry() => Interlocked.Increment(ref _commitRetryCount);
+
+    // ── Delta sizes ──────────────────────────────────────────────────────────
+
+    private static long _deltaSizeCount;
+    private static long _deltaSizeTotal;
+    private static long _deltaSizeMax;
+    private static long _deltaSizeMin = long.MaxValue;
+
+    public static void RecordDeltaSize(long bytes)
+    {
+        Interlocked.Increment(ref _deltaSizeCount);
+        Interlocked.Add(ref _deltaSizeTotal, bytes);
+        UpdateMax(ref _deltaSizeMax, bytes);
+        UpdateMin(ref _deltaSizeMin, bytes);
+    }
+
+    // ── Compaction ────────────────────────────────────────────────────────────
+
+    private static long _compactionCount;
+    private static long _compactionTotalUs;
+    private static long _compactionBytesReclaimed;
+    private static long _lastCompactionTimestamp;
+
+    public static void RecordCompaction(long elapsedUs, long bytesReclaimed)
+    {
+        Interlocked.Increment(ref _compactionCount);
+        Interlocked.Add(ref _compactionTotalUs, elapsedUs);
+        Interlocked.Add(ref _compactionBytesReclaimed, bytesReclaimed);
+        Interlocked.Exchange(ref _lastCompactionTimestamp, Stopwatch.GetTimestamp());
+    }
+
+    // ── Replay ────────────────────────────────────────────────────────────────
+
+    private static long _replayCount;
+    private static long _replayTotalUs;
+    private static long _replayOpsTotal;
+
+    public static void RecordReplay(long elapsedUs, long opsReplayed)
+    {
+        Interlocked.Increment(ref _replayCount);
+        Interlocked.Add(ref _replayTotalUs, elapsedUs);
+        Interlocked.Add(ref _replayOpsTotal, opsReplayed);
+    }
+
+    // ── Snapshot ──────────────────────────────────────────────────────────────
+
+    /// <summary>Capture a point-in-time snapshot of all metrics.</summary>
+    public static EngineMetricsSnapshot GetSnapshot() => new(
+        WalAppendCount: Volatile.Read(ref _walAppendCount),
+        WalAppendTotalUs: Volatile.Read(ref _walAppendTotalUs),
+        WalAppendMaxUs: Volatile.Read(ref _walAppendMaxUs),
+        WalAppendBytesTotal: Volatile.Read(ref _walAppendBytesTotal),
+        LockAcquireCount: Volatile.Read(ref _lockAcquireCount),
+        LockAcquireTotalUs: Volatile.Read(ref _lockAcquireTotalUs),
+        LockAcquireMaxUs: Volatile.Read(ref _lockAcquireMaxUs),
+        LockContentions: Volatile.Read(ref _lockContentions),
+        CommitCount: Volatile.Read(ref _commitCount),
+        CommitSuccessCount: Volatile.Read(ref _commitSuccessCount),
+        CommitFailCount: Volatile.Read(ref _commitFailCount),
+        CommitTotalUs: Volatile.Read(ref _commitTotalUs),
+        CommitMaxUs: Volatile.Read(ref _commitMaxUs),
+        CommitRetryCount: Volatile.Read(ref _commitRetryCount),
+        DeltaSizeCount: Volatile.Read(ref _deltaSizeCount),
+        DeltaSizeTotal: Volatile.Read(ref _deltaSizeTotal),
+        DeltaSizeMax: Volatile.Read(ref _deltaSizeMax),
+        DeltaSizeMin: Volatile.Read(ref _deltaSizeMin) == long.MaxValue ? 0 : Volatile.Read(ref _deltaSizeMin),
+        CompactionCount: Volatile.Read(ref _compactionCount),
+        CompactionTotalUs: Volatile.Read(ref _compactionTotalUs),
+        CompactionBytesReclaimed: Volatile.Read(ref _compactionBytesReclaimed),
+        LastCompactionTimestamp: Volatile.Read(ref _lastCompactionTimestamp),
+        ReplayCount: Volatile.Read(ref _replayCount),
+        ReplayTotalUs: Volatile.Read(ref _replayTotalUs),
+        ReplayOpsTotal: Volatile.Read(ref _replayOpsTotal));
+
+    /// <summary>Reset all counters to zero.</summary>
+    public static void Reset()
+    {
+        _walAppendCount = _walAppendTotalUs = _walAppendMaxUs = _walAppendBytesTotal = 0;
+        _lockAcquireCount = _lockAcquireTotalUs = _lockAcquireMaxUs = _lockContentions = 0;
+        _commitCount = _commitSuccessCount = _commitFailCount = _commitTotalUs = _commitMaxUs = _commitRetryCount = 0;
+        _deltaSizeCount = _deltaSizeTotal = _deltaSizeMax = 0;
+        _deltaSizeMin = long.MaxValue;
+        _compactionCount = _compactionTotalUs = _compactionBytesReclaimed = _lastCompactionTimestamp = 0;
+        _replayCount = _replayTotalUs = _replayOpsTotal = 0;
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /// <summary>Start a high-resolution stopwatch, return ticks.</summary>
+    public static long StartTiming() => Stopwatch.GetTimestamp();
+
+    /// <summary>Convert elapsed ticks to microseconds.</summary>
+    public static long ElapsedUs(long startTicks)
+        => (Stopwatch.GetTimestamp() - startTicks) * 1_000_000L / Stopwatch.Frequency;
+
+    private static void UpdateMax(ref long location, long value)
+    {
+        long current;
+        do { current = Volatile.Read(ref location); }
+        while (value > current && Interlocked.CompareExchange(ref location, value, current) != current);
+    }
+
+    private static void UpdateMin(ref long location, long value)
+    {
+        long current;
+        do { current = Volatile.Read(ref location); }
+        while (value < current && Interlocked.CompareExchange(ref location, value, current) != current);
+    }
+}
+
+/// <summary>Point-in-time snapshot of engine metrics (immutable).</summary>
+public sealed record EngineMetricsSnapshot(
+    // WAL
+    long WalAppendCount, long WalAppendTotalUs, long WalAppendMaxUs, long WalAppendBytesTotal,
+    // Locks
+    long LockAcquireCount, long LockAcquireTotalUs, long LockAcquireMaxUs, long LockContentions,
+    // Commits
+    long CommitCount, long CommitSuccessCount, long CommitFailCount,
+    long CommitTotalUs, long CommitMaxUs, long CommitRetryCount,
+    // Delta sizes
+    long DeltaSizeCount, long DeltaSizeTotal, long DeltaSizeMax, long DeltaSizeMin,
+    // Compaction
+    long CompactionCount, long CompactionTotalUs, long CompactionBytesReclaimed, long LastCompactionTimestamp,
+    // Replay
+    long ReplayCount, long ReplayTotalUs, long ReplayOpsTotal)
+{
+    public double WalAppendAvgUs => WalAppendCount > 0 ? (double)WalAppendTotalUs / WalAppendCount : 0;
+    public double LockAcquireAvgUs => LockAcquireCount > 0 ? (double)LockAcquireTotalUs / LockAcquireCount : 0;
+    public double CommitAvgUs => CommitCount > 0 ? (double)CommitTotalUs / CommitCount : 0;
+    public double DeltaSizeAvg => DeltaSizeCount > 0 ? (double)DeltaSizeTotal / DeltaSizeCount : 0;
+    public double CommitSuccessRate => CommitCount > 0 ? (double)CommitSuccessCount / CommitCount : 0;
+    public double LockContentionRate => LockAcquireCount > 0 ? (double)LockContentions / LockAcquireCount : 0;
+}

--- a/BareMetalWeb.Data/TransactionCommitEngine.cs
+++ b/BareMetalWeb.Data/TransactionCommitEngine.cs
@@ -35,6 +35,8 @@ public sealed class TransactionCommitEngine
         CancellationToken cancellationToken = default,
         bool allowEventDispatch = true)
     {
+        var commitStart = EngineMetrics.StartTiming();
+
         // 1. Acquire all locks in sorted order
         using var lockHandle = _lockManager.AcquireAll(
             envelope.TouchedAggregateKeys, envelope.TransactionId);
@@ -119,6 +121,7 @@ public sealed class TransactionCommitEngine
                     switch (assert.Severity)
                     {
                         case Severity.Error:
+                            EngineMetrics.RecordCommit(EngineMetrics.ElapsedUs(commitStart), false);
                             return Fail(assert.Code, assert.Message);
                         case Severity.Warning:
                             warnings.Add(new TransactionWarning(assert.Code, assert.Message));
@@ -164,6 +167,7 @@ public sealed class TransactionCommitEngine
             }
 
             // 7. Success
+            EngineMetrics.RecordCommit(EngineMetrics.ElapsedUs(commitStart), true);
             return new TransactionResult(
                 Success: true,
                 ErrorCode: null,
@@ -172,6 +176,7 @@ public sealed class TransactionCommitEngine
         }
         catch (TimeoutException)
         {
+            EngineMetrics.RecordCommit(EngineMetrics.ElapsedUs(commitStart), false);
             return Fail("LOCK_TIMEOUT", "Failed to acquire locks for transaction.");
         }
     }

--- a/BareMetalWeb.Host.Tests/RouteRegistrationExtensionsTests.cs
+++ b/BareMetalWeb.Host.Tests/RouteRegistrationExtensionsTests.cs
@@ -957,7 +957,7 @@ public class RouteRegistrationExtensionsTests : IDisposable
         Assert.True(afterData > afterAdmin);
         Assert.True(afterLookup > afterData);
         Assert.True(total > afterLookup);
-        Assert.Equal(staticCount + 16 + 4 + 13 + 21 + 5 + 13, total); // 3+16+4+13+21+5+13=75
+        Assert.Equal(staticCount + 16 + 4 + 13 + 21 + 5 + 14, total); // 3+16+4+13+21+5+14=76
     }
 
     [Fact]

--- a/BareMetalWeb.Host/RouteRegistrationExtensions.cs
+++ b/BareMetalWeb.Host/RouteRegistrationExtensions.cs
@@ -481,6 +481,7 @@ public static class RouteRegistrationExtensions
         host.RegisterRoute("GET /api/_binary/{type}/_layout", new RouteHandlerData(raw, DeltaApiHandlers.LayoutHandler));
         host.RegisterRoute("GET /api/_binary/{type}/_actions", new RouteHandlerData(raw, ActionApiHandlers.ListActionsHandler));
         host.RegisterRoute("POST /api/_binary/{type}/_action/{actionId}", new RouteHandlerData(raw, ActionApiHandlers.ExecuteActionHandler));
+        host.RegisterRoute("GET /api/_metrics", new RouteHandlerData(raw, EngineMetricsHandler));
         host.RegisterRoute("GET /api/_binary/{type}/{id}", new RouteHandlerData(raw, BinaryApiHandlers.GetHandler));
         host.RegisterRoute("GET /api/_binary/{type}", new RouteHandlerData(raw, BinaryApiHandlers.ListHandler));
         host.RegisterRoute("POST /api/_binary/{type}", new RouteHandlerData(raw, BinaryApiHandlers.CreateHandler));
@@ -1978,5 +1979,64 @@ public static class RouteRegistrationExtensions
         }
 
         return query;
+    }
+
+    /// <summary>GET /api/_metrics — returns engine telemetry snapshot as JSON.</summary>
+    private static async ValueTask EngineMetricsHandler(HttpContext context)
+    {
+        var snapshot = BareMetalWeb.Data.EngineMetrics.GetSnapshot();
+
+        context.Response.StatusCode = 200;
+        context.Response.ContentType = "application/json";
+        await using var w = new System.Text.Json.Utf8JsonWriter(context.Response.Body);
+        w.WriteStartObject();
+
+        w.WriteStartObject("wal");
+        w.WriteNumber("appendCount", snapshot.WalAppendCount);
+        w.WriteNumber("appendAvgUs", Math.Round(snapshot.WalAppendAvgUs, 1));
+        w.WriteNumber("appendMaxUs", snapshot.WalAppendMaxUs);
+        w.WriteNumber("appendBytesTotal", snapshot.WalAppendBytesTotal);
+        w.WriteEndObject();
+
+        w.WriteStartObject("locks");
+        w.WriteNumber("acquireCount", snapshot.LockAcquireCount);
+        w.WriteNumber("acquireAvgUs", Math.Round(snapshot.LockAcquireAvgUs, 1));
+        w.WriteNumber("acquireMaxUs", snapshot.LockAcquireMaxUs);
+        w.WriteNumber("contentions", snapshot.LockContentions);
+        w.WriteNumber("contentionRate", Math.Round(snapshot.LockContentionRate, 4));
+        w.WriteEndObject();
+
+        w.WriteStartObject("commits");
+        w.WriteNumber("count", snapshot.CommitCount);
+        w.WriteNumber("successCount", snapshot.CommitSuccessCount);
+        w.WriteNumber("failCount", snapshot.CommitFailCount);
+        w.WriteNumber("avgUs", Math.Round(snapshot.CommitAvgUs, 1));
+        w.WriteNumber("maxUs", snapshot.CommitMaxUs);
+        w.WriteNumber("retries", snapshot.CommitRetryCount);
+        w.WriteNumber("successRate", Math.Round(snapshot.CommitSuccessRate, 4));
+        w.WriteEndObject();
+
+        w.WriteStartObject("deltas");
+        w.WriteNumber("count", snapshot.DeltaSizeCount);
+        w.WriteNumber("avgBytes", Math.Round(snapshot.DeltaSizeAvg, 1));
+        w.WriteNumber("maxBytes", snapshot.DeltaSizeMax);
+        w.WriteNumber("minBytes", snapshot.DeltaSizeMin);
+        w.WriteNumber("totalBytes", snapshot.DeltaSizeTotal);
+        w.WriteEndObject();
+
+        w.WriteStartObject("compaction");
+        w.WriteNumber("count", snapshot.CompactionCount);
+        w.WriteNumber("totalUs", snapshot.CompactionTotalUs);
+        w.WriteNumber("bytesReclaimed", snapshot.CompactionBytesReclaimed);
+        w.WriteEndObject();
+
+        w.WriteStartObject("replay");
+        w.WriteNumber("count", snapshot.ReplayCount);
+        w.WriteNumber("totalUs", snapshot.ReplayTotalUs);
+        w.WriteNumber("opsTotal", snapshot.ReplayOpsTotal);
+        w.WriteEndObject();
+
+        w.WriteEndObject();
+        await w.FlushAsync(context.RequestAborted);
     }
 }


### PR DESCRIPTION
Lock-free engine telemetry with WAL append latency, lock contention, commit success rates, delta sizes, and compaction metrics. Exposed via GET /api/_metrics endpoint.

Closes #650