### PR TITLE
perf: eliminate reflection hot paths (#697)

### DIFF
--- a/BareMetalWeb.Data/ComputedFieldService.cs
+++ b/BareMetalWeb.Data/ComputedFieldService.cs
@@ -16,6 +16,7 @@ namespace BareMetalWeb.Data;
 public static class ComputedFieldService
 {
     private static readonly ConcurrentDictionary<string, ComputedValueCacheEntry> _cache = new();
+    private static readonly ConcurrentDictionary<(Type, string), PropertyInfo?> _propertyCache = new();
 
     private sealed record ComputedValueCacheEntry(object? Value, DateTime ExpiresUtc);
 
@@ -47,7 +48,7 @@ public static class ComputedFieldService
                     continue;
 
                 var value = await ComputeValueAsync(metadata, instance, field, config, cancellationToken);
-                field.Property.SetValue(instance, value);
+                field.SetValueFn(instance, value);
             }
         }
     }
@@ -64,12 +65,12 @@ public static class ComputedFieldService
     {
         var config = field.Computed;
         if (config == null)
-            return field.Property.GetValue(instance);
+            return field.GetValueFn(instance);
 
         if (config.Strategy == ComputedStrategy.Snapshot)
         {
             // Snapshot values are stored in the property
-            return field.Property.GetValue(instance);
+            return field.GetValueFn(instance);
         }
 
         if (config.Strategy == ComputedStrategy.CachedLive)
@@ -132,6 +133,11 @@ public static class ComputedFieldService
         return null;
     }
 
+    private static PropertyInfo? GetCachedProperty(Type type, string name)
+    {
+        return _propertyCache.GetOrAdd((type, name), static key => key.Item1.GetProperty(key.Item2));
+    }
+
     private static async ValueTask<object?> ComputeLookupAsync(
         DataEntityMetadata metadata,
         BaseDataObject instance,
@@ -140,7 +146,7 @@ public static class ComputedFieldService
         CancellationToken cancellationToken)
     {
         // Get the foreign key value
-        var fkProperty = metadata.Type.GetProperty(config.ForeignKeyField!);
+        var fkProperty = GetCachedProperty(metadata.Type, config.ForeignKeyField!);
         if (fkProperty == null)
             return null;
 
@@ -158,7 +164,7 @@ public static class ComputedFieldService
             return null;
 
         // Get the source field value
-        var sourceProperty = config.SourceEntity!.GetProperty(config.SourceField!);
+        var sourceProperty = GetCachedProperty(config.SourceEntity!, config.SourceField!);
         if (sourceProperty == null)
             return null;
 
@@ -173,7 +179,7 @@ public static class ComputedFieldService
         CancellationToken cancellationToken)
     {
         // Get the child collection property
-        var collectionProperty = metadata.Type.GetProperty(config.ChildCollectionProperty!);
+        var collectionProperty = GetCachedProperty(metadata.Type, config.ChildCollectionProperty!);
         if (collectionProperty == null)
             return null;
 
@@ -197,15 +203,21 @@ public static class ComputedFieldService
             return GetDefaultValueForAggregate(config.Aggregate, field.Property.PropertyType);
         }
 
-        // Get values from the source field
+        // Get values from the source field (cache lookup per item type)
         var values = new List<object?>();
+        PropertyInfo? cachedSourceProp = null;
+        Type? cachedItemType = null;
         foreach (var item in items)
         {
             var itemType = item.GetType();
-            var sourceProperty = itemType.GetProperty(config.SourceField);
-            if (sourceProperty != null)
+            if (itemType != cachedItemType)
             {
-                values.Add(sourceProperty.GetValue(item));
+                cachedItemType = itemType;
+                cachedSourceProp = GetCachedProperty(itemType, config.SourceField);
+            }
+            if (cachedSourceProp != null)
+            {
+                values.Add(cachedSourceProp.GetValue(item));
             }
         }
 

--- a/BareMetalWeb.Data/DataScaffold.cs
+++ b/BareMetalWeb.Data/DataScaffold.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Net;
@@ -88,6 +89,7 @@ public static class DataScaffold
     private static readonly Dictionary<string, LookupCacheEntry> LookupCache = new(StringComparer.OrdinalIgnoreCase);
     private static readonly Dictionary<string, (bool IsLarge, DateTime ExpiresUtc)> LargeListCache = new(StringComparer.OrdinalIgnoreCase);
     private static readonly IIdGenerator IdGenerator = new DefaultIdGenerator();
+    private static readonly ConcurrentDictionary<(Type, string), PropertyInfo?> PropertyCache = new();
 
     /// <summary>
     /// Fallback JSON AST (serialized) used when expression parsing fails.
@@ -1933,27 +1935,35 @@ public static class DataScaffold
 
     private static IEnumerable QueryByType(Type type, QueryDefinition? query)
     {
-        // Note: This uses sync-over-async for scaffolding/reflection scenarios called from synchronous UI rendering.
-        // QueryAsync<T> returns ValueTask<IEnumerable<T>> which cannot be cast directly to
-        // ValueTask<IEnumerable> (ValueTask is not covariant). We must use reflection to
-        // extract the result from the concrete ValueTask<IEnumerable<T>>.
+        var meta = GetEntityByType(type);
+        if (meta != null)
+        {
+            var vt = meta.Handlers.QueryAsync(query, CancellationToken.None);
+            return vt.IsCompleted ? (IEnumerable)vt.Result : (IEnumerable)vt.AsTask().GetAwaiter().GetResult();
+        }
+
+        // Fallback for unmapped types
         var method = typeof(IDataObjectStore).GetMethod(nameof(IDataObjectStore.QueryAsync))!;
         var generic = method.MakeGenericMethod(type);
         var result = generic.Invoke(DataStoreProvider.Current, new object?[] { query, CancellationToken.None })!;
 
-        // result is a ValueTask<IEnumerable<T>>; convert to Task then await synchronously
         var asTaskMethod = result.GetType().GetMethod(nameof(ValueTask<int>.AsTask))!;
         var task = (Task)asTaskMethod.Invoke(result, null)!;
         task.GetAwaiter().GetResult();
 
-        // Get the Result property from the completed Task<IEnumerable<T>>
         var resultProp = task.GetType().GetProperty(nameof(Task<object>.Result))!;
         return (IEnumerable)resultProp.GetValue(task)!;
     }
 
     private static int CountByType(Type type, QueryDefinition? query)
     {
-        // Note: This uses sync-over-async, consistent with QueryByType — see that method for rationale.
+        var meta = GetEntityByType(type);
+        if (meta != null)
+        {
+            var vt = meta.Handlers.CountAsync(query, CancellationToken.None);
+            return vt.IsCompleted ? vt.Result : vt.AsTask().GetAwaiter().GetResult();
+        }
+
         var method = typeof(IDataObjectStore).GetMethod(nameof(IDataObjectStore.CountAsync))!;
         var generic = method.MakeGenericMethod(type);
         var result = generic.Invoke(DataStoreProvider.Current, new object?[] { query, CancellationToken.None })!;
@@ -1966,11 +1976,18 @@ public static class DataScaffold
 
     private static object? LoadByIdForType(Type type, string id)
     {
-        // Note: This uses sync-over-async, consistent with QueryByType — see that method for rationale.
+        var meta = GetEntityByType(type);
+        if (meta != null)
+        {
+            var key = uint.Parse(id);
+            var vt = meta.Handlers.LoadAsync(key, CancellationToken.None);
+            return vt.IsCompleted ? vt.Result : vt.AsTask().GetAwaiter().GetResult();
+        }
+
         var method = typeof(IDataObjectStore).GetMethod(nameof(IDataObjectStore.LoadAsync))!;
         var generic = method.MakeGenericMethod(type);
-        var key = uint.Parse(id);
-        var result = generic.Invoke(DataStoreProvider.Current, new object?[] { key, CancellationToken.None })!;
+        var k = uint.Parse(id);
+        var result = generic.Invoke(DataStoreProvider.Current, new object?[] { k, CancellationToken.None })!;
         var asTaskMethod = result.GetType().GetMethod(nameof(ValueTask<object>.AsTask))!;
         var task = (Task)asTaskMethod.Invoke(result, null)!;
         task.GetAwaiter().GetResult();
@@ -2030,8 +2047,10 @@ public static class DataScaffold
             if (entity == null)
                 return null;
 
-            var displayProp = lookup.TargetType.GetProperty(lookup.DisplayField,
-                BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+            var displayProp = PropertyCache.GetOrAdd(
+                (lookup.TargetType, lookup.DisplayField),
+                static key => key.Item1.GetProperty(key.Item2,
+                    BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase));
             var displayVal = displayProp?.GetValue(entity);
             return displayVal != null ? ToDisplayString(displayVal, displayProp!.PropertyType) : null;
         }
@@ -2057,8 +2076,10 @@ public static class DataScaffold
             if (itemType != cachedType)
             {
                 cachedType = itemType;
-                valueProp = itemType.GetProperty(valueField, BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
-                displayProp = itemType.GetProperty(displayField, BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+                valueProp = PropertyCache.GetOrAdd((itemType, valueField),
+                    static key => key.Item1.GetProperty(key.Item2, BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase));
+                displayProp = PropertyCache.GetOrAdd((itemType, displayField),
+                    static key => key.Item1.GetProperty(key.Item2, BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase));
             }
             if (valueProp == null || displayProp == null)
                 continue;
@@ -2387,7 +2408,8 @@ public static class DataScaffold
             {
                 // Check if this is a lookup field (not just an enum) to add refresh/add buttons
                 // Re-extract the lookup attribute from the child type's property
-                var prop = childType.GetProperty(child.Name, BindingFlags.Public | BindingFlags.Instance);
+                var prop = PropertyCache.GetOrAdd((childType, child.Name),
+                    static key => key.Item1.GetProperty(key.Item2, BindingFlags.Public | BindingFlags.Instance));
                 var lookupAttr = prop?.GetCustomAttribute<DataLookupAttribute>();
                 string? targetSlug = null;
                 string? targetTypeName = null;

--- a/BareMetalWeb.Host/RouteHandlers.cs
+++ b/BareMetalWeb.Host/RouteHandlers.cs
@@ -43,6 +43,7 @@ public sealed class RouteHandlers : IRouteHandlers
     private static readonly TimeSpan MfaAttemptWindow = TimeSpan.FromMinutes(5);
     private static readonly TimeSpan MfaBaseBlockDuration = TimeSpan.FromSeconds(10);
     private static readonly ConcurrentDictionary<string, AttemptTracker> MfaAttempts = new(StringComparer.Ordinal);
+    private static readonly ConcurrentDictionary<Type, System.Reflection.PropertyInfo[]> JsonPropertyCache = new();
 
     public RouteHandlers(IHtmlRenderer renderer, ITemplateStore templateStore, bool allowAccountCreation, string mfaKeyRootFolder, AuditService auditService,
         IReadOnlyList<(string SettingId, string Value, string Description)>? settingDefaults = null)
@@ -3518,7 +3519,7 @@ public sealed class RouteHandlers : IRouteHandlers
             return;
         }
 
-        if (field.Property.GetValue(instance) is not StoredFileData fileData || string.IsNullOrWhiteSpace(fileData.StorageKey))
+        if (field.GetValueFn(instance) is not StoredFileData fileData || string.IsNullOrWhiteSpace(fileData.StorageKey))
         {
             context.Response.StatusCode = StatusCodes.Status404NotFound;
             await context.Response.WriteAsync("File not found.");
@@ -4278,13 +4279,13 @@ public sealed class RouteHandlers : IRouteHandlers
             var deleteKey = $"{field.Name}__delete";
             var deleteRequested = form.TryGetValue(deleteKey, out var deleteValue) && DataScaffold.IsTruthy(deleteValue.ToString());
             var uploadedFile = form.Files.GetFile(field.Name);
-            var existingFile = field.Property.GetValue(instance) as StoredFileData;
+            var existingFile = field.GetValueFn(instance) as StoredFileData;
 
             if (deleteRequested && uploadedFile == null)
             {
                 if (existingFile != null)
                     DeleteStoredFile(context, existingFile);
-                field.Property.SetValue(instance, null);
+                field.SetValueFn(instance, null);
                 continue;
             }
 
@@ -4337,7 +4338,7 @@ public sealed class RouteHandlers : IRouteHandlers
                 IsImage = field.FieldType == FormFieldType.Image
             };
 
-            field.Property.SetValue(instance, storedFile);
+            field.SetValueFn(instance, storedFile);
         }
     }
 
@@ -4388,7 +4389,7 @@ public sealed class RouteHandlers : IRouteHandlers
 
         foreach (var field in meta.Fields.Where(f => f.View))
         {
-            var value = field.Property.GetValue(instance);
+            var value = field.GetValueFn(instance);
             if (value is StoredFileData fileData && instance is BaseDataObject obj)
             {
                 data[field.Name] = new Dictionary<string, object?>
@@ -5676,14 +5677,14 @@ public sealed class RouteHandlers : IRouteHandlers
 
         if (DataScaffold.TryConvertValue(value, field.Property.PropertyType, out var converted) && converted != null)
         {
-            field.Property.SetValue(instance, converted);
+            field.SetValueFn(instance, converted);
             return;
         }
 
         var effectiveType = Nullable.GetUnderlyingType(field.Property.PropertyType) ?? field.Property.PropertyType;
         if (effectiveType == typeof(string))
         {
-            field.Property.SetValue(instance, value);
+            field.SetValueFn(instance, value);
         }
     }
 
@@ -6267,11 +6268,15 @@ public sealed class RouteHandlers : IRouteHandlers
         if (valueType.IsClass)
         {
             writer.WriteStartObject();
-            #pragma warning disable IL2075 // Child entity types are preserved via TrimmerRootAssembly
-            foreach (var prop in valueType.GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance))
-            #pragma warning restore IL2075
+            var props = JsonPropertyCache.GetOrAdd(valueType, static t =>
             {
-                if (!prop.CanRead || prop.GetIndexParameters().Length != 0) continue;
+                #pragma warning disable IL2070, IL2075
+                return t.GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance)
+                        .Where(p => p.CanRead && p.GetIndexParameters().Length == 0).ToArray();
+                #pragma warning restore IL2070, IL2075
+            });
+            foreach (var prop in props)
+            {
                 writer.WritePropertyName(prop.Name);
                 WriteJsonValue(writer, prop.GetValue(value));
             }


### PR DESCRIPTION
## Summary
Eliminates uncached reflection calls from hot paths across 3 files:

### RouteHandlers.cs
- Replace 7x `field.Property.GetValue/SetValue` with compiled `field.GetValueFn/SetValueFn` delegates (file upload, field binding, export)
- Cache `PropertyInfo[]` per type for JSON serialization fallback path

### ComputedFieldService.cs
- Replace `field.Property.GetValue/SetValue` with compiled delegate accessors
- Add `ConcurrentDictionary<(Type,string),PropertyInfo?>` cache for `Type.GetProperty()` calls in lookup, aggregation, and collection resolution

### DataScaffold.cs
- Use `metadata.Handlers` compiled delegates instead of `MakeGenericMethod`+`Invoke` for QueryByType/CountByType/LoadByIdForType (eliminates 12 reflection calls per invocation)
- Cache `PropertyInfo` for lookup display values, option building, and sub-entity form rendering

Closes #697