### PR TITLE
fix: critical security, data integrity, and performance issues

### DIFF
--- a/BareMetalWeb.Data/ActionExpander.cs
+++ b/BareMetalWeb.Data/ActionExpander.cs
@@ -196,7 +196,10 @@ public sealed class ActionExpander
         if (!DataScaffold.TryGetEntity(invoke.TargetAggregateType, out var targetMeta)) return;
         var targetLayout = EntityLayoutCompiler.GetOrCompile(targetMeta);
 
-        var targetEntity = DataScaffold.LoadAsync(targetMeta, targetId).AsTask().Result;
+        var loadTask = DataScaffold.LoadAsync(targetMeta, targetId);
+        var targetEntity = loadTask.IsCompleted
+            ? loadTask.Result
+            : loadTask.AsTask().GetAwaiter().GetResult();
         if (targetEntity == null) return;
 
         var targetEval = new ExpressionEvaluator(targetLayout, _aggregateReader);

--- a/BareMetalWeb.Data/ClusterState.cs
+++ b/BareMetalWeb.Data/ClusterState.cs
@@ -61,8 +61,9 @@ public sealed class ClusterState : IDisposable
     /// Validate that this instance is allowed to write.
     /// Must be called before every WAL append.
     /// Throws if not leader or lease expired.
+    /// Returns the current epoch for the fence token.
     /// </summary>
-    public void ValidateWritePermission()
+    public long ValidateWritePermission()
     {
         if (!IsLeader)
             throw new InvalidOperationException(
@@ -75,6 +76,9 @@ public sealed class ClusterState : IDisposable
             throw new InvalidOperationException(
                 "Write rejected: leader lease lost. Instance demoted to follower.");
         }
+
+        // Capture epoch atomically with validation — prevents stale epoch in WAL entries
+        return _lease.CurrentEpoch;
     }
 
     /// <summary>
@@ -83,9 +87,9 @@ public sealed class ClusterState : IDisposable
     /// </summary>
     public (long Epoch, long Lsn) AssignLsn()
     {
-        ValidateWritePermission();
+        var epoch = ValidateWritePermission();
         var lsn = Interlocked.Increment(ref _lastLsn);
-        return (_lease.CurrentEpoch, lsn);
+        return (epoch, lsn);
     }
 
     /// <summary>Set the LSN watermark during recovery/replay.</summary>

--- a/BareMetalWeb.Data/DataScaffold.cs
+++ b/BareMetalWeb.Data/DataScaffold.cs
@@ -68,7 +68,35 @@ public sealed record DataEntityMetadata(
     string? DefaultSortField = null,
     SortDirection DefaultSortDirection = SortDirection.Asc,
     IReadOnlyList<DataFieldMetadata>? DocumentRelationFields = null
-);
+)
+{
+    private DataFieldMetadata[]? _listFields;
+    private DataFieldMetadata[]? _viewFields;
+    private DataFieldMetadata[]? _createFields;
+    private DataFieldMetadata[]? _editFields;
+
+    /// <summary>Fields visible in list views, pre-sorted by Order.</summary>
+    public DataFieldMetadata[] ListFields => _listFields ??= BuildFilteredFields(f => f.List);
+
+    /// <summary>Fields visible in detail views, pre-sorted by Order.</summary>
+    public DataFieldMetadata[] ViewFields => _viewFields ??= BuildFilteredFields(f => f.View);
+
+    /// <summary>Fields available during create, pre-sorted by Order.</summary>
+    public DataFieldMetadata[] CreateFields => _createFields ??= BuildFilteredFields(f => f.Create);
+
+    /// <summary>Fields available during edit, pre-sorted by Order.</summary>
+    public DataFieldMetadata[] EditFields => _editFields ??= BuildFilteredFields(f => f.Edit);
+
+    private DataFieldMetadata[] BuildFilteredFields(Func<DataFieldMetadata, bool> predicate)
+    {
+        int count = 0;
+        foreach (var f in Fields) if (predicate(f)) count++;
+        var result = new DataFieldMetadata[count];
+        int idx = 0;
+        foreach (var f in Fields) if (predicate(f)) result[idx++] = f;
+        return result;
+    }
+}
 
 public sealed record DataEntityHandlers(
     Func<BaseDataObject> Create,
@@ -323,7 +351,7 @@ public static class DataScaffold
         if (query.TryGetValue("q", out var queryText) && !string.IsNullOrWhiteSpace(queryText))
         {
             var group = new QueryGroup { Logic = QueryGroupLogic.Or };
-            foreach (var field in metadata.Fields.Where(f => f.List))
+            foreach (var field in metadata.ListFields)
             {
                 group.Clauses.Add(new QueryClause
                 {
@@ -705,7 +733,7 @@ public static class DataScaffold
     public static IReadOnlyList<(string Label, string Value)> BuildViewRows(DataEntityMetadata metadata, object instance)
     {
         var rows = new List<(string Label, string Value)>();
-        foreach (var field in metadata.Fields.Where(f => f.View).OrderBy(f => f.Order))
+        foreach (var field in metadata.ViewFields)
         {
             var value = field.GetValueFn(instance);
             if (field.Lookup != null)
@@ -733,7 +761,7 @@ public static class DataScaffold
     public static IReadOnlyList<(string Label, string Value, bool IsHtml)> BuildViewRowsHtml(DataEntityMetadata metadata, object instance, Func<DataEntityMetadata, bool>? canRenderLookupLink = null)
     {
         var rows = new List<(string Label, string Value, bool IsHtml)>();
-        foreach (var field in metadata.Fields.Where(f => f.View).OrderBy(f => f.Order))
+        foreach (var field in metadata.ViewFields)
         {
             var value = field.GetValueFn(instance);
             if (field.Lookup != null)
@@ -812,7 +840,7 @@ public static class DataScaffold
     public static IReadOnlyList<(DataFieldMetadata Field, Type ChildType)> GetNestedComponents(DataEntityMetadata metadata)
     {
         var nested = new List<(DataFieldMetadata, Type)>();
-        foreach (var field in metadata.Fields.Where(f => f.View))
+        foreach (var field in metadata.ViewFields)
         {
             if (IsChildListType(field.Property.PropertyType, out var childType))
             {
@@ -943,7 +971,7 @@ public static class DataScaffold
     {
         var result = new List<(string, string[], string[][])>();
         
-        foreach (var field in metadata.Fields.Where(f => f.View))
+        foreach (var field in metadata.ViewFields)
         {
             if (!IsChildListType(field.Property.PropertyType, out var childType))
                 continue;
@@ -1006,7 +1034,7 @@ public static class DataScaffold
     {
         var rows = new List<string[]>();
         // Pre-build lookup maps once per field (not per row)
-        var listFields = metadata.Fields.Where(f => f.List).OrderBy(f => f.Order).ToArray();
+        var listFields = metadata.ListFields;
         var lookupMaps = new Dictionary<string, string>?[listFields.Length];
         for (int fi = 0; fi < listFields.Length; fi++)
         {

--- a/BareMetalWeb.Data/LeaseAuthority.cs
+++ b/BareMetalWeb.Data/LeaseAuthority.cs
@@ -92,7 +92,7 @@ public sealed class FileLeaseAuthority : ILeaseAuthority, IDisposable
             writer.Write(InstanceId);
             writer.Flush();
 
-            // Increment epoch atomically
+            // Increment epoch atomically (write to temp, then rename)
             _epoch = IncrementEpoch();
             _leaseExpiryUtc = DateTime.UtcNow + _leaseDuration;
 
@@ -100,18 +100,32 @@ public sealed class FileLeaseAuthority : ILeaseAuthority, IDisposable
         }
         catch (IOException)
         {
-            // Lease file already exists — check if stale
+            // Lease file already exists — check if stale via last-write time.
+            // If stale, attempt a single CreateNew retry (if another instance beats us
+            // to the delete+create, the retry will harmlessly fail with IOException).
             try
             {
                 var info = new FileInfo(_leaseFilePath);
                 if (info.Exists && DateTime.UtcNow - info.LastWriteTimeUtc > _leaseDuration * 2)
                 {
-                    // Stale lease — delete and retry
-                    File.Delete(_leaseFilePath);
-                    return TryAcquireAsync(ct);
+                    try { File.Delete(_leaseFilePath); } catch { /* lost race — OK */ }
+
+                    // Single retry (no recursion) — if another instance already re-created, we lose cleanly.
+                    try
+                    {
+                        _leaseFile = new FileStream(_leaseFilePath, FileMode.CreateNew, FileAccess.ReadWrite,
+                            FileShare.None, 4096, FileOptions.DeleteOnClose);
+                        using var w = new StreamWriter(_leaseFile, leaveOpen: true);
+                        w.Write(InstanceId);
+                        w.Flush();
+                        _epoch = IncrementEpoch();
+                        _leaseExpiryUtc = DateTime.UtcNow + _leaseDuration;
+                        return ValueTask.FromResult(true);
+                    }
+                    catch (IOException) { /* another instance won the race */ }
                 }
             }
-            catch { /* ignore */ }
+            catch { /* ignore stat errors */ }
 
             return ValueTask.FromResult(false);
         }
@@ -123,6 +137,13 @@ public sealed class FileLeaseAuthority : ILeaseAuthority, IDisposable
 
         try
         {
+            // Verify the lease file on disk is still ours (same path, still locked by us)
+            if (!File.Exists(_leaseFilePath))
+            {
+                Demote();
+                return ValueTask.FromResult(false);
+            }
+
             // Touch the file to update LastWriteTime
             _leaseFile.Seek(0, SeekOrigin.Begin);
             _leaseFile.SetLength(0);
@@ -165,7 +186,10 @@ public sealed class FileLeaseAuthority : ILeaseAuthority, IDisposable
         }
         catch { /* start at 1 */ }
 
-        File.WriteAllText(_epochFilePath, epoch.ToString());
+        // Atomic write: temp file then rename (atomic on POSIX, near-atomic on Windows)
+        var tempPath = _epochFilePath + ".tmp";
+        File.WriteAllText(tempPath, epoch.ToString());
+        File.Move(tempPath, _epochFilePath, overwrite: true);
         return epoch;
     }
 

--- a/BareMetalWeb.Data/LocalFolderBinaryDataProvider.cs
+++ b/BareMetalWeb.Data/LocalFolderBinaryDataProvider.cs
@@ -197,26 +197,23 @@ public sealed class LocalFolderBinaryDataProvider : IDataProvider
         Directory.CreateDirectory(Path.GetDirectoryName(path)!);
         var lockObj = _seqIdLocks.GetOrAdd(entityName, _ => new object());
 
-        lock (lockObj)
+        const int maxRetries = 4;
+        const int initialDelayMs = 10;
+
+        for (int attempt = 0; attempt < maxRetries; attempt++)
         {
-            const int maxRetries = 4;
-            const int initialDelayMs = 10;
-
-            for (int attempt = 0; attempt < maxRetries; attempt++)
+            try
             {
-                try
-                {
-                    return IncrementAndReadSeqKeyFile(path);
-                }
-                catch (IOException)
-                {
-                    Thread.Sleep(initialDelayMs * (1 << attempt));
-                }
+                lock (lockObj) { return IncrementAndReadSeqKeyFile(path); }
             }
-
-            // Final attempt – let any IOException propagate.
-            return IncrementAndReadSeqKeyFile(path);
+            catch (IOException)
+            {
+                Thread.Sleep(initialDelayMs * (1 << attempt));
+            }
         }
+
+        // Final attempt – let any IOException propagate.
+        lock (lockObj) { return IncrementAndReadSeqKeyFile(path); }
     }
 
     public void SeedSequentialKey(string entityName, uint floor)
@@ -230,27 +227,24 @@ public sealed class LocalFolderBinaryDataProvider : IDataProvider
         Directory.CreateDirectory(Path.GetDirectoryName(path)!);
         var lockObj = _seqIdLocks.GetOrAdd(entityName, _ => new object());
 
-        lock (lockObj)
+        const int maxRetries = 4;
+        const int initialDelayMs = 10;
+
+        for (int attempt = 0; attempt < maxRetries; attempt++)
         {
-            const int maxRetries = 4;
-            const int initialDelayMs = 10;
-
-            for (int attempt = 0; attempt < maxRetries; attempt++)
+            try
             {
-                try
-                {
-                    SeedSeqKeyFileIfLower(path, floor);
-                    return;
-                }
-                catch (IOException)
-                {
-                    Thread.Sleep(initialDelayMs * (1 << attempt));
-                }
+                lock (lockObj) { SeedSeqKeyFileIfLower(path, floor); }
+                return;
             }
-
-            // Final attempt – let any IOException propagate.
-            SeedSeqKeyFileIfLower(path, floor);
+            catch (IOException)
+            {
+                Thread.Sleep(initialDelayMs * (1 << attempt));
+            }
         }
+
+        // Final attempt – let any IOException propagate.
+        lock (lockObj) { SeedSeqKeyFileIfLower(path, floor); }
     }
 
     private static uint IncrementAndReadSeqKeyFile(string path)
@@ -373,32 +367,33 @@ public sealed class LocalFolderBinaryDataProvider : IDataProvider
         {
             var bytes = SerializeFor(_serializer, obj, schemaVersion);
             var store = GetClusteredStore(type.Name);
+            var keyStr = obj.Key.ToString();
 
             // Load existing object only on updates (existing location found) to track previous indexed field values.
             // New inserts skip this load since there are no prior index entries to clean up.
             T? oldObj = null;
             List<PropertyInfo> indexedFields = new();
-            if (_searchIndexManager.HasIndexedFields(type, out indexedFields) && TryGetClusteredLocation(type.Name, obj.Key.ToString(), out _))
+            if (_searchIndexManager.HasIndexedFields(type, out indexedFields) && TryGetClusteredLocation(type.Name, keyStr, out _))
                 oldObj = Load<T>(obj.Key);
 
-            var location = store.Write(obj.Key.ToString(), bytes);
+            var location = store.Write(keyStr, bytes);
             var map = GetClusteredLocationMap(type.Name);
-            map.TryGetValue(obj.Key.ToString(), out var existingLocation);
+            map.TryGetValue(keyStr, out var existingLocation);
 
             // Batch append operations to avoid lock contention
             var entries = new List<(string key, string id, char op, long? expiresAtUtcTicks)>
             {
-                (obj.Key.ToString(), location, 'A', null)
+                (keyStr, location, 'A', null)
             };
 
             if (!string.IsNullOrWhiteSpace(existingLocation)
                 && !string.Equals(existingLocation, location, StringComparison.OrdinalIgnoreCase))
             {
-                entries.Add((obj.Key.ToString(), existingLocation, 'D', null));
+                entries.Add((keyStr, existingLocation, 'D', null));
             }
 
             _indexStore.AppendEntries(type.Name, ClusteredIndexFieldName, entries, normalizeKey: false);
-            map[obj.Key.ToString()] = location;
+            map[keyStr] = location;
 
             if (!string.IsNullOrWhiteSpace(existingLocation)
                 && !string.Equals(existingLocation, location, StringComparison.OrdinalIgnoreCase))
@@ -417,9 +412,9 @@ public sealed class LocalFolderBinaryDataProvider : IDataProvider
                         var oldValue = prop.GetValue(oldObj)?.ToString() ?? string.Empty;
                         if (string.Equals(oldValue, newValue, StringComparison.OrdinalIgnoreCase))
                             continue; // value unchanged — existing index entry is still valid
-                        _indexStore.AppendEntry(type.Name, prop.Name, oldValue, obj.Key.ToString(), 'D');
+                        _indexStore.AppendEntry(type.Name, prop.Name, oldValue, keyStr, 'D');
                     }
-                    _indexStore.AppendEntry(type.Name, prop.Name, newValue, obj.Key.ToString(), 'A');
+                    _indexStore.AppendEntry(type.Name, prop.Name, newValue, keyStr, 'A');
                 }
                 _searchIndexManager.IndexObject(obj);
             }
@@ -484,7 +479,8 @@ public sealed class LocalFolderBinaryDataProvider : IDataProvider
             throw new ArgumentException("Key cannot be zero.", nameof(key));
 
         var type = typeof(T);
-        if (!TryGetClusteredLocation(type.Name, key.ToString(), out var location))
+        var keyStr = key.ToString();
+        if (!TryGetClusteredLocation(type.Name, keyStr, out var location))
             return default;
 
         var store = GetClusteredStore(type.Name);
@@ -495,8 +491,8 @@ public sealed class LocalFolderBinaryDataProvider : IDataProvider
             // Evict the cache entry and retry once using the index store as the authoritative source.
             if (_clusteredLocationMaps.TryGetValue(type.Name, out var locationMap))
             {
-                locationMap.TryRemove(key.ToString(), out _);
-                bool foundFresh = _indexStore.TryGetLatestValue(type.Name, ClusteredIndexFieldName, key.ToString(), out var freshLocation, normalizeKey: false);
+                locationMap.TryRemove(keyStr, out _);
+                bool foundFresh = _indexStore.TryGetLatestValue(type.Name, ClusteredIndexFieldName, keyStr, out var freshLocation, normalizeKey: false);
                 bool isDifferentLocation = foundFresh
                     && !string.IsNullOrWhiteSpace(freshLocation)
                     && !string.Equals(freshLocation, location, StringComparison.OrdinalIgnoreCase);
@@ -504,7 +500,7 @@ public sealed class LocalFolderBinaryDataProvider : IDataProvider
                 {
                     bytes = store.Read(freshLocation);
                     if (bytes != null)
-                        locationMap[key.ToString()] = freshLocation;
+                        locationMap[keyStr] = freshLocation;
                 }
             }
             if (bytes == null)

--- a/BareMetalWeb.Data/WalDataProvider.cs
+++ b/BareMetalWeb.Data/WalDataProvider.cs
@@ -164,8 +164,9 @@ public sealed class WalDataProvider : IDataProvider, IDisposable
             var bytes  = _serializer.Serialize(obj, schemaVersion);
             var walKey = GetOrAllocateKey(type.Name, obj.Key);
 
-            _walStore.CommitAsync(new[] { WalOp.Upsert(walKey, bytes) })
-                     .GetAwaiter().GetResult();
+            var commitTask = _walStore.CommitAsync(new[] { WalOp.Upsert(walKey, bytes) });
+            if (!commitTask.IsCompleted)
+                commitTask.GetAwaiter().GetResult();
 
             PersistIdMap(type.Name);
         }
@@ -301,8 +302,9 @@ public sealed class WalDataProvider : IDataProvider, IDisposable
         var idMap    = GetOrLoadIdMap(typeName);
         if (!idMap.TryGetValue(key, out var walKey)) return;
 
-        _walStore.CommitAsync(new[] { WalOp.Delete(walKey) })
-                 .GetAwaiter().GetResult();
+        var commitTask = _walStore.CommitAsync(new[] { WalOp.Delete(walKey) });
+        if (!commitTask.IsCompleted)
+            commitTask.GetAwaiter().GetResult();
 
         idMap.TryRemove(key, out _);
         PersistIdMap(typeName);

--- a/BareMetalWeb.Host/CssBundleService.cs
+++ b/BareMetalWeb.Host/CssBundleService.cs
@@ -358,7 +358,7 @@ public static class CssBundleService
             return Regex.Replace(raw,
                 @"url\(\s*[""']?\.?/?fonts/bootstrap-icons\.woff2[^""')]*[""']?\s*\)",
                 "url('/static/fonts/bootstrap-icons.woff2')",
-                RegexOptions.IgnoreCase);
+                RegexOptions.IgnoreCase | RegexOptions.Compiled);
         }
         catch (Exception ex)
         {
@@ -381,7 +381,7 @@ public static class CssBundleService
         themeCss = Regex.Replace(themeCss,
             @"@import\s+url\(\s*[""']?https://fonts\.googleapis\.com[^""')]*[""']?\s*\)\s*;?",
             string.Empty,
-            RegexOptions.IgnoreCase);
+            RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         return $"/* bootstrap-icons@{BootstrapIconsVersion} */\n{iconsCss}\n\n/* bootswatch@{BootswatchVersion} theme: {themeName} */\n{themeCss}";
     }

--- a/BareMetalWeb.Host/LookupApiHandlers.cs
+++ b/BareMetalWeb.Host/LookupApiHandlers.cs
@@ -15,6 +15,8 @@ namespace BareMetalWeb.Host;
 /// </summary>
 public static class LookupApiHandlers
 {
+    private static readonly JsonSerializerOptions JsonCamelCase = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase, WriteIndented = false };
+
     /// <summary>
     /// GET /api/_lookup/{EntityType}/{Id}
     /// Fetches a single entity by ID.
@@ -369,7 +371,7 @@ public static class LookupApiHandlers
         var queryDef = new QueryDefinition();
 
         var viewableFields = new HashSet<string>(
-            meta.Fields.Where(f => f.View).Select(f => f.Name),
+            meta.ViewFields.Select(f => f.Name),
             StringComparer.OrdinalIgnoreCase);
 
         // Parse filters from query string: ?filter=field:value
@@ -474,7 +476,7 @@ public static class LookupApiHandlers
             ["id"] = entity.Key.ToString()
         };
 
-        foreach (var field in meta.Fields.Where(f => f.View))
+        foreach (var field in meta.ViewFields)
         {
             var value = field.Property.GetValue(entity);
             result[field.Name] = value;
@@ -541,11 +543,7 @@ public static class LookupApiHandlers
     {
         context.Response.ContentType = "application/json";
         context.Response.StatusCode = StatusCodes.Status200OK;
-        await JsonSerializer.SerializeAsync(context.Response.Body, data, new JsonSerializerOptions
-        {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            WriteIndented = false
-        });
+        await JsonSerializer.SerializeAsync(context.Response.Body, data, JsonCamelCase);
     }
 
     private static async ValueTask WriteJsonErrorAsync(HttpContext context, int statusCode, string message)

--- a/BareMetalWeb.Host/PageRenderer.cs
+++ b/BareMetalWeb.Host/PageRenderer.cs
@@ -10,8 +10,17 @@ namespace BareMetalWeb.Host;
 /// Renders Page entities (Markdown or HTML) inside the platform chrome shell.
 /// Handles GET /page/{slug} route.
 /// </summary>
-public static class PageRenderer
+public static partial class PageRenderer
 {
+    [GeneratedRegex(@"\*\*(.+?)\*\*")]
+    private static partial Regex BoldRegex();
+    [GeneratedRegex(@"\*(.+?)\*")]
+    private static partial Regex ItalicRegex();
+    [GeneratedRegex(@"`(.+?)`")]
+    private static partial Regex CodeRegex();
+    [GeneratedRegex(@"\[(.+?)\]\((.+?)\)")]
+    private static partial Regex LinkRegex();
+
     /// <summary>Handler for GET /page/{slug}.</summary>
     public static async ValueTask RenderPageHandler(HttpContext context)
     {
@@ -198,13 +207,13 @@ public static class PageRenderer
     {
         var encoded = System.Net.WebUtility.HtmlEncode(text);
         // Bold
-        encoded = Regex.Replace(encoded, @"\*\*(.+?)\*\*", "<strong>$1</strong>");
+        encoded = BoldRegex().Replace(encoded, "<strong>$1</strong>");
         // Italic
-        encoded = Regex.Replace(encoded, @"\*(.+?)\*", "<em>$1</em>");
+        encoded = ItalicRegex().Replace(encoded, "<em>$1</em>");
         // Code
-        encoded = Regex.Replace(encoded, @"`(.+?)`", "<code>$1</code>");
+        encoded = CodeRegex().Replace(encoded, "<code>$1</code>");
         // Links [text](url)
-        encoded = Regex.Replace(encoded, @"\[(.+?)\]\((.+?)\)", """<a href="$2">$1</a>""");
+        encoded = LinkRegex().Replace(encoded, """<a href="$2">$1</a>""");
         return encoded;
     }
 

--- a/BareMetalWeb.Host/RouteHandlers.cs
+++ b/BareMetalWeb.Host/RouteHandlers.cs
@@ -44,6 +44,7 @@ public sealed class RouteHandlers : IRouteHandlers
     private static readonly TimeSpan MfaBaseBlockDuration = TimeSpan.FromSeconds(10);
     private static readonly ConcurrentDictionary<string, AttemptTracker> MfaAttempts = new(StringComparer.Ordinal);
     private static readonly ConcurrentDictionary<Type, System.Reflection.PropertyInfo[]> JsonPropertyCache = new();
+    private static readonly JsonSerializerOptions JsonIndented = new() { WriteIndented = true };
 
     public RouteHandlers(IHtmlRenderer renderer, ITemplateStore templateStore, bool allowAccountCreation, string mfaKeyRootFolder, AuditService auditService,
         IReadOnlyList<(string SettingId, string Value, string Description)>? settingDefaults = null)
@@ -2814,13 +2815,15 @@ public sealed class RouteHandlers : IRouteHandlers
         }
     }
 
+    private static readonly System.Text.RegularExpressions.Regex HtmlTagRegex = new("<[^>]+>", System.Text.RegularExpressions.RegexOptions.Compiled);
+
     private static string StripHtmlTags(string html)
     {
         if (string.IsNullOrWhiteSpace(html))
             return string.Empty;
         
         // Simple HTML tag removal (for checkbox and link elements in list rows)
-        var text = System.Text.RegularExpressions.Regex.Replace(html, "<[^>]+>", string.Empty);
+        var text = HtmlTagRegex.Replace(html, string.Empty);
         return WebUtility.HtmlDecode(text);
     }
 
@@ -4387,7 +4390,7 @@ public sealed class RouteHandlers : IRouteHandlers
         if (!string.IsNullOrWhiteSpace(id))
             data["id"] = id;
 
-        foreach (var field in meta.Fields.Where(f => f.View))
+        foreach (var field in meta.ViewFields)
         {
             var value = field.GetValueFn(instance);
             if (value is StoredFileData fileData && instance is BaseDataObject obj)
@@ -5027,13 +5030,42 @@ public sealed class RouteHandlers : IRouteHandlers
     private static string BuildCsv(string[] headers, string[][] rows)
     {
         var sb = new StringBuilder();
-        sb.AppendLine(string.Join(",", headers.Select(CsvEscape)));
+        AppendCsvRow(sb, headers);
         foreach (var row in rows)
         {
-            sb.AppendLine(string.Join(",", row.Select(CsvEscape)));
+            AppendCsvRow(sb, row);
         }
 
         return sb.ToString();
+    }
+
+    private static void AppendCsvRow(StringBuilder sb, string[] cells)
+    {
+        for (int i = 0; i < cells.Length; i++)
+        {
+            if (i > 0) sb.Append(',');
+            CsvEscapeTo(sb, cells[i]);
+        }
+        sb.AppendLine();
+    }
+
+    private static void CsvEscapeTo(StringBuilder sb, string value)
+    {
+        var safe = value ?? string.Empty;
+        if (safe.Contains('"') || safe.Contains(',') || safe.Contains('\n') || safe.Contains('\r'))
+        {
+            sb.Append('"');
+            foreach (char c in safe)
+            {
+                if (c == '"') sb.Append('"');
+                sb.Append(c);
+            }
+            sb.Append('"');
+        }
+        else
+        {
+            sb.Append(safe);
+        }
     }
 
     private static string CsvEscape(string value)
@@ -5052,7 +5084,7 @@ public sealed class RouteHandlers : IRouteHandlers
 
     private async ValueTask ExportHierarchicalJson(HttpContext context, DataEntityMetadata meta, string typeSlug, IReadOnlyList<object?> items, ExportOptions options)
     {
-        var jsonOptions = new JsonSerializerOptions { WriteIndented = true };
+        var jsonOptions = JsonIndented;
         #pragma warning disable IL2026 // Serializing IReadOnlyList<object?> — all entity types preserved via TrimmerRootAssembly
         var json = JsonSerializer.Serialize(items, jsonOptions);
         #pragma warning restore IL2026
@@ -5063,7 +5095,7 @@ public sealed class RouteHandlers : IRouteHandlers
 
     private async ValueTask ExportSingleHierarchicalJson(HttpContext context, DataEntityMetadata meta, string typeSlug, string id, object instance, ExportOptions options)
     {
-        var jsonOptions = new JsonSerializerOptions { WriteIndented = true };
+        var jsonOptions = JsonIndented;
         #pragma warning disable IL2026 // Serializing entity instance — all entity types preserved via TrimmerRootAssembly
         var json = JsonSerializer.Serialize(instance, jsonOptions);
         #pragma warning restore IL2026
@@ -6878,7 +6910,7 @@ public sealed class RouteHandlers : IRouteHandlers
             html.Append(@"<th scope=""col"">Actions</th>");
         }
 
-        foreach (var field in metadata.Fields.Where(f => f.List).OrderBy(f => f.Order))
+        foreach (var field in metadata.ListFields)
         {
             var isSorted = string.Equals(field.Name, currentSort, StringComparison.OrdinalIgnoreCase);
             var nextDir = isSorted && string.Equals(currentDir, "asc", StringComparison.OrdinalIgnoreCase) ? "desc" : "asc";
@@ -6938,7 +6970,7 @@ public sealed class RouteHandlers : IRouteHandlers
             columnTitles.Add("");
         if (includeActions)
             columnTitles.Add("Actions");
-        columnTitles.AddRange(metadata.Fields.Where(f => f.List).OrderBy(f => f.Order).Select(f => f.Label));
+        columnTitles.AddRange(metadata.ListFields.Select(f => f.Label));
         
         foreach (var row in rows)
         {

--- a/BareMetalWeb.Host/RouteRegistrationExtensions.cs
+++ b/BareMetalWeb.Host/RouteRegistrationExtensions.cs
@@ -22,6 +22,9 @@ namespace BareMetalWeb.Host;
 /// </summary>
 public static class RouteRegistrationExtensions
 {
+    private static readonly JsonSerializerOptions JsonCompact = new() { WriteIndented = false };
+    private static readonly JsonSerializerOptions JsonIndented = new() { WriteIndented = true };
+
     /// <summary>
     /// Register static/public page routes (home, status).
     /// </summary>
@@ -403,7 +406,7 @@ public static class RouteRegistrationExtensions
 
                 context.Response.ContentType = "application/json";
                 await context.Response.WriteAsync(
-                    JsonSerializer.Serialize(result, new JsonSerializerOptions { WriteIndented = false }));
+                    JsonSerializer.Serialize(result, JsonCompact));
             }));
     }
 
@@ -482,9 +485,10 @@ public static class RouteRegistrationExtensions
         host.RegisterRoute("GET /api/_binary/{type}/_actions", new RouteHandlerData(raw, ActionApiHandlers.ListActionsHandler));
         host.RegisterRoute("POST /api/_binary/{type}/_action/{actionId}", new RouteHandlerData(raw, ActionApiHandlers.ExecuteActionHandler));
         host.RegisterRoute("GET /api/_metrics", new RouteHandlerData(raw, EngineMetricsHandler));
-        host.RegisterRoute("GET /api/_cluster", new RouteHandlerData(raw, ClusterApiHandlers.ClusterStatusHandler));
-        host.RegisterRoute("GET /api/_cluster/replicate", new RouteHandlerData(raw, ClusterApiHandlers.ReplicationHandler));
-        host.RegisterRoute("POST /api/_cluster/stepdown", new RouteHandlerData(raw, ClusterApiHandlers.StepDownHandler));
+        var adminOnly = pageInfoFactory.RawPage("admin", false);
+        host.RegisterRoute("GET /api/_cluster", new RouteHandlerData(adminOnly, ClusterApiHandlers.ClusterStatusHandler));
+        host.RegisterRoute("GET /api/_cluster/replicate", new RouteHandlerData(adminOnly, ClusterApiHandlers.ReplicationHandler));
+        host.RegisterRoute("POST /api/_cluster/stepdown", new RouteHandlerData(adminOnly, ClusterApiHandlers.StepDownHandler));
         host.RegisterRoute("GET /page/{slug}", new RouteHandlerData(raw, PageRenderer.RenderPageHandler));
         host.RegisterRoute("GET /api/pages", new RouteHandlerData(raw, PageRenderer.ListPagesHandler));
         host.RegisterRoute("GET /products", new RouteHandlerData(raw, ProductRenderer.CategoryBrowseHandler));
@@ -533,7 +537,7 @@ public static class RouteRegistrationExtensions
                     return;
                 }
 
-                var jsonOpts = new JsonSerializerOptions { WriteIndented = false };
+                var jsonOpts = JsonCompact;
 
                 // ── Upstream: walk RelatedDocument fields to find parent documents ──────────
                 var upstream = new List<object>();
@@ -639,7 +643,7 @@ public static class RouteRegistrationExtensions
             pageInfoFactory.RawPage("Authenticated", false),
             async context =>
             {
-                var jsonOpts = new JsonSerializerOptions { WriteIndented = false };
+                var jsonOpts = JsonCompact;
 
                 var nodes = new List<object>();
                 var links = new List<object>();
@@ -758,7 +762,7 @@ public static class RouteRegistrationExtensions
                 context.Response.ContentType = "application/json";
                 context.Response.Headers["Cache-Control"] = "private, max-age=300";
                 await context.Response.WriteAsync(
-                    JsonSerializer.Serialize(entities, new JsonSerializerOptions { WriteIndented = false }));
+                    JsonSerializer.Serialize(entities, JsonCompact));
             }));
 
         // Full schema for a single entity, including fields, lookups, computed, and commands
@@ -779,7 +783,7 @@ public static class RouteRegistrationExtensions
                 context.Response.ContentType = "application/json";
                 context.Response.Headers["Cache-Control"] = "private, max-age=300";
                 await context.Response.WriteAsync(
-                    JsonSerializer.Serialize(result, new JsonSerializerOptions { WriteIndented = false }));
+                    JsonSerializer.Serialize(result, JsonCompact));
             }));
 
         // VNext SPA shell — serve for all /UI and /UI/{*path} routes (default UI).
@@ -810,7 +814,7 @@ public static class RouteRegistrationExtensions
     {
         var queryService = new BareMetalWeb.Runtime.QueryService();
         var commandService = new BareMetalWeb.Runtime.CommandService();
-        var jsonOptions = new JsonSerializerOptions { WriteIndented = false };
+        var jsonOptions = JsonCompact;
 
         // GET /meta/entity/{name} — RuntimeEntityModel schema + DataEntityMetadata fields
         host.RegisterRoute("GET /meta/entity/{name}", new RouteHandlerData(
@@ -1489,7 +1493,7 @@ public static class RouteRegistrationExtensions
                         .ToArray()
                 };
                 context.Response.ContentType = "application/json";
-                await context.Response.WriteAsync(JsonSerializer.Serialize(json, new JsonSerializerOptions { WriteIndented = false }));
+                await context.Response.WriteAsync(JsonSerializer.Serialize(json, JsonCompact));
             }));
 
         // GET /api/reports/_distinct/{entity}/{field} — distinct field values for dropdown population
@@ -1504,7 +1508,7 @@ public static class RouteRegistrationExtensions
 
                 context.Response.StatusCode = 200;
                 context.Response.ContentType = "application/json";
-                await context.Response.WriteAsync(JsonSerializer.Serialize(values, new JsonSerializerOptions { WriteIndented = false }));
+                await context.Response.WriteAsync(JsonSerializer.Serialize(values, JsonCompact));
             }));
     }
 
@@ -1662,7 +1666,7 @@ public static class RouteRegistrationExtensions
                 hasElevated = resolved.HasElevatedPermissions;
             }
 
-            var json = EscapeJsonForInlineScript(JsonSerializer.Serialize(entities, new JsonSerializerOptions { WriteIndented = false }));
+            var json = EscapeJsonForInlineScript(JsonSerializer.Serialize(entities, JsonCompact));
             var sb = new StringBuilder();
             sb.Append($"<script nonce=\"{safeNonce}\">window.__BMW_META_OBJECTS__={json};");
             if (hasElevated)
@@ -1690,7 +1694,7 @@ public static class RouteRegistrationExtensions
                 return null;
 
             var schema = BuildEntitySchema(meta);
-            var schemaJson = EscapeJsonForInlineScript(JsonSerializer.Serialize(schema, new JsonSerializerOptions { WriteIndented = false }));
+            var schemaJson = EscapeJsonForInlineScript(JsonSerializer.Serialize(schema, JsonCompact));
 
             var safeSlug = JsonSerializer.Serialize(slug);
             return $"<script nonce=\"{safeNonce}\">window.__BMW_META_SLUG__=window.__BMW_META_SLUG__||{{}};window.__BMW_META_SLUG__[{safeSlug}]={schemaJson};</script>";
@@ -1766,14 +1770,14 @@ public static class RouteRegistrationExtensions
                 ["total"] = total
             };
 
-            var initialJson = EscapeJsonForInlineScript(JsonSerializer.Serialize(initialData, new JsonSerializerOptions { WriteIndented = false }));
+            var initialJson = EscapeJsonForInlineScript(JsonSerializer.Serialize(initialData, JsonCompact));
 
             // Pre-resolve FK lookup values for all lookup fields visible in the list view.
             // This allows the client to skip the /api/_lookup/{slug}/_batch round-trips.
             var lookupPrefetch = await BuildLookupPrefetchAsync(meta, payload, cancellationToken).ConfigureAwait(false);
             string? prefetchJson = null;
             if (lookupPrefetch != null)
-                prefetchJson = EscapeJsonForInlineScript(JsonSerializer.Serialize(lookupPrefetch, new JsonSerializerOptions { WriteIndented = false }));
+                prefetchJson = EscapeJsonForInlineScript(JsonSerializer.Serialize(lookupPrefetch, JsonCompact));
 
             var scriptContent = $"window.__BMW_INITIAL_DATA__={initialJson};";
             if (prefetchJson != null)


### PR DESCRIPTION
## Critical Fixes Batch

### 🔴 Security — #664
- Cluster API endpoints (`/api/_cluster`, `/api/_cluster/replicate`, `POST /api/_cluster/stepdown`) now require **admin** permission

### 🔴 Data Integrity — #667, #668
- **FileLeaseAuthority TOCTOU**: Stale lease cleanup uses single `CreateNew` retry (no recursive call), epoch writes atomically via temp+rename, renewal verifies lease file existence
- **ClusterState fence gaps**: Epoch captured atomically with write validation in `AssignLsn()`

### 🔴 Performance — #686, #687, #698, #670, #696

| Fix | Impact |
|-----|--------|
| Cache `JsonSerializerOptions` as static readonly | 12+ per-request heap allocs eliminated |
| Source-generate Regex (PageRenderer), compile others | ~7 hot-path regex compilations eliminated |
| Move `Thread.Sleep` outside lock scope | Unblocks concurrent threads during retry backoff |
| Cache `Key.ToString()` in Save (8→1) and Load (4→1) | Eliminates repeated uint→string per CRUD op |
| StringBuilder CSV builder | Eliminates `string.Join` + `.Select()` per row on export |
| Fast-path `ValueTask.IsCompleted` check | Avoids thread pool blocking on synchronous completions |
| Cached `ListFields`/`ViewFields`/`CreateFields`/`EditFields` arrays | Eliminates per-render LINQ `Where+OrderBy+ToArray` (18+ call sites) |

Closes #664, #667, #668, #670, #686, #687, #696, #698