### PR TITLE
security: upgrade API key to 256-bit entropy (#666)

### DIFF
--- a/BareMetalWeb.Data/SystemPrincipal.cs
+++ b/BareMetalWeb.Data/SystemPrincipal.cs
@@ -75,7 +75,11 @@ public sealed class SystemPrincipal : User
     }
 
     public static string GenerateRawApiKey()
-        => Guid.NewGuid().ToString("N");
+    {
+        Span<byte> bytes = stackalloc byte[32];
+        System.Security.Cryptography.RandomNumberGenerator.Fill(bytes);
+        return Convert.ToHexString(bytes).ToLowerInvariant();
+    }
 
     private string EncodeApiKey(string apiKey)
     {


### PR DESCRIPTION
One-liner: `RandomNumberGenerator.Fill(32 bytes)` replaces `Guid.NewGuid()`.

- 128-bit → 256-bit entropy
- 32-char → 64-char lowercase hex output
- Backward compatible: existing keys already hashed+salted, no migration needed

Closes #666