### PR TITLE
fix: handle non-numeric session cookies gracefully (500 crash)

### DIFF
--- a/BareMetalWeb.Host/UserAuth.cs
+++ b/BareMetalWeb.Host/UserAuth.cs
@@ -32,7 +32,13 @@ public static class UserAuth
             return null;
         }
 
-        var session = DataStoreProvider.Current.Load<UserSession>(uint.Parse(sessionId));
+        if (!uint.TryParse(sessionId, out var sessionKey))
+        {
+            context.DeleteCookie(SessionCookieName);
+            return null;
+        }
+
+        var session = DataStoreProvider.Current.Load<UserSession>(sessionKey);
         if (session == null)
             return null;
 
@@ -86,7 +92,13 @@ public static class UserAuth
             return null;
         }
 
-        var session = await DataStoreProvider.Current.LoadAsync<UserSession>(uint.Parse(sessionId), cancellationToken).ConfigureAwait(false);
+        if (!uint.TryParse(sessionId, out var sessionKey))
+        {
+            context.DeleteCookie(SessionCookieName);
+            return null;
+        }
+
+        var session = await DataStoreProvider.Current.LoadAsync<UserSession>(sessionKey, cancellationToken).ConfigureAwait(false);
         if (session == null)
             return null;
 
@@ -131,7 +143,10 @@ public static class UserAuth
         if (session == null)
             return null;
 
-        var user = await Users.GetByIdAsync(uint.Parse(session.UserId), cancellationToken).ConfigureAwait(false);
+        if (!uint.TryParse(session.UserId, out var userId))
+            return null;
+
+        var user = await Users.GetByIdAsync(userId, cancellationToken).ConfigureAwait(false);
         if (user == null || !user.IsActive)
             return null;
 


### PR DESCRIPTION
**Root cause:** Old GUID-based session cookies survive the uint32 key migration. `uint.Parse(sessionId)` throws `FormatException` → unhandled → 500 on every page load.

**Fix:** Replace `uint.Parse` with `uint.TryParse` in all three paths:
- `GetSession()` (sync, line 35)
- `GetSessionAsync()` (async, line 89)
- `GetUserAsync()` (UserId parse, line 140)

Invalid cookies are cleared and the request proceeds as anonymous.

Closes #706