### PR TITLE
fix: narrow swallowed exception handlers for diagnostics

### DIFF
--- a/BareMetalWeb.Data/TransactionCommitEngine.cs
+++ b/BareMetalWeb.Data/TransactionCommitEngine.cs
@@ -225,7 +225,10 @@ public sealed class TransactionCommitEngine
         foreach (var field in layout.Fields)
         {
             try { field.Setter(clone, field.Getter(source)); }
-            catch { /* skip non-clonable fields */ }
+            catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+            {
+                System.Diagnostics.Debug.WriteLine($"CloneEntity: skipping field {field.Name}: {ex.GetType().Name}");
+            }
         }
         return clone;
     }

--- a/BareMetalWeb.Data/WalStore.cs
+++ b/BareMetalWeb.Data/WalStore.cs
@@ -189,7 +189,8 @@ public sealed class WalStore : IDisposable
                 FileShare.ReadWrite, 4096);
             return TryReadOpPayloadFromStream(fs, offset32, key, out payload);
         }
-        catch (IOException) { return false; }
+        catch (FileNotFoundException) { return false; }
+        catch (DirectoryNotFoundException) { return false; }
     }
 
     // ── IDisposable ───────────────────────────────────────────────────────────
@@ -205,7 +206,10 @@ public sealed class WalStore : IDisposable
             if (_visibleCommitPtr != WalConstants.NullPtr)
             {
                 try { WalSnapshot.Write(_directory, _visibleCommitPtr, HeadMap); }
-                catch { /* best-effort snapshot on shutdown */ }
+                catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException)
+                {
+                    System.Diagnostics.Debug.WriteLine($"WalStore: snapshot on shutdown failed: {ex.GetType().Name}: {ex.Message}");
+                }
             }
 
             _activeWriter?.WriteFooterAndClose();


### PR DESCRIPTION
Three locations silently caught all exceptions. Now:
- **CloneEntity**: catches non-fatal exceptions with `Debug.WriteLine` logging
- **WalStore.TryReadOpPayload**: catches only `FileNotFoundException`/`DirectoryNotFoundException` (not all `IOException`)
- **WalStore.Dispose**: logs snapshot failure via `Debug.WriteLine` instead of silent swallow

Closes #673