### PR TITLE
perf: add capacity hints to hot-path list/dict allocations

### DIFF
--- a/BareMetalWeb.Data/ReportExecutor.cs
+++ b/BareMetalWeb.Data/ReportExecutor.cs
@@ -108,7 +108,7 @@ public sealed class ReportExecutor
             if (toAccessor == null)
                 continue;
 
-            var hashMap = new Dictionary<string, List<BaseDataObject>>(StringComparer.OrdinalIgnoreCase);
+            var hashMap = new Dictionary<string, List<BaseDataObject>>(joinRows.Count, StringComparer.OrdinalIgnoreCase);
             foreach (var jr in joinRows)
             {
                 var key = GetStringValue(toAccessor, jr);

--- a/BareMetalWeb.Data/WalDataProvider.cs
+++ b/BareMetalWeb.Data/WalDataProvider.cs
@@ -296,7 +296,7 @@ public sealed class WalDataProvider : IDataProvider, IDisposable
         // ── Full scan (no usable index) ───────────────────────────────────────
 
         var canShortCircuit = query == null || query.Sorts.Count == 0;
-        var results         = new List<T>();
+        var results         = new List<T>(Math.Min(top, idMap.Count));
         int matched         = 0;
 
         foreach (var (objKey, walKey) in idMap)  // ConcurrentDictionary supports safe concurrent enumeration


### PR DESCRIPTION
Fixes #681

Two surgical capacity hints to eliminate unnecessary array doublings:

1. **WalDataProvider.Query** (full-scan path): `new List<T>(Math.Min(top, idMap.Count))` — pre-sizes to the smaller of the query limit or total entity count, avoiding 8-10 doublings on large scans.

2. **ReportExecutor join hashMap**: `new Dictionary<>(joinRows.Count, ...)` — pre-sizes to join row count (upper bound on unique keys).

Item 3 (DataScaffold `??=` caches) already has a comment explaining the pattern is intentionally idempotent — no fix needed.