### PR TITLE
fix: correct index file paths in Data Sizing page

### DIFF
--- a/BareMetalWeb.Host/RouteHandlers.cs
+++ b/BareMetalWeb.Host/RouteHandlers.cs
@@ -7268,11 +7268,11 @@ public sealed class RouteHandlers : IRouteHandlers
 
                 idMapSizes.TryGetValue(typeName, out long idMapBytes);
 
-                // Index / paged files in subfolders
+                // Index / paged files — stored under <dataRoot>/Index/<entity> and <dataRoot>/Paged/<entity>
                 long indexBytes  = 0;
                 foreach (var sub in new[] { "Paged", "Index" })
                 {
-                    var subDir = Path.Combine(entityFolder, sub);
+                    var subDir = Path.Combine(dataRoot, sub, typeName);
                     if (Directory.Exists(subDir))
                     {
                         foreach (var fi in new DirectoryInfo(subDir).EnumerateFiles("*", SearchOption.AllDirectories))


### PR DESCRIPTION
Fixes #724

The Data & Index Sizing admin page was looking for index files at `<dataRoot>/<entity>/Index/` and `<dataRoot>/<entity>/Paged/` — but they're actually stored at `<dataRoot>/Index/<entity>/` and `<dataRoot>/Paged/<entity>/`. The path components were swapped, so the scan always found zero bytes.

One-line fix: changed `Path.Combine(entityFolder, sub)` to `Path.Combine(dataRoot, sub, typeName)`.