### PR TITLE
fix: treeview styling + Subject nav visibility (#726, #732)

### DIFF
--- a/BareMetalWeb.Core/wwwroot/static/css/site.css
+++ b/BareMetalWeb.Core/wwwroot/static/css/site.css
@@ -209,13 +209,39 @@ body {
 .bm-data-tree-list {
     list-style: none;
     margin: 0;
-    padding-left: 1.5rem;
+    padding-left: 1.25rem;
     position: relative;
 }
 
+/* Remove left padding on the root-level list */
+.bm-data-tree-sidebar > .bm-data-tree-list {
+    padding-left: 0;
+}
+
 .bm-data-tree-list > li {
-    margin-bottom: 0.25rem;
+    margin-bottom: 0.15rem;
     position: relative;
+}
+
+/* Tree connector lines */
+.bm-data-tree-list .bm-data-tree-list > li::before {
+    content: '';
+    position: absolute;
+    left: -0.75rem;
+    top: 0;
+    height: 100%;
+    border-left: 1px solid var(--bs-border-color, rgba(0, 0, 0, 0.15));
+}
+.bm-data-tree-list .bm-data-tree-list > li:last-child::before {
+    height: 0.95rem;
+}
+.bm-data-tree-list .bm-data-tree-list > li::after {
+    content: '';
+    position: absolute;
+    left: -0.75rem;
+    top: 0.95rem;
+    width: 0.5rem;
+    border-top: 1px solid var(--bs-border-color, rgba(0, 0, 0, 0.15));
 }
 
 /* Tree item wrapper */
@@ -232,18 +258,18 @@ body {
 
 /* Expand/collapse toggle button */
 .bm-tree-toggle {
-    width: 1.2rem;
-    height: 1.2rem;
+    width: 1.4rem;
+    height: 1.4rem;
     display: inline-flex;
     align-items: center;
     justify-content: center;
     cursor: pointer;
     user-select: none;
-    font-size: 0.7rem;
+    font-size: 0.85rem;
     flex-shrink: 0;
     color: var(--bs-secondary-color, #6c757d);
     transition: color 0.15s ease;
-    border-radius: 0.15rem;
+    border-radius: 0.25rem;
 }
 
 .bm-tree-toggle:hover {

--- a/BareMetalWeb.Core/wwwroot/static/js/tree-view.js
+++ b/BareMetalWeb.Core/wwwroot/static/js/tree-view.js
@@ -20,19 +20,19 @@
                 const childList = li.querySelector(':scope > .bm-data-tree-list');
                 if (!childList) return;
                 
-                // Toggle visibility
+                const icon = this.querySelector('i');
+                if (!icon) return;
+
                 const isCurrentlyExpanded = !childList.classList.contains('d-none');
                 
                 if (isCurrentlyExpanded) {
-                    // Collapse
                     childList.classList.add('d-none');
-                    this.textContent = '▸';
+                    icon.className = 'bi bi-chevron-right';
                     this.classList.remove('bm-tree-expanded');
                     this.classList.add('bm-tree-collapsed');
                 } else {
-                    // Expand
                     childList.classList.remove('d-none');
-                    this.textContent = '▾';
+                    icon.className = 'bi bi-chevron-down';
                     this.classList.remove('bm-tree-collapsed');
                     this.classList.add('bm-tree-expanded');
                 }

--- a/BareMetalWeb.Core/wwwroot/static/js/vnext-app.js
+++ b/BareMetalWeb.Core/wwwroot/static/js/vnext-app.js
@@ -845,15 +845,16 @@
 
             var row = '<li class="bm-tree-item"><div class="bm-tree-node">';
             if (node.children.length > 0) {
-                var icon = isExpanded ? '&#9662;' : '&#9656;';
+                var icon = isExpanded ? '<i class="bi bi-chevron-down"></i>' : '<i class="bi bi-chevron-right"></i>';
                 var expCls = isExpanded ? 'bm-tree-expanded' : 'bm-tree-collapsed';
                 row += '<span class="bm-tree-toggle ' + expCls + '" onclick="(function(t){' +
                     'var li=t.closest(\'.bm-tree-item\');' +
                     'var ul=li&&li.querySelector(\':scope > ul\');' +
                     'if(!ul)return;' +
+                    'var ic=t.querySelector(\'i\');if(!ic)return;' +
                     'var exp=!ul.classList.contains(\'d-none\');' +
                     'ul.classList.toggle(\'d-none\',exp);' +
-                    't.innerHTML=exp?\'&#9656;\':\'&#9662;\';' +
+                    'ic.className=exp?\'bi bi-chevron-right\':\'bi bi-chevron-down\';' +
                     't.classList.toggle(\'bm-tree-expanded\',!exp);' +
                     't.classList.toggle(\'bm-tree-collapsed\',exp);' +
                     '})(this)">' + icon + '</span>';

--- a/BareMetalWeb.Data/DataScaffold.cs
+++ b/BareMetalWeb.Data/DataScaffold.cs
@@ -1206,7 +1206,9 @@ public static class DataScaffold
         // Add expand/collapse toggle for nodes with children
         if (hasChildren)
         {
-            var toggleIcon = isExpanded ? "▾" : "▸"; // Using triangle arrows
+            var toggleIcon = isExpanded
+                ? "<i class=\"bi bi-chevron-down\"></i>"
+                : "<i class=\"bi bi-chevron-right\"></i>";
             html.Append($"<span class=\"bm-tree-toggle {expandClass}\" data-item-id=\"{WebUtility.HtmlEncode(itemId)}\">{toggleIcon}</span>");
         }
         else

--- a/BareMetalWeb.UserClasses/DataObjects/Subject.cs
+++ b/BareMetalWeb.UserClasses/DataObjects/Subject.cs
@@ -3,7 +3,7 @@ using BareMetalWeb.Data;
 
 namespace BareMetalWeb.Data.DataObjects;
 
-[DataEntity("Subjects", ShowOnNav = false, NavGroup = "Admin", NavOrder = 10)]
+[DataEntity("Subjects", ShowOnNav = true, NavGroup = "School", NavOrder = 10)]
 public class Subject : RenderableDataObject
 {
     [DataField(Label = "Name", Order = 1, Required = true)]


### PR DESCRIPTION
## Changes

### Treeview Visual Improvements (#726)
- Replace tiny unicode toggle arrows (▸/▾) with Bootstrap Icons (`bi-chevron-right`/`bi-chevron-down`)
- Add tree connector lines via CSS pseudo-elements for clear parent-child hierarchy
- Remove unnecessary root-level left padding on tree sidebar
- Increase toggle hit target size (0.7rem → 0.85rem, 1.2rem → 1.4rem)
- Update client-side JS (tree-view.js + vnext-app.js) to swap icon classes instead of text content

### Subject Lookup (#732)
- Make Subject entity visible in navigation (`ShowOnNav = true`, `NavGroup = "School"`) so users can create and manage subjects
- The TTP editor lookup dropdown can only show subject names if Subject records exist and are accessible

Closes #726
Closes #732