### PR TITLE
feat: proxy lease-owner affinity cookie injection

### DIFF
--- a/BareMetalWeb.Host/BareMetalWebExtensions.cs
+++ b/BareMetalWeb.Host/BareMetalWebExtensions.cs
@@ -218,6 +218,7 @@ public static class BareMetalWebExtensions
         var clusterState = new BareMetalWeb.Data.ClusterState(new BareMetalWeb.Data.LocalLeaseAuthority());
         _ = clusterState.TryBecomeLeaderAsync(CancellationToken.None);
         ClusterApiHandlers.Initialize(clusterState);
+        ProxyRouteHandler.Initialize(clusterState);
 
         appInfo.RegisterBinaryApiRoutes(routeHandlers, pageInfoFactory, mainTemplate);       // binary wire-format API
         appInfo.RegisterApiRoutes(routeHandlers, pageInfoFactory);

--- a/BareMetalWeb.Host/ProxyRouteHandler.cs
+++ b/BareMetalWeb.Host/ProxyRouteHandler.cs
@@ -1,7 +1,9 @@
 using System.Net;
 using System.Net.Http.Headers;
+using System.Security.Cryptography;
 using System.Text;
 using BareMetalWeb.Core.Interfaces;
+using BareMetalWeb.Data;
 using BareMetalWeb.Interfaces;
 using Microsoft.Extensions.Primitives;
 
@@ -45,6 +47,11 @@ public sealed class ProxyRouteHandler
         HttpStatusCode.ServiceUnavailable,
         HttpStatusCode.GatewayTimeout
     };
+
+    private static ClusterState? _clusterState;
+
+    /// <summary>Set the cluster state reference so proxy handlers can inject lease-owner affinity cookies.</summary>
+    public static void Initialize(ClusterState clusterState) => _clusterState = clusterState;
 
     private readonly ProxyRouteConfig _route;
     private readonly IBufferedLogger _logger;
@@ -131,6 +138,7 @@ public sealed class ProxyRouteHandler
 
             CopyRequestHeaders(context, requestMessage);
             ApplyTraceId(context, requestMessage);
+            ApplyLeaseAffinityCookie(requestMessage);
 
             try
             {
@@ -386,6 +394,35 @@ public sealed class ProxyRouteHandler
         {
             context.Response.Headers.TryAdd(_route.TraceIdHeader, traceId);
         }
+    }
+
+    private void ApplyLeaseAffinityCookie(HttpRequestMessage requestMessage)
+    {
+        if (!_route.LeaseAffinityCookieEnabled || _clusterState == null)
+            return;
+
+        var instanceId = _clusterState.InstanceId;
+        if (string.IsNullOrEmpty(instanceId))
+            return;
+
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(instanceId));
+        var affinityValue = Convert.ToHexStringLower(hash);
+        var cookieName = string.IsNullOrWhiteSpace(_route.LeaseAffinityCookieName)
+            ? "ARRAffinity"
+            : _route.LeaseAffinityCookieName;
+
+        // Append (or create) the Cookie header with the affinity cookie
+        var existing = requestMessage.Headers.TryGetValues("Cookie", out var vals)
+            ? string.Join("; ", vals)
+            : null;
+        var affinityCookie = $"{cookieName}={affinityValue}";
+        var sameSiteCookie = $"{cookieName}SameSite={affinityValue}";
+        var combined = string.IsNullOrWhiteSpace(existing)
+            ? $"{affinityCookie}; {sameSiteCookie}"
+            : $"{existing}; {affinityCookie}; {sameSiteCookie}";
+
+        requestMessage.Headers.Remove("Cookie");
+        requestMessage.Headers.TryAddWithoutValidation("Cookie", combined);
     }
 
     private static async Task<byte[]?> TryBufferRequestBodyAsync(HttpContext context, int maxBytes)

--- a/BareMetalWeb.Host/ProxyRoutingOptions.cs
+++ b/BareMetalWeb.Host/ProxyRoutingOptions.cs
@@ -47,6 +47,16 @@ public sealed class ProxyRouteConfig
     public double FailurePercentageThreshold { get; set; } = 50;
     public int MinimumRequestsInWindow { get; set; } = 10;
     public int OfflineSeconds { get; set; } = 60;
+
+    /// <summary>
+    /// When true, the proxy injects an ARRAffinity cookie into outgoing requests
+    /// using a SHA-256 hash of the current lease owner's InstanceId.
+    /// This pins proxied requests to the backend instance that holds the cluster lease.
+    /// </summary>
+    public bool LeaseAffinityCookieEnabled { get; set; } = false;
+
+    /// <summary>Cookie name for lease affinity (default: ARRAffinity).</summary>
+    public string LeaseAffinityCookieName { get; set; } = "ARRAffinity";
 }
 
 public sealed class ProxyTargetState


### PR DESCRIPTION
## Feature

When `LeaseAffinityCookieEnabled` is set on a proxy route config, the proxy injects **ARRAffinity** and **ARRAffinitySameSite** cookies into outgoing proxied requests. The cookie value is a **SHA-256 hash of the current cluster lease owner's InstanceId**.

This pins proxied requests to the backend instance that holds the cluster write lease, so load-balanced requests (e.g. through Azure App Service ARR) route to the elected leader.

## Config

```json
{
  "Proxy": {
    "Routes": [{
      "Route": "/api/backend",
      "TargetBaseUrl": "https://myapp.azurewebsites.net",
      "LeaseAffinityCookieEnabled": true,
      "LeaseAffinityCookieName": "ARRAffinity"
    }]
  }
}
```

## Implementation

| File | Change |
|------|--------|
| `ProxyRouteHandler.cs` | Added `Initialize(ClusterState)`, `ApplyLeaseAffinityCookie()` — SHA-256 hash of InstanceId injected as cookie |
| `ProxyRoutingOptions.cs` | Added `LeaseAffinityCookieEnabled` and `LeaseAffinityCookieName` config properties |
| `BareMetalWebExtensions.cs` | Wired `ProxyRouteHandler.Initialize(clusterState)` at startup |

The existing JSON API endpoints and proxy status endpoint are unchanged.