### PR TITLE
fix: menu cleanup — deduplicate nav, move items to correct groups

### DIFF
--- a/BareMetalWeb.Host/RouteRegistrationExtensions.cs
+++ b/BareMetalWeb.Host/RouteRegistrationExtensions.cs
@@ -246,9 +246,9 @@ public static class RouteRegistrationExtensions
         IPageInfoFactory pageInfoFactory,
         IHtmlTemplate mainTemplate)
     {
-        // Entity browsing
+        // Entity browsing (SSR legacy — hidden from nav; VNext /UI is the primary entry point)
         host.RegisterRoute("GET /ssr/admin/data", new RouteHandlerData(
-            pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "message" }, new[] { "Data", "" }, "Authenticated", true, 1, navGroup: "Admin", navAlignment: NavAlignment.Right),
+            pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "message" }, new[] { "Data", "" }, "Authenticated", false, 1, navGroup: "Admin", navAlignment: NavAlignment.Right),
             routeHandlers.DataEntitiesHandler));
 
         host.RegisterRoute("GET /ssr/admin/data/{type}", new RouteHandlerData(

--- a/BareMetalWeb.UserClasses/DataObjects/DomainEventSubscription.cs
+++ b/BareMetalWeb.UserClasses/DataObjects/DomainEventSubscription.cs
@@ -7,7 +7,7 @@ namespace BareMetalWeb.Data.DataObjects;
 /// transitions to a specific value, fire a registered action on a target aggregate.
 /// No scripting — deterministic, replay-safe, runs inside commit pipeline.
 /// </summary>
-[DataEntity("Webhooks", Slug = "domain-event-subscriptions", ShowOnNav = true, NavGroup = "Automation", NavOrder = 10, Permissions = "admin")]
+[DataEntity("Webhooks", Slug = "domain-event-subscriptions", ShowOnNav = true, NavGroup = "Admin", NavOrder = 50, Permissions = "admin")]
 public class DomainEventSubscription : RenderableDataObject
 {
     /// <summary>Human-readable label for this subscription.</summary>

--- a/BareMetalWeb.UserClasses/DataObjects/Product.cs
+++ b/BareMetalWeb.UserClasses/DataObjects/Product.cs
@@ -12,6 +12,7 @@ public class Product : RenderableDataObject
     public string Sku { get; set; } = string.Empty;
 
     [DataField(Label = "Category", Order = 3)]
+    [DataLookup(typeof(ProductCategory), DisplayField = "Name", SortField = "Name", SortDirection = SortDirection.Asc, CacheSeconds = 120)]
     [DataIndex]
     public string Category { get; set; } = string.Empty;
 

--- a/BareMetalWeb.UserClasses/DataObjects/ProductEntities.cs
+++ b/BareMetalWeb.UserClasses/DataObjects/ProductEntities.cs
@@ -3,7 +3,7 @@ using BareMetalWeb.Data;
 namespace BareMetalWeb.Data.DataObjects;
 
 /// <summary>Product category for browsing hierarchy.</summary>
-[DataEntity("Product Categories", ShowOnNav = true, NavGroup = "Commerce", NavOrder = 5)]
+[DataEntity("Product Categories", ShowOnNav = true, NavGroup = "Sales", NavOrder = 15)]
 public class ProductCategory : RenderableDataObject
 {
     [DataField(Label = "Name", Order = 1, Required = true)]


### PR DESCRIPTION
## Changes

### #749 — System menu items rendering twice
The SSR `/ssr/admin/data` route was registered with `ShowOnNavBar = true`, adding a duplicate "Data" entry in the Admin dropdown (the VNext `/UI` route already provides this). Fixed by setting `ShowOnNavBar = false` on the SSR route.

### #742 — Domain Event Subscriptions under wrong menu
Moved `DomainEventSubscription` (Webhooks) from `NavGroup = "Automation"` → `NavGroup = "Admin"` so it appears in the right-side admin menu with other admin-only items.

### #743 — ProductCategory under wrong group + missing FK
- Moved `ProductCategory` from `NavGroup = "Commerce"` → `NavGroup = "Sales"` to group with Products
- Added `[DataLookup(typeof(ProductCategory), ...)]` on `Product.Category` so the edit form renders a dropdown instead of a free-text field

Closes #749, closes #742, closes #743