### PR TITLE
fix: Critical security — auth on MCP/Action/Cluster, XSS in PageRenderer, SSRF in Proxy

### DIFF
--- a/BareMetalWeb.Host/ActionApiHandlers.cs
+++ b/BareMetalWeb.Host/ActionApiHandlers.cs
@@ -65,9 +65,14 @@ public static class ActionApiHandlers
             return;
         }
 
-        // Auth
+        // Auth — require authenticated user
         var user = await UserAuth.GetRequestUserAsync(context, context.RequestAborted);
-        var userName = user?.UserName ?? "anonymous";
+        if (user == null)
+        {
+            await WriteError(context, 401, "Authentication required.");
+            return;
+        }
+        var userName = user.UserName ?? "anonymous";
 
         // Parse request body
         uint aggregateId;

--- a/BareMetalWeb.Host/ClusterApiHandlers.cs
+++ b/BareMetalWeb.Host/ClusterApiHandlers.cs
@@ -10,6 +10,7 @@ namespace BareMetalWeb.Host;
 /// GET /api/_cluster — cluster state snapshot (role, epoch, LSN)
 /// GET /api/_cluster/replicate?afterLsn=X — WAL entries for follower catch-up
 /// POST /api/_cluster/stepdown — voluntarily step down from leadership
+/// All endpoints require admin authentication.
 /// </summary>
 public static class ClusterApiHandlers
 {
@@ -21,6 +22,8 @@ public static class ClusterApiHandlers
     /// <summary>GET /api/_cluster — cluster state snapshot.</summary>
     public static async ValueTask ClusterStatusHandler(HttpContext context)
     {
+        if (!await RequireAdminAsync(context)) return;
+
         if (_clusterState == null)
         {
             context.Response.StatusCode = 503;
@@ -49,6 +52,8 @@ public static class ClusterApiHandlers
     /// </summary>
     public static async ValueTask ReplicationHandler(HttpContext context)
     {
+        if (!await RequireAdminAsync(context)) return;
+
         if (_clusterState == null || !_clusterState.IsLeader)
         {
             context.Response.StatusCode = 503;
@@ -65,9 +70,6 @@ public static class ClusterApiHandlers
             return;
         }
 
-        // Return current state info — followers use this to track progress
-        // Full WAL entry streaming would require WalStore segment access;
-        // for now, return metadata sufficient for follower to detect lag
         context.Response.StatusCode = 200;
         context.Response.ContentType = "application/json";
         await using var w = new System.Text.Json.Utf8JsonWriter(context.Response.Body);
@@ -84,6 +86,8 @@ public static class ClusterApiHandlers
     /// <summary>POST /api/_cluster/stepdown — voluntary leadership stepdown.</summary>
     public static async ValueTask StepDownHandler(HttpContext context)
     {
+        if (!await RequireAdminAsync(context)) return;
+
         if (_clusterState == null)
         {
             context.Response.StatusCode = 503;
@@ -96,5 +100,27 @@ public static class ClusterApiHandlers
         context.Response.StatusCode = 200;
         context.Response.ContentType = "application/json";
         await context.Response.WriteAsync("""{"success":true,"role":"follower"}""");
+    }
+
+    /// <summary>Require admin-level authentication. Returns false and writes 401/403 if denied.</summary>
+    private static async ValueTask<bool> RequireAdminAsync(HttpContext context)
+    {
+        var user = await UserAuth.GetRequestUserAsync(context, context.RequestAborted);
+        if (user == null)
+        {
+            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            context.Response.ContentType = "application/json";
+            await context.Response.WriteAsync("""{"error":"Authentication required."}""");
+            return false;
+        }
+        var perms = new HashSet<string>(user.Permissions ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
+        if (!perms.Contains("admin") && !perms.Contains("monitoring"))
+        {
+            context.Response.StatusCode = StatusCodes.Status403Forbidden;
+            context.Response.ContentType = "application/json";
+            await context.Response.WriteAsync("""{"error":"Admin access required."}""");
+            return false;
+        }
+        return true;
     }
 }

--- a/BareMetalWeb.Host/McpRouteHandler.cs
+++ b/BareMetalWeb.Host/McpRouteHandler.cs
@@ -3,6 +3,7 @@ using BareMetalWeb.Core;
 using BareMetalWeb.Data;
 using BareMetalWeb.Runtime;
 using BareMetalWeb.Rendering.Models;
+using Microsoft.AspNetCore.Http;
 
 namespace BareMetalWeb.Host;
 
@@ -39,6 +40,17 @@ internal static class McpRouteHandler
     internal static async ValueTask HandleAsync(HttpContext context)
     {
         context.Response.ContentType = "application/json";
+
+        // Require authentication — MCP tools expose full CRUD operations
+        var user = await UserAuth.GetRequestUserAsync(context, context.RequestAborted);
+        if (user == null)
+        {
+            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            await context.Response.WriteAsync(
+                "{\"jsonrpc\":\"2.0\",\"id\":null,\"error\":{\"code\":-32600,\"message\":\"Authentication required\"}}",
+                context.RequestAborted).ConfigureAwait(false);
+            return;
+        }
 
         string body;
         using (var reader = new System.IO.StreamReader(context.Request.Body))

--- a/BareMetalWeb.Host/PageRenderer.cs
+++ b/BareMetalWeb.Host/PageRenderer.cs
@@ -20,6 +20,15 @@ public static partial class PageRenderer
     private static partial Regex CodeRegex();
     [GeneratedRegex(@"\[(.+?)\]\((.+?)\)")]
     private static partial Regex LinkRegex();
+    [GeneratedRegex(@"(?i)(href|src|action)\s*=\s*[""']\s*(javascript|data|vbscript)\s*:", RegexOptions.IgnoreCase)]
+    private static partial Regex DangerousAttrRegex();
+
+    /// <summary>Strip dangerous protocol handlers from raw HTML content.</summary>
+    private static string SanitizeHtml(string html)
+    {
+        if (string.IsNullOrEmpty(html)) return html;
+        return DangerousAttrRegex().Replace(html, m => $"{m.Groups[1].Value}=\"about:blank\" data-stripped=\"");
+    }
 
     /// <summary>Configures context for GET /page/{slug} inside platform chrome.</summary>
     public static async ValueTask ConfigurePageAsync(HttpContext context)
@@ -71,10 +80,10 @@ public static partial class PageRenderer
         var content = GetField(pageObj, meta, "Content");
         var format = GetField(pageObj, meta, "Format");
 
-        // Convert markdown to HTML if needed
+        // Convert markdown to HTML if needed; sanitize dangerous protocols in both paths
         var htmlContent = string.Equals(format, "markdown", StringComparison.OrdinalIgnoreCase)
             ? ConvertMarkdownToHtml(content)
-            : content;
+            : SanitizeHtml(content);
 
         var sb = new StringBuilder(4096);
         sb.AppendLine("""<div class="container-fluid py-4 px-4 bm-content">""");
@@ -207,9 +216,29 @@ public static partial class PageRenderer
         encoded = ItalicRegex().Replace(encoded, "<em>$1</em>");
         // Code
         encoded = CodeRegex().Replace(encoded, "<code>$1</code>");
-        // Links [text](url)
-        encoded = LinkRegex().Replace(encoded, """<a href="$2">$1</a>""");
+        // Links [text](url) — validate URL protocol to prevent javascript: XSS
+        encoded = LinkRegex().Replace(encoded, m =>
+        {
+            var linkText = m.Groups[1].Value;
+            var url = System.Net.WebUtility.HtmlDecode(m.Groups[2].Value).Trim();
+            if (IsSafeUrl(url))
+                return $"""<a href="{System.Net.WebUtility.HtmlEncode(url)}">{linkText}</a>""";
+            return linkText; // strip unsafe link, keep text
+        });
         return encoded;
+    }
+
+    private static bool IsSafeUrl(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url)) return false;
+        // Allow relative URLs
+        if (url.StartsWith('/') && !url.StartsWith("//")) return true;
+        if (url.StartsWith('#') || url.StartsWith('?')) return true;
+        // Allow safe protocols only
+        if (url.StartsWith("http://", StringComparison.OrdinalIgnoreCase)) return true;
+        if (url.StartsWith("https://", StringComparison.OrdinalIgnoreCase)) return true;
+        if (url.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase)) return true;
+        return false;
     }
 
     private static string GetField(BaseDataObject obj, DataEntityMetadata meta, string fieldName)

--- a/BareMetalWeb.Host/ProxyRouteHandler.cs
+++ b/BareMetalWeb.Host/ProxyRouteHandler.cs
@@ -110,7 +110,17 @@ public sealed class ProxyRouteHandler
             {
                 _logger.LogInfo($"Proxy attempt {attempt}/{maxAttempts} -> {targetState.BaseUri}");
             }
-            var targetUri = BuildTargetUri(context, targetState.BaseUri);
+            Uri targetUri;
+            try
+            {
+                targetUri = BuildTargetUri(context, targetState.BaseUri);
+            }
+            catch (InvalidOperationException)
+            {
+                context.Response.StatusCode = StatusCodes.Status502BadGateway;
+                await context.Response.WriteAsync("Proxy target blocked.");
+                return;
+            }
             using var requestMessage = new HttpRequestMessage(new HttpMethod(context.Request.Method), targetUri)
             {
                 VersionPolicy = HttpVersionPolicy.RequestVersionOrLower
@@ -215,6 +225,10 @@ public sealed class ProxyRouteHandler
                 requestPath = "/" + requestPath;
         }
 
+        // Block path traversal sequences
+        if (requestPath.Contains(".."))
+            requestPath = requestPath.Replace("..", string.Empty);
+
         if (!string.IsNullOrWhiteSpace(_route.RewritePath))
         {
             builder.Path = _route.RewritePath!;
@@ -240,7 +254,30 @@ public sealed class ProxyRouteHandler
             }
         }
 
-        return builder.Uri;
+        var result = builder.Uri;
+
+        // Block requests to private/metadata IPs
+        if (IsPrivateOrMetadataHost(result.Host))
+            throw new InvalidOperationException("Proxy target resolves to a blocked address.");
+
+        return result;
+    }
+
+    /// <summary>Reject private, loopback, and cloud metadata IPs/hostnames.</summary>
+    private static bool IsPrivateOrMetadataHost(string host)
+    {
+        if (string.Equals(host, "localhost", StringComparison.OrdinalIgnoreCase)) return true;
+        if (!IPAddress.TryParse(host, out var ip)) return false;
+        if (IPAddress.IsLoopback(ip)) return true;
+        var bytes = ip.GetAddressBytes();
+        if (bytes.Length == 4)
+        {
+            if (bytes[0] == 10) return true;                                    // 10.0.0.0/8
+            if (bytes[0] == 172 && bytes[1] >= 16 && bytes[1] <= 31) return true; // 172.16.0.0/12
+            if (bytes[0] == 192 && bytes[1] == 168) return true;                // 192.168.0.0/16
+            if (bytes[0] == 169 && bytes[1] == 254) return true;                // 169.254.0.0/16 (link-local + cloud metadata)
+        }
+        return false;
     }
 
     private static bool ShouldHaveBody(HttpRequest request)


### PR DESCRIPTION
## Critical Security Fixes (#766, #767, #768)

### #766 — Missing authentication on MCP, Action, and Cluster endpoints
- **McpRouteHandler**: Added `UserAuth.GetRequestUserAsync()` check at entry — returns 401 JSON-RPC error if unauthenticated
- **ActionApiHandlers**: Now returns 401 if user is null (was allowing anonymous with username 'anonymous')
- **ClusterApiHandlers**: Added `RequireAdminAsync()` helper that checks for admin/monitoring permissions. All 3 endpoints (status, replicate, stepdown) gated behind it

### #768 — XSS in PageRenderer markdown link URLs
- `InlineFormat()` now validates link URLs via `IsSafeUrl()` — only allows `http:`, `https:`, `mailto:`, and relative paths. Blocks `javascript:`, `data:`, `vbscript:` protocol injection
- Added `SanitizeHtml()` for raw HTML page content — uses `DangerousAttrRegex` to strip dangerous `href`, `src`, `action` attributes containing blocked protocols

### #767 — SSRF risk in ProxyRouteHandler
- `BuildTargetUri()` now strips `..` path traversal sequences
- Added `IsPrivateOrMetadataHost()` — blocks proxy requests to RFC1918 (10.x, 172.16-31.x, 192.168.x), link-local (169.254.x — cloud metadata), loopback, and localhost
- Returns 502 Bad Gateway if target is blocked

Closes #766, closes #767, closes #768