### PR TITLE
fix: HIGH security — CSRF, unbounded queries, body limits, full scans, N+1

### DIFF
--- a/BareMetalWeb.Host/ActionApiHandlers.cs
+++ b/BareMetalWeb.Host/ActionApiHandlers.cs
@@ -42,6 +42,14 @@ public static class ActionApiHandlers
     /// </summary>
     public static async ValueTask ExecuteActionHandler(HttpContext context)
     {
+        // Content-Type and body size validation
+        if (!BinaryApiHandlers.HasValidApiContentType(context))
+        {
+            await WriteError(context, 415, "Unsupported Content-Type.");
+            return;
+        }
+        if (!await BinaryApiHandlers.CheckBodySizeAsync(context)) return;
+
         if (_commitEngine == null)
         {
             await WriteError(context, 500, "Action engine not initialized.");

--- a/BareMetalWeb.Host/BinaryApiHandlers.cs
+++ b/BareMetalWeb.Host/BinaryApiHandlers.cs
@@ -273,6 +273,8 @@ public static class BinaryApiHandlers
     /// </summary>
     public static async ValueTask CreateHandler(HttpContext context)
     {
+        if (!HasValidApiContentType(context)) { await WriteError(context, (415, "Unsupported Content-Type.")); return; }
+        if (!await CheckBodySizeAsync(context)) return;
         var (meta, _, error) = await ValidateAsync(context);
         if (meta == null) { await WriteError(context, error!.Value); return; }
         if (_serializer == null) { await WriteError(context, (500, "Binary API not initialized.")); return; }
@@ -298,6 +300,8 @@ public static class BinaryApiHandlers
     /// </summary>
     public static async ValueTask UpdateHandler(HttpContext context)
     {
+        if (!HasValidApiContentType(context)) { await WriteError(context, (415, "Unsupported Content-Type.")); return; }
+        if (!await CheckBodySizeAsync(context)) return;
         var (meta, _, error) = await ValidateAsync(context);
         if (meta == null) { await WriteError(context, error!.Value); return; }
         if (_serializer == null) { await WriteError(context, (500, "Binary API not initialized.")); return; }
@@ -355,6 +359,27 @@ public static class BinaryApiHandlers
     }
 
     // ────────────── Shared utilities ──────────────
+
+    private const long MaxRequestBodyBytes = 10 * 1024 * 1024; // 10 MB
+
+    /// <summary>Reject requests without a recognized Content-Type (CSRF mitigation).</summary>
+    internal static bool HasValidApiContentType(HttpContext context)
+    {
+        var ct = context.Request.ContentType ?? string.Empty;
+        return ct.Contains("application/json", StringComparison.OrdinalIgnoreCase)
+            || ct.Contains(BinaryContentType, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>Returns 413 if Content-Length exceeds the limit. Returns true if OK.</summary>
+    internal static async ValueTask<bool> CheckBodySizeAsync(HttpContext context, long maxBytes = MaxRequestBodyBytes)
+    {
+        if (context.Request.ContentLength.HasValue && context.Request.ContentLength.Value > maxBytes)
+        {
+            await WriteError(context, (StatusCodes.Status413PayloadTooLarge, $"Request body exceeds {maxBytes / (1024 * 1024)}MB limit."));
+            return false;
+        }
+        return true;
+    }
 
     private static bool WantsJson(HttpContext context)
     {

--- a/BareMetalWeb.Host/DeltaApiHandlers.cs
+++ b/BareMetalWeb.Host/DeltaApiHandlers.cs
@@ -22,6 +22,15 @@ public static class DeltaApiHandlers
     /// </summary>
     public static async ValueTask DeltaHandler(HttpContext context)
     {
+        // Content-Type and body size validation (CSRF mitigation + DoS prevention)
+        if (!BinaryApiHandlers.HasValidApiContentType(context)
+            && !(context.Request.ContentType ?? "").Contains(BinaryContentType, StringComparison.OrdinalIgnoreCase))
+        {
+            await WriteResult(context, 415, MutationResult.EntityNotFound, "Unsupported Content-Type.");
+            return;
+        }
+        if (!await BinaryApiHandlers.CheckBodySizeAsync(context)) return;
+
         // Resolve entity type + auth
         var typeSlug = BinaryApiHandlers.GetRouteValue(context, "type") ?? string.Empty;
         if (string.IsNullOrWhiteSpace(typeSlug))

--- a/BareMetalWeb.Host/LookupApiHandlers.cs
+++ b/BareMetalWeb.Host/LookupApiHandlers.cs
@@ -137,6 +137,7 @@ public static class LookupApiHandlers
                 .Select(e => e.GetString()!)
                 .Where(s => !string.IsNullOrWhiteSpace(s))
                 .Distinct()
+                .Take(500) // Cap batch size to prevent resource exhaustion
                 .ToList();
         }
         catch (JsonException)
@@ -504,8 +505,12 @@ public static class LookupApiHandlers
         if (!traverseRelationships)
             return result;
 
+        int traversed = 0;
+        const int MaxTraversals = 20; // Cap FK loads per entity to prevent N+1 explosion
         foreach (var field in meta.Fields.Where(f => f.View && f.Lookup != null))
         {
+            if (traversed >= MaxTraversals) break;
+
             if (!result.TryGetValue(field.Name, out var rawValue) || rawValue == null)
                 continue;
 
@@ -520,9 +525,11 @@ public static class LookupApiHandlers
             if (string.Equals(expandedKey, field.Name, StringComparison.Ordinal) || result.ContainsKey(expandedKey))
                 continue;
 
-            var related = await relatedMeta.Handlers.LoadAsync(uint.Parse(idStr), cancellationToken);
+            if (!uint.TryParse(idStr, out var relatedId)) continue;
+            var related = await relatedMeta.Handlers.LoadAsync(relatedId, cancellationToken);
             if (related != null)
                 result[expandedKey] = EntityToJson(related, relatedMeta);
+            traversed++;
         }
 
         return result;

--- a/BareMetalWeb.Host/McpRouteHandler.cs
+++ b/BareMetalWeb.Host/McpRouteHandler.cs
@@ -52,6 +52,16 @@ internal static class McpRouteHandler
             return;
         }
 
+        // Body size limit
+        if (context.Request.ContentLength.HasValue && context.Request.ContentLength.Value > 10 * 1024 * 1024)
+        {
+            context.Response.StatusCode = 413;
+            await context.Response.WriteAsync(
+                "{\"jsonrpc\":\"2.0\",\"id\":null,\"error\":{\"code\":-32600,\"message\":\"Request body too large\"}}",
+                context.RequestAborted).ConfigureAwait(false);
+            return;
+        }
+
         string body;
         using (var reader = new System.IO.StreamReader(context.Request.Body))
             body = await reader.ReadToEndAsync(context.RequestAborted).ConfigureAwait(false);

--- a/BareMetalWeb.Host/PageRenderer.cs
+++ b/BareMetalWeb.Host/PageRenderer.cs
@@ -51,22 +51,18 @@ public static partial class PageRenderer
             return;
         }
 
-        // Find published page by slug
-        var pages = await meta.Handlers.QueryAsync(null, context.RequestAborted);
-        BaseDataObject? pageObj = null;
-
-        foreach (var p in pages)
+        // Find published page by slug — use filtered query instead of full table scan
+        var queryDef = new BareMetalWeb.Data.QueryDefinition
         {
-            var pageSlug = GetField(p, meta, "Slug");
-            var status = GetField(p, meta, "Status");
-
-            if (string.Equals(pageSlug, slug, StringComparison.OrdinalIgnoreCase) &&
-                string.Equals(status, "published", StringComparison.OrdinalIgnoreCase))
+            Clauses = new()
             {
-                pageObj = p;
-                break;
-            }
-        }
+                new BareMetalWeb.Data.QueryClause { Field = "Slug", Operator = BareMetalWeb.Data.QueryOperator.Equals, Value = slug },
+                new BareMetalWeb.Data.QueryClause { Field = "Status", Operator = BareMetalWeb.Data.QueryOperator.Equals, Value = "published" }
+            },
+            Top = 1
+        };
+        var pages = await meta.Handlers.QueryAsync(queryDef, context.RequestAborted);
+        BaseDataObject? pageObj = pages.FirstOrDefault();
 
         if (pageObj == null)
         {

--- a/BareMetalWeb.Host/ProductRenderer.cs
+++ b/BareMetalWeb.Host/ProductRenderer.cs
@@ -23,7 +23,9 @@ public static class ProductRenderer
             return;
         }
 
-        var categories = await catMeta.Handlers.QueryAsync(null, context.RequestAborted);
+        // Load categories with cap to prevent unbounded queries
+        var catQuery = new BareMetalWeb.Data.QueryDefinition { Top = 1000 };
+        var categories = await catMeta.Handlers.QueryAsync(catQuery, context.RequestAborted);
         var catList = new List<(string Slug, string Name, string Desc, string Icon, int Order)>();
 
         foreach (var c in categories)
@@ -76,22 +78,28 @@ public static class ProductRenderer
             return;
         }
 
-        // Find category name
+        // Find category by slug — filtered query instead of full scan
         string categoryName = categorySlug;
         uint categoryKey = 0;
-        var cats = await catMeta.Handlers.QueryAsync(null, context.RequestAborted);
+        var catQueryDef = new BareMetalWeb.Data.QueryDefinition
+        {
+            Clauses = new() { new BareMetalWeb.Data.QueryClause { Field = "Slug", Operator = BareMetalWeb.Data.QueryOperator.Equals, Value = categorySlug } },
+            Top = 1
+        };
+        var cats = await catMeta.Handlers.QueryAsync(catQueryDef, context.RequestAborted);
         foreach (var c in cats)
         {
-            if (string.Equals(GetField(c, catMeta, "Slug"), categorySlug, StringComparison.OrdinalIgnoreCase))
-            {
-                categoryName = GetField(c, catMeta, "Name");
-                categoryKey = c.Key;
-                break;
-            }
+            categoryName = GetField(c, catMeta, "Name");
+            categoryKey = c.Key;
         }
 
-        // Load products, filter by category
-        var products = await prodMeta.Handlers.QueryAsync(null, context.RequestAborted);
+        // Load products — filter by category via query, cap results
+        var prodQueryDef = new BareMetalWeb.Data.QueryDefinition
+        {
+            Clauses = new() { new BareMetalWeb.Data.QueryClause { Field = "Category", Operator = BareMetalWeb.Data.QueryOperator.Equals, Value = categoryName } },
+            Top = 10000
+        };
+        var products = await prodMeta.Handlers.QueryAsync(prodQueryDef, context.RequestAborted);
         var filtered = new List<ProductView>();
 
         // Parse query filter

--- a/BareMetalWeb.Host/Program.cs
+++ b/BareMetalWeb.Host/Program.cs
@@ -42,6 +42,13 @@ await app.UseBareMetalWeb(configureRoutes: (appInfo, routeHandlers, pageInfoFact
     }));
     appInfo.RegisterRoute("POST /api/device/token", new RouteHandlerData(pageInfoFactory.RawPage("Public", false), async context =>
     {
+        // Validate Content-Type (CSRF mitigation)
+        if (!(context.Request.ContentType ?? "").Contains("application/json", StringComparison.OrdinalIgnoreCase))
+        {
+            context.Response.StatusCode = 415;
+            await context.Response.WriteAsync("{\"error\":\"Unsupported Content-Type\"}");
+            return;
+        }
         string body;
         using (var reader = new System.IO.StreamReader(context.Request.Body))
             body = await reader.ReadToEndAsync();
@@ -54,8 +61,8 @@ await app.UseBareMetalWeb(configureRoutes: (appInfo, routeHandlers, pageInfoFact
             await context.Response.WriteAsync("{\"error\":\"missing device_code\"}");
             return;
         }
-        var all = DataStoreProvider.Current.Query<DeviceCodeAuth>(null).ToList();
-        var dc = all.FirstOrDefault(d => d.DeviceCode == deviceCode);
+        var queryDef = new BareMetalWeb.Data.QueryDefinition { Clauses = new() { new BareMetalWeb.Data.QueryClause { Field = "DeviceCode", Operator = BareMetalWeb.Data.QueryOperator.Equals, Value = deviceCode } }, Top = 1 };
+        var dc = (await DataStoreProvider.Current.QueryAsync<DeviceCodeAuth>(queryDef)).FirstOrDefault();
         if (dc == null || dc.IsExpired(DateTime.UtcNow))
         {
             context.Response.ContentType = "application/json";
@@ -132,6 +139,12 @@ await app.UseBareMetalWeb(configureRoutes: (appInfo, routeHandlers, pageInfoFact
         if (context.Request.HasFormContentType)
         {
             var form = await context.Request.ReadFormAsync();
+            // CSRF validation for form-based POST
+            if (!BareMetalWeb.Host.CsrfProtection.ValidateFormToken(context, form))
+            {
+                context.Response.Redirect("/device?msg=Error:+Invalid+security+token.+Please+try+again.");
+                return;
+            }
             code = form["code"].ToString().Trim().ToUpperInvariant();
         }
         if (string.IsNullOrEmpty(code) || user == null)
@@ -139,8 +152,9 @@ await app.UseBareMetalWeb(configureRoutes: (appInfo, routeHandlers, pageInfoFact
             context.Response.Redirect("/device?msg=Error:+Invalid+request");
             return;
         }
-        var all = DataStoreProvider.Current.Query<DeviceCodeAuth>(null).ToList();
-        var dc = all.FirstOrDefault(d => d.UserCode == code && d.Status == "pending" && !d.IsExpired(DateTime.UtcNow));
+        var queryDef = new BareMetalWeb.Data.QueryDefinition { Clauses = new() { new BareMetalWeb.Data.QueryClause { Field = "UserCode", Operator = BareMetalWeb.Data.QueryOperator.Equals, Value = code } }, Top = 10 };
+        var candidates = await DataStoreProvider.Current.QueryAsync<DeviceCodeAuth>(queryDef);
+        var dc = candidates.FirstOrDefault(d => d.Status == "pending" && !d.IsExpired(DateTime.UtcNow));
         if (dc == null)
         {
             context.Response.Redirect($"/device?msg=Error:+Invalid+or+expired+code&code={System.Net.WebUtility.UrlEncode(code)}");

--- a/BareMetalWeb.Host/ReportHtmlRenderer.cs
+++ b/BareMetalWeb.Host/ReportHtmlRenderer.cs
@@ -325,12 +325,13 @@ public static class ReportHtmlRenderer
             string.Equals(f.Name, fieldName, StringComparison.OrdinalIgnoreCase));
         if (field == null) return Array.Empty<string>();
 
-        // Load all records and extract distinct non-null values
         var getter = field.GetValueFn;
         if (getter == null) return Array.Empty<string>();
 
+        // Use capped query to avoid loading entire table; async-safe via Task.Run
         var distinct = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
-        var allItems = meta.Handlers.QueryAsync(null, CancellationToken.None).AsTask().GetAwaiter().GetResult();
+        var queryDef = new BareMetalWeb.Data.QueryDefinition { Top = 10000 };
+        var allItems = Task.Run(async () => await meta.Handlers.QueryAsync(queryDef, CancellationToken.None)).GetAwaiter().GetResult();
         foreach (var item in allItems)
         {
             var val = getter(item);

--- a/BareMetalWeb.Host/RouteHandlers.cs
+++ b/BareMetalWeb.Host/RouteHandlers.cs
@@ -1594,6 +1594,7 @@ public sealed class RouteHandlers : IRouteHandlers
         if (effectiveViewType == ViewType.TreeView || effectiveViewType == ViewType.OrgChart || effectiveViewType == ViewType.Timeline || effectiveViewType == ViewType.Timetable)
         {
             var allQuery = DataScaffold.BuildQueryDefinition(queryDictionary, meta);
+            allQuery.Top ??= 10000; // Cap to prevent unbounded memory usage
             var allResults = (await DataScaffold.QueryAsync(meta, allQuery)).Cast<BaseDataObject>().ToList();
             
             var basePath = $"/ssr/admin/data/{typeSlug}";


### PR DESCRIPTION
## HIGH Priority Security & Performance Fixes (#769–#773)

### #769 — CSRF Mitigation
- **Binary API** (Create/Update): Validate Content-Type is `application/json` or `application/x-bmw-binary` — blocks CSRF via HTML form POST
- **Delta PATCH**: Same Content-Type validation
- **Action POST**: Same Content-Type validation  
- **POST /device**: Added `CsrfProtection.ValidateFormToken()` for form-based device code approval
- **POST /api/device/token**: Validate Content-Type is `application/json`

### #770 — Unbounded Query Caps
- **Batch API**: Cap IDs array at 500 via `.Take(500)`
- **Tree/OrgChart/Timeline views**: Default `Top(10000)` cap
- MCP already capped at 200, Lookup API already at 10000

### #771 — Request Body Size Limits
- **Binary Create/Update**: 10MB Content-Length check via `CheckBodySizeAsync()`
- **Delta PATCH**: Same 10MB check
- **Action POST**: Same 10MB check  
- **MCP**: 10MB Content-Length check

### #772 — Full Table Scan Elimination
- **PageRenderer**: Filtered query on `Slug`+`Status` instead of `Query(null)` — O(1) via index
- **ProductRenderer**: Filtered query on category `Slug`; products filtered by `Category`
- **Device token**: Filtered query on `DeviceCode` with `Top=1`
- **Device approve**: Filtered query on `UserCode` with `Top=10`
- **ReportHtmlRenderer**: Capped query (`Top=10000`) + `Task.Run` wrapper to avoid sync-over-async deadlock

### #773 — N+1 Query Mitigation
- **LookupApiHandlers**: Cap FK traversals at 20 per entity; add `uint.TryParse` guard

Closes #769, closes #770, closes #771, closes #772, closes #773