### PR TITLE
Sync docs with security audit changes

### DIFF
--- a/docs/OWASP.md
+++ b/docs/OWASP.md
@@ -1,0 +1,53 @@
+# OWASP Security Considerations
+
+This document maps BareMetalWeb's security controls to the OWASP Top 10 (2021).
+
+## A01:2021 — Broken Access Control
+
+- **Route-level permissions**: Every route declares `PermissionsNeeded` — `Public`, `AnonymousOnly`, `Authenticated`, or comma-separated permission strings. Enforced in `RequestHandler` before dispatching.
+- **Entity-level permissions**: `[DataEntity(Permissions = "...")]` gates CRUD API access per entity type.
+- **MCP/Cluster auth**: MCP endpoints require authentication; cluster endpoints require admin/monitoring permissions.
+- **CSRF protection**: Form POSTs validated via `CsrfProtection.ValidateFormToken()`. API writes use Content-Type validation (non-simple types trigger CORS preflight).
+
+## A02:2021 — Cryptographic Failures
+
+- **Password hashing**: PBKDF2 with per-user salt (configurable iteration count).
+- **Session cookies**: AES-256-GCM encrypted + HMAC via `CookieProtection`. Keys stored in `{dataRoot}/.keys/`.
+- **API keys**: Stored as PBKDF2 hashes; raw key shown only once at creation.
+
+## A03:2021 — Injection
+
+- **XSS**: Page renderer validates link URLs via `IsSafeUrl()` (http/https/mailto/relative only). Raw HTML sanitized via `SanitizeHtml()` stripping dangerous attributes (`on*`, `style`, `javascript:`).
+- **Path traversal**: Proxy strips `..` segments from request paths. Static file handler rejects paths with `..`.
+
+## A04:2021 — Insecure Design
+
+- **Query caps**: Tree/orgchart queries capped at `Top(10000)`. Batch operations capped at 500 items. FK traversals capped at 20 per entity.
+- **Body size limits**: 10 MB limit on all write endpoints.
+
+## A05:2021 — Security Misconfiguration
+
+- **Security headers**: CSP with nonce, HSTS (HTTPS only), `X-Content-Type-Options: nosniff`.
+- **Error sanitization**: Exception messages and entity type names stripped from API error responses.
+
+## A07:2021 — Identification and Authentication Failures
+
+- **Rate limiting**: Login, registration, device code, and MFA endpoints rate-limited (5-10 attempts per 60s window per IP/user).
+- **MFA support**: TOTP-based MFA for enrolled users.
+- **Session management**: Sliding expiry (8h standard, 30d remember-me). Sessions revoked on logout.
+
+## A08:2021 — Software and Data Integrity Failures
+
+- **WAL integrity**: Append-only write-ahead log with checksums. Atomic commit operations.
+- **CSRF tokens**: HMAC-based, tied to session ID, 1-hour expiry.
+
+## A09:2021 — Security Logging and Monitoring Failures
+
+- **Session logging**: `SessionLog` entity tracks user activity.
+- **Request tracking**: `ClientRequestTracker` monitors per-IP request rates with lock-free `ConcurrentDictionary` implementation.
+- **Cluster status**: Health endpoint exposes cluster state and leader election status.
+
+## A10:2021 — Server-Side Request Forgery (SSRF)
+
+- **Proxy SSRF protection**: `IsPrivateOrMetadataHost()` blocks RFC 1918, link-local (169.254.x.x), and loopback addresses. Returns 502 instead of forwarding.
+- **Path traversal**: Proxy strips `..` from forwarded paths.

--- a/docs/PROXY.md
+++ b/docs/PROXY.md
@@ -133,3 +133,19 @@ GET /proxy/status
 ```
 
 Returns JSON with the health and traffic stats for each proxy route and target.
+
+## Security
+
+### SSRF Protection
+
+The proxy blocks requests to private, loopback, and cloud metadata IP ranges:
+
+- **RFC 1918**: `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`
+- **Link-local**: `169.254.0.0/16` (includes AWS/Azure/GCP metadata at `169.254.169.254`)
+- **Loopback**: `127.0.0.0/8`, `::1`
+
+If the resolved target falls within any of these ranges, the proxy returns **502 Bad Gateway** without forwarding the request. This prevents attackers from using the proxy to reach internal services or cloud metadata endpoints.
+
+### Path Traversal Protection
+
+The proxy strips `..` segments from the request path before constructing the upstream URL, preventing directory traversal attacks against upstream targets.

--- a/docs/QUERY_INDEX_ARCHITECTURE.md
+++ b/docs/QUERY_INDEX_ARCHITECTURE.md
@@ -49,7 +49,7 @@ The `idMap` (`uint objKey → ulong walKey`) is filtered at load time — tombst
 
 ### Deserialization Cache
 
-`Load<T>(key)` uses an in-memory deserialization cache keyed by `(typeName, key, walPointer)`. When the WAL pointer hasn't changed (same version), the cached deserialized object is returned without binary parsing. The cache holds up to 4096 entries with 25% batch eviction when full. Entries are invalidated on `Save()` and `Delete()`.
+`Load<T>(key)` uses an in-memory deserialization cache keyed by `(typeName, key, walPointer)`. When the WAL pointer hasn't changed (same version), the cached deserialized object is returned without binary parsing. The cache holds up to 4096 entries with **LRU eviction** — when full, the oldest 25% by last-access timestamp are evicted. Access timestamps are tracked via `Environment.TickCount64` on each cache hit. Entries are invalidated on `Save()` and `Delete()`.
 
 ## Query Acceleration Paths
 
@@ -126,7 +126,7 @@ For queries with non-indexed filters, complex operators (Contains, GreaterThan, 
 |-------|----------|-----|--------------|------|
 | **Inverted index** | `IndexStore._invertedCache` | `(entity, field)` | On `AppendEntry()` | Unbounded (one per indexed field) |
 | **Forward index** | `IndexStore._forwardCache` | `(entity, field)` | On `AppendEntry()` | Unbounded (one per indexed field) |
-| **Deserialization** | `WalDataProvider._deserCache` | `(typeName, key, walPtr)` | On `Save()` / `Delete()` | 4096 entries, 25% eviction |
+| **Deserialization** | `WalDataProvider._deserCache` | `(typeName, key, walPtr)` | On `Save()` / `Delete()` | 4096 entries, LRU eviction (oldest 25%) |
 | **Live count** | `WalDataProvider._liveCounts` | `typeName` | `Save()` increments, `Delete()` decrements | One per entity type |
 | **Schema members** | `WalDataProvider._schemaMemberCache` | `(type, version)` | Never (immutable) | One per schema version |
 

--- a/docs/architecture/auth.md
+++ b/docs/architecture/auth.md
@@ -175,3 +175,50 @@ The `Strict-Transport-Security` (HSTS) header is only emitted when the request i
 ---
 
 _Status: Verified against codebase @ commit c9a5bdc (HSTS header and data query timeout added)_
+
+---
+
+## Rate Limiting
+
+Several endpoints are rate-limited to prevent brute-force and abuse:
+
+| Endpoint | Limit | Window | Key |
+|----------|-------|--------|-----|
+| `POST /account/login` | 5 attempts | 60 s | IP address |
+| `POST /register` | 5 attempts | 60 s | IP address |
+| `POST /api/device/code` | 10 requests | 60 s | IP address |
+| `POST /api/device/token` | 10 requests | 60 s | IP address |
+| `POST /account/mfa` | 5 attempts | 60 s | User ID |
+
+When the rate limit is exceeded, the server returns **429 Too Many Requests** with a `Retry-After` header indicating how many seconds to wait.
+
+The rate limiter uses `ConcurrentDictionary<string, AttemptTracker>` with lock-free `AddOrUpdate` semantics. Stale entries are cleaned up on a sliding window.
+
+---
+
+## API Endpoint Authentication
+
+### MCP (Model Context Protocol)
+
+All MCP requests require authentication. The MCP handler checks `UserAuth.GetRequestUserAsync()` at entry and returns **401 Unauthorized** if no valid session or API key is present.
+
+### Cluster Endpoints
+
+All cluster management endpoints (`/api/cluster/*`) require the **admin** or **monitoring** permission. The handler uses `RequireAdminAsync()` which returns **401** for unauthenticated users and **403** for users lacking the required permissions.
+
+### Binary/Delta API Content-Type
+
+Binary and delta API write endpoints (`POST`, `PUT`, `PATCH`) validate the `Content-Type` header. Requests with a `Content-Type` that matches simple CORS types (`application/x-www-form-urlencoded`, `multipart/form-data`, `text/plain`) are rejected with **415 Unsupported Media Type**. This prevents CSRF via form submissions — non-simple content types trigger a CORS preflight that the browser will block if the origin isn't allowed.
+
+### Request Body Size Limits
+
+Write endpoints enforce a **10 MB** body size limit. Requests with a `Content-Length` exceeding this limit are rejected with **413 Request Entity Too Large** before reading the body.
+
+---
+
+## Error Information Disclosure Protection
+
+API error responses are sanitized to prevent information leakage:
+
+- **Exception messages** (`ex.Message`) are never exposed in HTTP responses — generic error text is returned instead
+- **Entity type names** are stripped from 404 responses to prevent entity enumeration attacks


### PR DESCRIPTION
Updates documentation to reflect all security hardening from PRs #782, #783, #784.

### Changes
- **docs/OWASP.md**: Complete OWASP Top 10 (2021) mapping with all current security controls
- **docs/PROXY.md**: Added SSRF protection and path traversal protection sections
- **docs/architecture/auth.md**: Added rate limiting table, MCP/cluster auth, Content-Type CSRF mitigation, body size limits, error information disclosure protection
- **docs/QUERY_INDEX_ARCHITECTURE.md**: Updated deserialization cache description to reflect LRU eviction (was random)