### PR TITLE
Fix sample data crash: handle corrupt WAL payloads gracefully

### DIFF
--- a/BareMetalWeb.Data/BinaryObjectSerializer.cs
+++ b/BareMetalWeb.Data/BinaryObjectSerializer.cs
@@ -1085,6 +1085,11 @@ public sealed class BinaryObjectSerializer : ISchemaAwareObjectSerializer
             throw new InvalidOperationException($"String byte length {length} exceeds MaxStringBytes {MaxStringBytes}.");
         if (length == 0) return string.Empty;
 
+        // Guard against corrupted length that exceeds remaining stream data
+        var remaining = reader.BaseStream.Length - reader.BaseStream.Position;
+        if (length > remaining)
+            throw new InvalidOperationException($"String byte length {length} exceeds remaining payload ({remaining} bytes). Data may be corrupt.");
+
         const int StackLimit = 512;
         if (length <= StackLimit)
         {
@@ -1113,6 +1118,9 @@ public sealed class BinaryObjectSerializer : ISchemaAwareObjectSerializer
         if (length > MaxStringBytes)
             throw new InvalidOperationException($"String byte length {length} exceeds MaxStringBytes {MaxStringBytes}.");
         if (length == 0) return string.Empty;
+
+        if (length > reader.Remaining)
+            throw new InvalidOperationException($"String byte length {length} exceeds remaining payload ({reader.Remaining} bytes). Data may be corrupt.");
 
         const int StackLimit = 512;
         if (length <= StackLimit)

--- a/BareMetalWeb.Data/SpanReader.cs
+++ b/BareMetalWeb.Data/SpanReader.cs
@@ -102,6 +102,8 @@ namespace BareMetalWeb.Data;
             _offset += destination.Length;
         }
 
+        public int Remaining => _buffer.Length - _offset;
+
         private void EnsureAvailable(int size)
         {
             if (_offset + size > _buffer.Length)

--- a/BareMetalWeb.Data/WalDataProvider.cs
+++ b/BareMetalWeb.Data/WalDataProvider.cs
@@ -300,7 +300,16 @@ public sealed class WalDataProvider : IDataProvider, IDisposable
         if (!_walStore.TryReadOpPayload(ptr, walKey, out var payload)) return default;
         if (payload.IsEmpty) return default;
 
-        var result = DeserializePayload<T>(payload, key);
+        T? result;
+        try
+        {
+            result = DeserializePayload<T>(payload, key);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError($"Corrupt payload for {typeName} Key={key} WalPtr={ptr}: {ex.Message}", ex);
+            return default;
+        }
         if (result != null)
         {
             if (_deserCache.Count >= DeserCacheMaxSize)


### PR DESCRIPTION
## Fix: #781 — Sample data crashes with 'string byte length 36693459 exceeds maximum'

### Root Cause
A corrupted or misaligned WAL payload causes the binary deserializer's `ReadString()` to read a 4-byte int32 length prefix as ~36MB, exceeding the 4MB safety limit. This crashes the entire sample data generation operation.

### Changes

**BareMetalWeb.Data/WalDataProvider.cs**
- `Load<T>()` now wraps `DeserializePayload()` in try-catch — corrupted records return null (skipped) instead of crashing. Full details logged for debugging.

**BareMetalWeb.Data/BinaryObjectSerializer.cs**
- Both `ReadString()` overloads now validate the claimed byte length against remaining stream/span bytes. If the length exceeds what's left in the buffer, a clear 'data may be corrupt' error is thrown instead of attempting a 36MB allocation.

**BareMetalWeb.Data/SpanReader.cs**
- Added `Remaining` property for bounds checking during deserialization.

### Impact
- Corrupted WAL records are now **non-fatal** — they're logged and skipped
- Sample data generation continues even if prior records have corrupt payloads
- Better diagnostics: error messages now include the record key, WAL pointer, and corruption details

Closes #781