### PR TITLE
feat: Virtual entities → DataRecord + WAL storage

### DIFF
--- a/BareMetalWeb.Data.Tests/VirtualEntityDataRecordTests.cs
+++ b/BareMetalWeb.Data.Tests/VirtualEntityDataRecordTests.cs
@@ -1,0 +1,207 @@
+using BareMetalWeb.Core;
+using BareMetalWeb.Data;
+using Xunit;
+
+namespace BareMetalWeb.Data.Tests;
+
+/// <summary>
+/// Tests for Phase 3: virtual entities backed by DataRecord + WAL
+/// via DataEntityHandlers (the same pipeline used by DataScaffold).
+/// </summary>
+[Collection("WalDataRecord")]
+public class VirtualEntityDataRecordTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly WalDataProvider _provider;
+    private readonly EntitySchema _schema;
+    private readonly DataEntityHandlers _handlers;
+
+    public VirtualEntityDataRecordTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"ve-dr-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+        _provider = new WalDataProvider(_tempDir);
+        _schema = new EntitySchema.Builder("Ticket", "tickets")
+            .AddField("Title", FieldType.StringUtf8, typeof(string), required: true, maxLength: 200)
+            .AddField("Description", FieldType.StringUtf8, typeof(string), nullable: true)
+            .AddField("Priority", FieldType.Int32, typeof(int))
+            .AddField("IsOpen", FieldType.Bool, typeof(bool))
+            .Build();
+
+        // Build handlers exactly as RuntimeEntityModel.ToEntityMetadata(walProvider, schema) does
+        _handlers = new DataEntityHandlers(
+            Create: () => _schema.CreateRecord(),
+            LoadAsync: async (id, ct) =>
+            {
+                var rec = await _provider.LoadRecordAsync(id, _schema, ct).ConfigureAwait(false);
+                return rec;
+            },
+            SaveAsync: async (obj, ct) =>
+            {
+                if (obj is DataRecord rec)
+                    await _provider.SaveRecordAsync(rec, _schema, ct).ConfigureAwait(false);
+            },
+            DeleteAsync: (id, ct) => _provider.DeleteRecordAsync(id, _schema, ct),
+            QueryAsync: async (query, ct) =>
+            {
+                var items = await _provider.QueryRecordsAsync(_schema, query, ct).ConfigureAwait(false);
+                return items.Cast<BaseDataObject>();
+            },
+            CountAsync: (query, ct) => _provider.CountRecordsAsync(_schema, query, ct)
+        );
+    }
+
+    public void Dispose()
+    {
+        (_provider as IDisposable)?.Dispose();
+        try { Directory.Delete(_tempDir, true); } catch { }
+    }
+
+    // ── Create ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Create_ReturnsDataRecordWithCorrectEntityTypeName()
+    {
+        var obj = _handlers.Create();
+        Assert.IsType<DataRecord>(obj);
+        var rec = (DataRecord)obj;
+        Assert.Equal("Ticket", rec.EntityTypeName);
+        Assert.NotNull(rec.Schema);
+        Assert.Equal(4, rec.FieldCount);
+    }
+
+    // ── CRUD round-trip via handlers ───────────────────────────────────────
+
+    [Fact]
+    public async Task SaveAndLoad_RoundTripsViaHandlers()
+    {
+        var obj = _handlers.Create();
+        var rec = (DataRecord)obj;
+        rec.Key = 1;
+        rec.SetValue(0, "Fix login bug");
+        rec.SetValue(1, "Users cannot log in after password reset");
+        rec.SetValue(2, 1);
+        rec.SetValue(3, true);
+
+        await _handlers.SaveAsync(rec, CancellationToken.None);
+
+        var loaded = await _handlers.LoadAsync(1, CancellationToken.None);
+        Assert.NotNull(loaded);
+        Assert.IsType<DataRecord>(loaded);
+        var loadedRec = (DataRecord)loaded;
+        Assert.Equal(1u, loadedRec.Key);
+        Assert.Equal("Fix login bug", loadedRec.GetValue(0));
+        Assert.Equal("Users cannot log in after password reset", loadedRec.GetValue(1));
+        Assert.Equal(1, loadedRec.GetValue(2));
+        Assert.Equal(true, loadedRec.GetValue(3));
+    }
+
+    [Fact]
+    public async Task Load_MissingKey_ReturnsNull()
+    {
+        var result = await _handlers.LoadAsync(9999, CancellationToken.None);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task Delete_RemovesRecord()
+    {
+        var rec = (DataRecord)_handlers.Create();
+        rec.Key = 10;
+        rec.SetValue(0, "To be deleted");
+        await _handlers.SaveAsync(rec, CancellationToken.None);
+
+        await _handlers.DeleteAsync(10, CancellationToken.None);
+
+        var loaded = await _handlers.LoadAsync(10, CancellationToken.None);
+        Assert.Null(loaded);
+    }
+
+    // ── Query + Count ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task QueryAndCount_AllRecords()
+    {
+        for (uint i = 1; i <= 3; i++)
+        {
+            var rec = (DataRecord)_handlers.Create();
+            rec.Key = i;
+            rec.SetValue(0, $"Ticket {i}");
+            rec.SetValue(2, (int)i);
+            rec.SetValue(3, true);
+            await _handlers.SaveAsync(rec, CancellationToken.None);
+        }
+
+        var all = (await _handlers.QueryAsync(null, CancellationToken.None)).ToList();
+        Assert.Equal(3, all.Count);
+        Assert.All(all, obj => Assert.IsType<DataRecord>(obj));
+
+        var count = await _handlers.CountAsync(null, CancellationToken.None);
+        Assert.Equal(3, count);
+    }
+
+    [Fact]
+    public async Task Query_WithFilter_ReturnsMatching()
+    {
+        var open = (DataRecord)_handlers.Create();
+        open.Key = 1; open.SetValue(0, "Open ticket"); open.SetValue(3, true);
+        await _handlers.SaveAsync(open, CancellationToken.None);
+
+        var closed = (DataRecord)_handlers.Create();
+        closed.Key = 2; closed.SetValue(0, "Closed ticket"); closed.SetValue(3, false);
+        await _handlers.SaveAsync(closed, CancellationToken.None);
+
+        var query = new QueryDefinition();
+        query.Clauses.Add(new QueryClause { Field = "IsOpen", Operator = QueryOperator.Equals, Value = "True" });
+
+        var results = (await _handlers.QueryAsync(query, CancellationToken.None)).ToList();
+        Assert.Single(results);
+        Assert.Equal(1u, results[0].Key);
+    }
+
+    // ── DynamicPropertyInfo ordinal access ─────────────────────────────────
+
+    [Fact]
+    public void DynamicPropertyInfo_GetSetValue_OnDataRecord()
+    {
+        var rec = _schema.CreateRecord();
+        rec.Key = 1;
+
+        // Create DynamicPropertyInfo with ordinal (as RuntimeEntityModel does)
+        var prop = new DynamicPropertyInfo("Title", typeof(string), 0);
+        prop.SetValue(rec, "Hello World");
+        Assert.Equal("Hello World", prop.GetValue(rec));
+
+        var prop2 = new DynamicPropertyInfo("Priority", typeof(int), 2);
+        prop2.SetValue(rec, 42);
+        Assert.Equal(42, prop2.GetValue(rec));
+    }
+
+    [Fact]
+    public void DynamicPropertyInfo_FallsBackToSchema_WhenNoOrdinal()
+    {
+        var rec = _schema.CreateRecord();
+        rec.SetValue(0, "Test title");
+
+        // No ordinal — falls back to Schema.TryGetOrdinal
+        var prop = new DynamicPropertyInfo("Title", typeof(string));
+        Assert.Equal("Test title", prop.GetValue(rec));
+    }
+
+    // ── DataRecord.Schema property ────────────────────────────────────────
+
+    [Fact]
+    public void DataRecord_Schema_IsSetFromConstructor()
+    {
+        var rec = new DataRecord(_schema);
+        Assert.Same(_schema, rec.Schema);
+        Assert.Equal("Ticket", rec.EntityTypeName);
+    }
+
+    [Fact]
+    public void DataRecord_FieldCount_Constructor_HasNoSchema()
+    {
+        var rec = new DataRecord(5);
+        Assert.Null(rec.Schema);
+    }
+}

--- a/BareMetalWeb.Data.Tests/WalDataRecordTests.cs
+++ b/BareMetalWeb.Data.Tests/WalDataRecordTests.cs
@@ -3,6 +3,7 @@ using Xunit;
 
 namespace BareMetalWeb.Data.Tests;
 
+[Collection("WalDataRecord")]
 public class WalDataRecordTests : IDisposable
 {
     private readonly string _tempDir;

--- a/BareMetalWeb.Data/DataRecord.cs
+++ b/BareMetalWeb.Data/DataRecord.cs
@@ -38,8 +38,16 @@ public sealed class DataRecord : BaseDataObject
     public DataRecord(EntitySchema schema)
     {
         EntityTypeName = schema.EntityName;
+        Schema = schema;
         _values = new object?[schema.FieldCount];
     }
+
+    /// <summary>
+    /// The schema this record was created from, if any. Used by downstream code
+    /// (e.g. <see cref="DynamicPropertyInfo"/>) to resolve field names → ordinals
+    /// without requiring the schema to be passed explicitly.
+    /// </summary>
+    public EntitySchema? Schema { get; }
 
     // ── Hot-path accessors (ordinal) ───────────────────────────────────────
 

--- a/BareMetalWeb.Data/DynamicPropertyInfo.cs
+++ b/BareMetalWeb.Data/DynamicPropertyInfo.cs
@@ -6,19 +6,26 @@ namespace BareMetalWeb.Data;
 
 /// <summary>
 /// A <see cref="PropertyInfo"/> implementation for virtual entity fields.
-/// Reads field values from and writes field values to a <see cref="DynamicDataObject"/>
-/// string-keyed dictionary. All values are stored as strings to avoid serialization
-/// complexity; the CLR <see cref="PropertyType"/> carries type metadata for form rendering.
+/// Supports both legacy <see cref="DynamicDataObject"/> (string dictionary) and
+/// <see cref="DataRecord"/> (ordinal-indexed <c>object?[]</c>) storage.
+/// When an ordinal is provided, <see cref="DataRecord"/> access is ~1–2 ns via array index.
 /// </summary>
 internal sealed class DynamicPropertyInfo : PropertyInfo
 {
     private readonly string _fieldName;
     private readonly Type _propertyType;
+    private readonly int _ordinal;
 
+    /// <summary>Creates a property backed by dictionary lookup (legacy path).</summary>
     public DynamicPropertyInfo(string fieldName, Type propertyType)
+        : this(fieldName, propertyType, -1) { }
+
+    /// <summary>Creates a property backed by ordinal index on <see cref="DataRecord"/>.</summary>
+    public DynamicPropertyInfo(string fieldName, Type propertyType, int ordinal)
     {
         _fieldName = fieldName ?? throw new ArgumentNullException(nameof(fieldName));
         _propertyType = propertyType ?? throw new ArgumentNullException(nameof(propertyType));
+        _ordinal = ordinal;
     }
 
     // ── MemberInfo ──────────────────────────────────────────────────────────
@@ -41,22 +48,32 @@ internal sealed class DynamicPropertyInfo : PropertyInfo
     public override MethodInfo? GetSetMethod(bool nonPublic) => null;
 
     /// <summary>
-    /// Returns the field's string value from the <see cref="DynamicDataObject"/> dictionary,
-    /// or <c>null</c> if the object is not a <see cref="DynamicDataObject"/>.
+    /// Returns the field value. For <see cref="DataRecord"/>, uses ordinal array access (~1–2 ns).
+    /// For <see cref="DynamicDataObject"/>, falls back to dictionary lookup.
     /// </summary>
     public override object? GetValue(object? obj, BindingFlags invokeAttr, Binder? binder, object?[]? index, CultureInfo? culture)
     {
+        if (obj is DataRecord dr)
+        {
+            if (_ordinal >= 0) return dr.GetValue(_ordinal);
+            if (dr.Schema != null) return dr.GetField(dr.Schema, _fieldName);
+        }
         if (obj is DynamicDataObject dynamicObj)
             return dynamicObj.GetField(_fieldName);
         return null;
     }
 
     /// <summary>
-    /// Stores the value in the <see cref="DynamicDataObject"/> dictionary as a string.
-    /// Handles common CLR types (bool, DateTime, DateOnly, TimeOnly, enums, numerics).
+    /// Stores a value. For <see cref="DataRecord"/>, stores the native CLR value by ordinal.
+    /// For <see cref="DynamicDataObject"/>, converts to string and stores in dictionary.
     /// </summary>
     public override void SetValue(object? obj, object? value, BindingFlags invokeAttr, Binder? binder, object?[]? index, CultureInfo? culture)
     {
+        if (obj is DataRecord dr)
+        {
+            if (_ordinal >= 0) { dr.SetValue(_ordinal, value); return; }
+            if (dr.Schema != null) { dr.SetField(dr.Schema, _fieldName, value); return; }
+        }
         if (obj is not DynamicDataObject dynamicObj)
             return;
 

--- a/BareMetalWeb.Data/ExpressionEngine/ServerLookupResolver.cs
+++ b/BareMetalWeb.Data/ExpressionEngine/ServerLookupResolver.cs
@@ -157,6 +157,9 @@ public sealed class ServerLookupResolver : ILookupResolver
 
     private static object? ExtractFieldValue(object entity, string fieldName)
     {
+        if (entity is DataRecord rec && rec.Schema != null)
+            return rec.GetField(rec.Schema, fieldName);
+
         if (entity is DynamicDataObject dyn)
             return dyn.GetField(fieldName);
 

--- a/BareMetalWeb.Data/MetadataWireSerializer.cs
+++ b/BareMetalWeb.Data/MetadataWireSerializer.cs
@@ -100,27 +100,36 @@ public sealed class MetadataWireSerializer
     /// </summary>
     public static FieldPlan[] BuildPlan(Type entityType, IReadOnlyList<FieldPlanDescriptor> fields)
     {
-        return PlanCache.GetOrAdd(entityType, _ =>
+        return PlanCache.GetOrAdd(entityType, _ => BuildPlanCore(fields));
+    }
+
+    /// <summary>
+    /// Builds a FieldPlan[] without caching. Used when the cache key (Type) is shared
+    /// across multiple schemas (e.g. all DataRecord entities share typeof(DataRecord)).
+    /// </summary>
+    public static FieldPlan[] BuildPlanUncached(IReadOnlyList<FieldPlanDescriptor> fields)
+        => BuildPlanCore(fields);
+
+    private static FieldPlan[] BuildPlanCore(IReadOnlyList<FieldPlanDescriptor> fields)
+    {
+        var plans = new FieldPlan[fields.Count];
+        for (int i = 0; i < fields.Count; i++)
         {
-            var plans = new FieldPlan[fields.Count];
-            for (int i = 0; i < fields.Count; i++)
+            var f = fields[i];
+            plans[i] = new FieldPlan
             {
-                var f = fields[i];
-                plans[i] = new FieldPlan
-                {
-                    Name = f.Name,
-                    Ordinal = i,
-                    WireType = f.WireType,
-                    IsNullable = f.IsNullable,
-                    Getter = f.Getter,
-                    Setter = f.Setter,
-                    EnumUnderlying = f.EnumUnderlying,
-                    ElementWireType = f.ElementWireType,
-                    ClrType = f.ClrType,
-                };
-            }
-            return plans;
-        });
+                Name = f.Name,
+                Ordinal = i,
+                WireType = f.WireType,
+                IsNullable = f.IsNullable,
+                Getter = f.Getter,
+                Setter = f.Setter,
+                EnumUnderlying = f.EnumUnderlying,
+                ElementWireType = f.ElementWireType,
+                ClrType = f.ClrType,
+            };
+        }
+        return plans;
     }
 
     /// <summary>

--- a/BareMetalWeb.Data/WalDataProvider.cs
+++ b/BareMetalWeb.Data/WalDataProvider.cs
@@ -784,7 +784,7 @@ public sealed class WalDataProvider : IDataProvider, IDisposable
         return _recordPlans.GetOrAdd(schema.EntityName, _ =>
         {
             var descriptors = schema.BuildFieldPlanDescriptors();
-            return MetadataWireSerializer.BuildPlan(typeof(DataRecord), descriptors);
+            return MetadataWireSerializer.BuildPlanUncached(descriptors);
         });
     }
 

--- a/BareMetalWeb.Host/BareMetalWebExtensions.cs
+++ b/BareMetalWeb.Host/BareMetalWebExtensions.cs
@@ -97,6 +97,7 @@ public static class BareMetalWebExtensions
         await RuntimeEntityRegistry.BuildAsync(
             dataStore,
             new RuntimeEntityCompiler(),
+            systemProvider as WalDataProvider,
             dataRoot,
             msg => logger.LogInfo($"[RuntimeEntityRegistry] {msg}")).ConfigureAwait(false);
 

--- a/BareMetalWeb.Runtime/RuntimeEntityModel.cs
+++ b/BareMetalWeb.Runtime/RuntimeEntityModel.cs
@@ -73,6 +73,128 @@ public sealed class RuntimeEntityModel
     public IReadOnlyList<RuntimeActionModel> Actions { get; }
 
     /// <summary>
+    /// Builds a <see cref="DataEntityMetadata"/> that uses <see cref="DataRecord"/> + WAL storage.
+    /// Replaces <see cref="DynamicDataObject"/> + JSON; all field access is ordinal-based (~1–2 ns).
+    /// </summary>
+    public DataEntityMetadata ToEntityMetadata(WalDataProvider walProvider, EntitySchema schema)
+    {
+        var entityTypeName = Name;
+        var fields = new List<DataFieldMetadata>();
+
+        foreach (var f in Fields)
+        {
+            var clrType = RuntimeEntityCompiler.MapClrType(f.FieldType, f.IsNullable, f.EnumValues);
+            var prop = new DynamicPropertyInfo(f.Name, clrType, f.Ordinal);
+
+            DataLookupConfig? lookup = null;
+            if (f.FieldType == Rendering.Models.FormFieldType.LookupList
+                && !string.IsNullOrWhiteSpace(f.LookupEntitySlug)
+                && DataScaffold.TryGetEntity(f.LookupEntitySlug!, out var targetMeta))
+            {
+                lookup = new DataLookupConfig(
+                    TargetType: targetMeta.Type,
+                    ValueField: f.LookupValueField ?? "Id",
+                    DisplayField: f.LookupDisplayField ?? (f.LookupValueField ?? "Id"),
+                    QueryField: null,
+                    QueryOperator: QueryOperator.Contains,
+                    QueryValue: null,
+                    SortField: null,
+                    SortDirection: SortDirection.Asc,
+                    CacheTtl: TimeSpan.FromMinutes(5)
+                );
+            }
+
+            ValidationConfig? validation = null;
+            if (f.MinLength.HasValue || f.MaxLength.HasValue || f.RangeMin.HasValue ||
+                f.RangeMax.HasValue || !string.IsNullOrWhiteSpace(f.Pattern))
+            {
+                var validators = new List<ValidationAttribute>();
+                if (f.MinLength.HasValue) validators.Add(new MinLengthAttribute(f.MinLength.Value));
+                if (f.MaxLength.HasValue) validators.Add(new MaxLengthAttribute(f.MaxLength.Value));
+                if (f.RangeMin.HasValue && f.RangeMax.HasValue)
+                    validators.Add(new RangeAttribute(f.RangeMin.Value, f.RangeMax.Value));
+                if (!string.IsNullOrWhiteSpace(f.Pattern))
+                    validators.Add(new RegexPatternAttribute(f.Pattern!));
+
+                validation = new ValidationConfig(f.MinLength, f.MaxLength, f.RangeMin, f.RangeMax,
+                    f.Pattern, null, false, false, false,
+                    validators, Array.Empty<ValidationRuleAttribute>());
+            }
+
+            fields.Add(new DataFieldMetadata(
+                Property: prop,
+                Name: f.Name,
+                Label: f.Label,
+                FieldType: f.FieldType,
+                Order: f.Ordinal,
+                Required: f.Required,
+                List: f.List,
+                View: f.View,
+                Edit: f.Edit,
+                Create: f.Create,
+                ReadOnly: f.ReadOnly,
+                Placeholder: f.Placeholder,
+                Lookup: lookup,
+                IdGeneration: IdGenerationStrategy.None,
+                Computed: null,
+                Upload: null,
+                Calculated: null,
+                Validation: validation
+            ));
+        }
+
+        // Build action descriptors from RuntimeActionModel
+        var commands = Actions.Select((a, i) => new RemoteCommandMetadata(
+            Method: null!,
+            Name: a.Name,
+            Label: a.Label,
+            Icon: a.Icon,
+            ConfirmMessage: null,
+            Destructive: false,
+            Permission: a.Permission,
+            OverrideEntityPermissions: false,
+            Order: i
+        )).ToList();
+
+        var handlers = new DataEntityHandlers(
+            Create: () => schema.CreateRecord(),
+            LoadAsync: async (id, ct) =>
+            {
+                var rec = await walProvider.LoadRecordAsync(id, schema, ct).ConfigureAwait(false);
+                return rec;
+            },
+            SaveAsync: async (obj, ct) =>
+            {
+                if (obj is DataRecord rec)
+                    await walProvider.SaveRecordAsync(rec, schema, ct).ConfigureAwait(false);
+            },
+            DeleteAsync: (id, ct) => walProvider.DeleteRecordAsync(id, schema, ct),
+            QueryAsync: async (query, ct) =>
+            {
+                var items = await walProvider.QueryRecordsAsync(schema, query, ct).ConfigureAwait(false);
+                return items.Cast<BaseDataObject>();
+            },
+            CountAsync: (query, ct) => walProvider.CountRecordsAsync(schema, query, ct)
+        );
+
+        return new DataEntityMetadata(
+            Type: typeof(DataRecord),
+            Name: Name,
+            Slug: Slug,
+            Permissions: Permissions,
+            ShowOnNav: ShowOnNav,
+            NavGroup: NavGroup,
+            NavOrder: NavOrder,
+            IdGeneration: IdStrategy,
+            ViewType: ViewType.Table,
+            ParentField: null,
+            Fields: fields,
+            Handlers: handlers,
+            Commands: commands
+        );
+    }
+
+    /// <summary>
     /// Builds a <see cref="DataEntityMetadata"/> compatible with the existing
     /// <see cref="DataScaffold"/> registration path, so that this entity works
     /// transparently with all admin-UI routes, API routes and rendering pipelines.

--- a/BareMetalWeb.Runtime/RuntimeEntityRegistry.cs
+++ b/BareMetalWeb.Runtime/RuntimeEntityRegistry.cs
@@ -105,16 +105,18 @@ public sealed class RuntimeEntityRegistry
     /// </summary>
     /// <param name="store">The data store to load schema records from.</param>
     /// <param name="compiler">Compiler instance to use.</param>
-    /// <param name="dataRootPath">Root path for virtual entity JSON storage.</param>
+    /// <param name="walProvider">WAL provider for DataRecord storage (pass null to fall back to JSON).</param>
+    /// <param name="dataRootPath">Root path for virtual entity JSON storage (fallback).</param>
     /// <param name="logger">Optional logger for warnings.</param>
     public static async Task<RuntimeEntityRegistry> BuildAsync(
         IDataObjectStore store,
         IRuntimeEntityCompiler compiler,
+        WalDataProvider? walProvider,
         string dataRootPath,
         Action<string>? logger = null)
     {
         var registry = new RuntimeEntityRegistry();
-        var jsonStore = new VirtualEntityJsonStore(dataRootPath);
+        var jsonStore = walProvider == null ? new VirtualEntityJsonStore(dataRootPath) : null;
 
         // Load all schema records in parallel
         var entityDefs = (await store.QueryAsync<EntityDefinition>().ConfigureAwait(false)).ToList();
@@ -171,7 +173,16 @@ public sealed class RuntimeEntityRegistry
             registry.Register(model);
 
             // Register with DataScaffold so existing admin-UI/API routes work
-            var entityMetadata = model.ToEntityMetadata(jsonStore);
+            DataEntityMetadata entityMetadata;
+            if (walProvider != null)
+            {
+                var schema = EntitySchemaFactory.FromModel(model);
+                entityMetadata = model.ToEntityMetadata(walProvider, schema);
+            }
+            else
+            {
+                entityMetadata = model.ToEntityMetadata(jsonStore!);
+            }
             DataScaffold.RegisterVirtualEntity(entityMetadata);
 
             // Persist schema hash + version back to EntityDefinition if changed


### PR DESCRIPTION
## Summary
Closes #789 — Phase 3 of the AOT-safe metadata architecture (#719). Depends on #787 (#796) and #788 (#802).

## What Changed

### DataRecord — Schema property
- Added `Schema` property set by the `EntitySchema` constructor
- Enables downstream code (DynamicPropertyInfo, ServerLookupResolver) to resolve field names → ordinals without passing schema explicitly

### DynamicPropertyInfo — Ordinal-based DataRecord access
- New constructor `DynamicPropertyInfo(name, type, ordinal)` for ordinal-indexed access (~1–2 ns)
- `GetValue()` / `SetValue()` check `DataRecord` first (ordinal → array index), fall back to `DynamicDataObject` dictionary
- Backward-compatible: old `DynamicPropertyInfo(name, type)` constructor still works for VirtualEntityLoader path

### RuntimeEntityModel — WAL-backed ToEntityMetadata
- New `ToEntityMetadata(WalDataProvider, EntitySchema)` overload
- `Create: () => schema.CreateRecord()` — returns DataRecord, not DynamicDataObject
- CRUD handlers delegate to `WalDataProvider.SaveRecord/LoadRecord/QueryRecords/CountRecords/DeleteRecord`
- Old `ToEntityMetadata(VirtualEntityJsonStore)` preserved for backward compat

### RuntimeEntityRegistry — WAL integration
- `BuildAsync` now accepts `WalDataProvider?` parameter
- When provided, builds `EntitySchema` via `EntitySchemaFactory.FromModel()` and uses WAL path
- Falls back to JSON path when `walProvider` is null

### MetadataWireSerializer — PlanCache fix
- Added `BuildPlanUncached()` for DataRecord schemas that share `typeof(DataRecord)` as cache key
- Prevents cross-schema contamination when multiple entity types all use DataRecord
- `WalDataProvider.GetOrBuildRecordPlan` now uses `BuildPlanUncached` (per-entity cache in `_recordPlans`)

### ServerLookupResolver — DataRecord support
- `ExtractFieldValue()` now handles DataRecord via `rec.GetField(rec.Schema, fieldName)`

### BareMetalWebExtensions — Wiring
- Passes `systemProvider as WalDataProvider` to `BuildAsync`

## Tests (10 new)
- Create: returns DataRecord with correct EntityTypeName + Schema
- CRUD round-trip: Save → Load via handler delegates
- Load missing key: returns null
- Delete: removes record
- Query: all records, with filter
- Count: total and filtered
- DynamicPropertyInfo: ordinal access, schema fallback
- DataRecord.Schema: set from constructor, null for fieldCount ctor

## Zero Reflection
The entire virtual entity pipeline now uses:
- Ordinal closures for field access (~1–2 ns)
- Typed closures for BaseDataObject properties
- No Expression.Compile, no PropertyInfo reflection, no Activator.CreateInstance

## Next Steps
- Phase 4 (#790): System entities as metadata
- Phase 5 (#791): Eliminate all remaining reflection