### PR TITLE
refactor: eliminate PropertyInfo.SetValue/GetValue from hot paths (#791)

### DIFF
--- a/BareMetalWeb.Data/BinaryObjectSerializer.cs
+++ b/BareMetalWeb.Data/BinaryObjectSerializer.cs
@@ -1239,6 +1239,7 @@ public sealed class BinaryObjectSerializer : ISchemaAwareObjectSerializer
     private static string GetTypeIdentifier(Type type)
         => type.AssemblyQualifiedName ?? type.FullName ?? type.Name;
 
+    [RequiresUnreferencedCode("Assembly scanning for type resolution is not AOT-safe.")]
     private static Type ResolveType(string typeName)
     {
         var resolved = Type.GetType(typeName, throwOnError: false, ignoreCase: false);

--- a/BareMetalWeb.Data/ComputedFieldService.cs
+++ b/BareMetalWeb.Data/ComputedFieldService.cs
@@ -16,7 +16,7 @@ namespace BareMetalWeb.Data;
 public static class ComputedFieldService
 {
     private static readonly ConcurrentDictionary<string, ComputedValueCacheEntry> _cache = new();
-    private static readonly ConcurrentDictionary<(Type, string), PropertyInfo?> _propertyCache = new();
+    private static readonly ConcurrentDictionary<(Type, string), Func<object, object?>?> _getterCache = new();
 
     private sealed record ComputedValueCacheEntry(object? Value, DateTime ExpiresUtc);
 
@@ -134,9 +134,13 @@ public static class ComputedFieldService
         return null;
     }
 
-    private static PropertyInfo? GetCachedProperty(Type type, string name)
+    private static Func<object, object?>? GetCachedGetter(Type type, string name)
     {
-        return _propertyCache.GetOrAdd((type, name), static key => key.Item1.GetProperty(key.Item2));
+        return _getterCache.GetOrAdd((type, name), static key =>
+        {
+            var prop = key.Item1.GetProperty(key.Item2);
+            return prop != null ? PropertyAccessorFactory.BuildGetter(prop) : null;
+        });
     }
 
     private static async ValueTask<object?> ComputeLookupAsync(
@@ -147,11 +151,11 @@ public static class ComputedFieldService
         CancellationToken cancellationToken)
     {
         // Get the foreign key value
-        var fkProperty = GetCachedProperty(metadata.Type, config.ForeignKeyField!);
-        if (fkProperty == null)
+        var fkGetter = GetCachedGetter(metadata.Type, config.ForeignKeyField!);
+        if (fkGetter == null)
             return null;
 
-        var foreignKeyValue = fkProperty.GetValue(instance)?.ToString();
+        var foreignKeyValue = fkGetter(instance)?.ToString();
         if (string.IsNullOrEmpty(foreignKeyValue) || !uint.TryParse(foreignKeyValue, out var foreignKey))
             return null;
 
@@ -165,11 +169,11 @@ public static class ComputedFieldService
             return null;
 
         // Get the source field value
-        var sourceProperty = GetCachedProperty(config.SourceEntity!, config.SourceField!);
-        if (sourceProperty == null)
+        var sourceGetter = GetCachedGetter(config.SourceEntity!, config.SourceField!);
+        if (sourceGetter == null)
             return null;
 
-        return sourceProperty.GetValue(relatedEntity);
+        return sourceGetter(relatedEntity);
     }
 
     private static async ValueTask<object?> ComputeAggregationAsync(
@@ -180,11 +184,11 @@ public static class ComputedFieldService
         CancellationToken cancellationToken)
     {
         // Get the child collection property
-        var collectionProperty = GetCachedProperty(metadata.Type, config.ChildCollectionProperty!);
-        if (collectionProperty == null)
+        var collectionGetter = GetCachedGetter(metadata.Type, config.ChildCollectionProperty!);
+        if (collectionGetter == null)
             return null;
 
-        var collection = collectionProperty.GetValue(instance) as IEnumerable;
+        var collection = collectionGetter(instance) as IEnumerable;
         if (collection == null)
         {
             // Try to query for child entities if the collection isn't loaded
@@ -206,7 +210,7 @@ public static class ComputedFieldService
 
         // Get values from the source field (cache lookup per item type)
         var values = new List<object?>();
-        PropertyInfo? cachedSourceProp = null;
+        Func<object, object?>? cachedSourceGetter = null;
         Type? cachedItemType = null;
         foreach (var item in items)
         {
@@ -214,11 +218,11 @@ public static class ComputedFieldService
             if (itemType != cachedItemType)
             {
                 cachedItemType = itemType;
-                cachedSourceProp = GetCachedProperty(itemType, config.SourceField);
+                cachedSourceGetter = GetCachedGetter(itemType, config.SourceField);
             }
-            if (cachedSourceProp != null)
+            if (cachedSourceGetter != null)
             {
-                values.Add(cachedSourceProp.GetValue(item));
+                values.Add(cachedSourceGetter(item));
             }
         }
 

--- a/BareMetalWeb.Data/ExpressionEngine/CalculatedFieldService.cs
+++ b/BareMetalWeb.Data/ExpressionEngine/CalculatedFieldService.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using BareMetalWeb.Core;
 
 namespace BareMetalWeb.Data.ExpressionEngine;
 
@@ -20,6 +21,7 @@ public static class CalculatedFieldService
 
     private sealed record CalculatedFieldInfo(
         PropertyInfo Property,
+        Action<object, object?> SetValue,
         CalculatedFieldAttribute Attribute,
         ExpressionNode Expression,
         HashSet<string> Dependencies
@@ -66,7 +68,7 @@ public static class CalculatedFieldService
             try
             {
                 var result = fieldInfo.Expression.Evaluate(context);
-                fieldInfo.Property.SetValue(instance, ConvertToPropertyType(result, fieldInfo.Property.PropertyType));
+                fieldInfo.SetValue(instance, ConvertToPropertyType(result, fieldInfo.Property.PropertyType));
 
                 context[fieldInfo.Property.Name] = result;
             }
@@ -125,7 +127,7 @@ public static class CalculatedFieldService
             try
             {
                 var result = await fieldInfo.Expression.EvaluateAsync(context, resolver, cancellationToken);
-                fieldInfo.Property.SetValue(instance, ConvertToPropertyType(result, fieldInfo.Property.PropertyType));
+                fieldInfo.SetValue(instance, ConvertToPropertyType(result, fieldInfo.Property.PropertyType));
                 context[fieldInfo.Property.Name] = result;
             }
             catch (Exception ex)
@@ -202,7 +204,7 @@ public static class CalculatedFieldService
                 var expression = GetCompiledExpression(attr.Expression);
                 var dependencies = ExtractDependencies(expression);
 
-                fields.Add(new CalculatedFieldInfo(prop, attr, expression, dependencies));
+                fields.Add(new CalculatedFieldInfo(prop, PropertyAccessorFactory.BuildSetter(prop), attr, expression, dependencies));
             }
 
             return fields;
@@ -300,14 +302,28 @@ public static class CalculatedFieldService
 
     private static Dictionary<string, object?> BuildContext(BaseDataObject instance, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type type)
     {
-        var context = new Dictionary<string, object?>();
-
-        foreach (var prop in type.GetProperties())
+        // Use compiled layout for efficient field access when available
+        var meta = DataScaffold.GetEntityByType(type);
+        if (meta != null)
         {
-            context[prop.Name] = prop.GetValue(instance);
+            var layout = EntityLayoutCompiler.GetOrCompile(meta);
+            var context = new Dictionary<string, object?>(layout.Fields.Length + 4);
+            context["Key"] = instance.Key;
+            foreach (var field in layout.Fields)
+            {
+                try { context[field.Name] = field.Getter(instance); }
+                catch { context[field.Name] = null; }
+            }
+            return context;
         }
 
-        return context;
+        // Fallback for unregistered types
+        var ctx = new Dictionary<string, object?>();
+        foreach (var prop in type.GetProperties())
+        {
+            ctx[prop.Name] = prop.GetValue(instance);
+        }
+        return ctx;
     }
 
     private static bool HasCycle(


### PR DESCRIPTION
## Changes
- **CalculatedFieldService**: Replaced `PropertyInfo.SetValue` with compiled delegates cached in `CalculatedFieldInfo` record. `BuildContext` now uses `EntityLayoutCompiler` ordinal getters instead of `Type.GetProperties()` reflection.
- **ComputedFieldService**: Replaced `PropertyInfo` cache with compiled getter delegate cache (`Func<object, object?>`). All FK lookups, aggregations, and collection access now use compiled delegates.
- **BinaryObjectSerializer**: Annotated `ResolveType` with `[RequiresUnreferencedCode]`.

## Impact
Eliminates `PropertyInfo.SetValue/GetValue` reflection from calculated and computed field evaluation hot paths. These are replaced by compiled delegates (via `PropertyAccessorFactory.BuildGetter/BuildSetter`) which are ~50x faster and cached per type.

## Tests
2137 unit tests pass. 6 integration tests fail (pre-existing).

Closes partially #791 (remaining reflection items require full DataRecord migration per #719)