### PR TITLE
Fix test race condition in JS bundle tests (#864)

### DIFF
--- a/BareMetalWeb.Host.Tests/CompressionHelperTests.cs
+++ b/BareMetalWeb.Host.Tests/CompressionHelperTests.cs
@@ -129,6 +129,7 @@ public class CompressionHelperTests
     }
 }
 
+[Collection("JsBundleService")]
 public class JsBundleServiceCompressionTests : IDisposable
 {
     private readonly string _tempDir;
@@ -202,6 +203,7 @@ public class JsBundleServiceCompressionTests : IDisposable
     }
 }
 
+[Collection("CssBundleService")]
 public class CssBundleServiceCompressionTests : IDisposable
 {
     private readonly string _tempRoot;

--- a/BareMetalWeb.Host.Tests/CssBundleServiceTests.cs
+++ b/BareMetalWeb.Host.Tests/CssBundleServiceTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 
 namespace BareMetalWeb.Host.Tests;
 
+[Collection("CssBundleService")]
 public class CssBundleServiceTests : IDisposable
 {
     private readonly string _tempRoot;

--- a/BareMetalWeb.Host.Tests/JsBundleServiceTests.cs
+++ b/BareMetalWeb.Host.Tests/JsBundleServiceTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 
 namespace BareMetalWeb.Host.Tests;
 
+[Collection("JsBundleService")]
 public class JsBundleServiceTests : IDisposable
 {
     private readonly string _tempDir;


### PR DESCRIPTION
## Root Cause

`JsBundleServiceTests` and `JsBundleServiceCompressionTests` both call `JsBundleService.BuildBundle()` which writes to the **static** `_bundles` `ConcurrentDictionary`. xUnit runs different test classes in parallel by default.

The compression tests write `theme-switcher.js` with 500 `x` characters (`new string('x', 500)`). When this runs in parallel with `BuildBundle_MinifiesNonMinFiles`, the compression test can overwrite `_bundles[BundlePath]` between the minify test's `BuildBundle` and `TryServeAsync` calls — causing the assertion to find `xxxxxxxxx` instead of `var x = 1;`.

## Fix

Added `[Collection("JsBundleService")]` to both test classes so xUnit runs them sequentially. Same fix applied preventively to `CssBundleServiceTests` / `CssBundleServiceCompressionTests`.

Fixes #864