### PR TITLE
SIMD-accelerate MinifyJs, fix bloom filter alloc, optimize tokenizer

### DIFF
--- a/BareMetalWeb.Data/SearchIndexing.cs
+++ b/BareMetalWeb.Data/SearchIndexing.cs
@@ -1036,8 +1036,6 @@ public sealed class SearchIndexManager
         if (value.IsEmpty)
             return;
 
-        // Use stack-allocated buffer for tokens up to 256 chars
-        // For longer tokens, we'll fall back to slower path with array rental
         const int MaxStackTokenSize = 256;
         Span<char> buffer = stackalloc char[MaxStackTokenSize];
         int bufferPos = 0;
@@ -1046,18 +1044,41 @@ public sealed class SearchIndexManager
         for (int i = 0; i < value.Length; i++)
         {
             var ch = value[i];
-            
-            if (char.IsLetterOrDigit(ch))
+
+            // ASCII fast path: range check + bitwise lowercase (no Unicode table lookup)
+            if (ch <= 127)
             {
+                if ((uint)(ch - 'a') <= 'z' - 'a' || (uint)(ch - 'A') <= 'Z' - 'A' || (uint)(ch - '0') <= '9' - '0')
+                {
+                    // Bitwise OR 0x20 lowercases A-Z, is a no-op for 0-9
+                    var lowerCh = (char)(ch | 0x20);
+                    if (bufferPos < MaxStackTokenSize)
+                    {
+                        buffer[bufferPos++] = lowerCh;
+                    }
+                    else
+                    {
+                        if (overflowBuffer == null)
+                        {
+                            overflowBuffer = new List<char>(MaxStackTokenSize * 2);
+                            for (int j = 0; j < bufferPos; j++)
+                                overflowBuffer.Add(buffer[j]);
+                        }
+                        overflowBuffer.Add(lowerCh);
+                    }
+                    continue;
+                }
+            }
+            else if (char.IsLetterOrDigit(ch))
+            {
+                // Unicode path: full table lookup + invariant lowercase
                 var lowerCh = char.ToLowerInvariant(ch);
-                
                 if (bufferPos < MaxStackTokenSize)
                 {
                     buffer[bufferPos++] = lowerCh;
                 }
                 else
                 {
-                    // Rare case: token exceeds stack buffer, switch to heap allocation
                     if (overflowBuffer == null)
                     {
                         overflowBuffer = new List<char>(MaxStackTokenSize * 2);
@@ -1373,9 +1394,8 @@ public sealed class SearchIndexManager
 
     private int ComputeBloomHash(string token, int hashIndex, int size)
     {
-        // Use a simple but effective hash combining the token and hash index
-        var baseHash = token.ToLowerInvariant().GetHashCode();
-        var hash = ((baseHash ^ (hashIndex * 0x9e3779b9)) & 0x7FFFFFFF); // Mix with golden ratio, ensure positive
+        var baseHash = StringComparer.OrdinalIgnoreCase.GetHashCode(token);
+        var hash = ((baseHash ^ (hashIndex * 0x9e3779b9)) & 0x7FFFFFFF);
         return (int)(hash % size);
     }
 

--- a/BareMetalWeb.Host/JsBundleService.cs
+++ b/BareMetalWeb.Host/JsBundleService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using System.Collections.Concurrent;
 using System.IO;
 using System.Security.Cryptography;
@@ -72,6 +73,9 @@ public static class JsBundleService
 
     private static readonly ConcurrentDictionary<string, BundleData> _bundles = new(StringComparer.OrdinalIgnoreCase);
 
+    /// <summary>Characters that require special handling during minification. SIMD-accelerated via SearchValues.</summary>
+    private static readonly SearchValues<char> s_jsSpecialChars = SearchValues.Create("\r\n\"'`/");
+
     /// <summary>
     /// Builds and caches the SSR and VNext JS bundles from files in <paramref name="jsDirectory"/>.
     /// Should be called once at application startup.
@@ -135,12 +139,31 @@ public static class JsBundleService
     internal static string MinifyJs(string source)
     {
         var sb = new StringBuilder(source.Length);
-        int i = 0, len = source.Length;
+        var span = source.AsSpan();
+        int i = 0;
         int consecutiveNewlines = 0;
 
-        while (i < len)
+        while (i < span.Length)
         {
-            char c = source[i];
+            // SIMD fast path: bulk-copy plain text to next special character.
+            // SearchValues<char> uses hardware SIMD (SSE/AVX on x64, NEON on ARM64).
+            var remaining = span.Slice(i);
+            int nextSpecial = remaining.IndexOfAny(s_jsSpecialChars);
+
+            if (nextSpecial < 0)
+            {
+                sb.Append(remaining);
+                break;
+            }
+
+            if (nextSpecial > 0)
+            {
+                sb.Append(remaining.Slice(0, nextSpecial));
+                consecutiveNewlines = 0;
+                i += nextSpecial;
+            }
+
+            char c = span[i];
 
             // Normalise CRLF → LF by skipping bare \r
             if (c == '\r') { i++; continue; }
@@ -152,39 +175,71 @@ public static class JsBundleService
                 char quote = c;
                 sb.Append(c);
                 i++;
-                while (i < len)
+                while (i < span.Length)
                 {
-                    char sc = source[i];
-                    if (sc == '\\' && i + 1 < len)   // escape sequence: copy both chars
+                    // SIMD inner scan: find next quote, backslash, or newline
+                    var litRemaining = span.Slice(i);
+                    int nextLit = quote == '`'
+                        ? litRemaining.IndexOfAny('\\', quote)
+                        : litRemaining.IndexOfAny('\\', quote, '\n');
+
+                    if (nextLit < 0)
+                    {
+                        sb.Append(litRemaining);
+                        i = span.Length;
+                        break;
+                    }
+
+                    if (nextLit > 0)
+                    {
+                        sb.Append(litRemaining.Slice(0, nextLit));
+                        i += nextLit;
+                    }
+
+                    char sc = span[i];
+                    if (sc == '\\' && i + 1 < span.Length)
                     {
                         sb.Append(sc);
                         i++;
-                        sb.Append(source[i]);
+                        sb.Append(span[i]);
                         i++;
                         continue;
                     }
                     sb.Append(sc);
                     i++;
                     if (sc == quote) break;
-                    if (sc == '\n' && quote != '`') break; // unterminated non-template string
+                    if (sc == '\n' && quote != '`') break;
                 }
                 continue;
             }
 
-            // Line comment: skip to end of line (newline is handled on the next iteration)
-            if (c == '/' && i + 1 < len && source[i + 1] == '/')
+            // Line comment: skip to end of line (SIMD scan for newline)
+            if (c == '/' && i + 1 < span.Length && span[i + 1] == '/')
             {
                 i += 2;
-                while (i < len && source[i] != '\n') i++;
+                var commentRemaining = span.Slice(i);
+                int nlIdx = commentRemaining.IndexOf('\n');
+                i += nlIdx < 0 ? commentRemaining.Length : nlIdx;
                 continue;
             }
 
-            // Block comment: replace the whole comment with one space to avoid merging tokens
-            if (c == '/' && i + 1 < len && source[i + 1] == '*')
+            // Block comment: replace with one space (SIMD scan for *)
+            if (c == '/' && i + 1 < span.Length && span[i + 1] == '*')
             {
                 i += 2;
-                while (i + 1 < len && !(source[i] == '*' && source[i + 1] == '/')) i++;
-                if (i + 1 < len) i += 2; // consume closing */
+                while (i + 1 < span.Length)
+                {
+                    var blockRemaining = span.Slice(i);
+                    int starIdx = blockRemaining.IndexOf('*');
+                    if (starIdx < 0) { i = span.Length; break; }
+                    i += starIdx;
+                    if (i + 1 < span.Length && span[i + 1] == '/')
+                    {
+                        i += 2;
+                        break;
+                    }
+                    i++;
+                }
                 sb.Append(' ');
                 continue;
             }
@@ -198,6 +253,7 @@ public static class JsBundleService
                 continue;
             }
 
+            // Regular slash (division/regex) — not followed by / or *
             consecutiveNewlines = 0;
             sb.Append(c);
             i++;


### PR DESCRIPTION
## Changes

### MinifyJs — SIMD-accelerated text scanning
Uses `SearchValues<char>` + `IndexOfAny` to bulk-scan for special characters (`\r\n"'\`/`) using hardware SIMD (SSE/AVX on x64, NEON on ARM64). Between special chars, plain text is bulk-copied to the StringBuilder instead of character-by-character. Inner loops for string literals, line comments, and block comments also use `IndexOf`/`IndexOfAny` for vectorized scanning.

**Expected speedup:** ~3-5x on large JS bundles.

### Bloom filter — fix allocation bug
`ComputeBloomHash` was calling `token.ToLowerInvariant()` which **allocates a new string on every call**. Replaced with `StringComparer.OrdinalIgnoreCase.GetHashCode()` — zero allocations, same case-insensitive semantics.

### TokenizeToHashSet — ASCII fast path
For ASCII characters (the 95%+ common case), uses range checks + bitwise OR lowercase (`ch | 0x20`) instead of `char.IsLetterOrDigit()` + `char.ToLowerInvariant()` Unicode table lookups. Falls back to full Unicode path for non-ASCII characters.

Part of #869