### PR TITLE
perf: WAL commit, recovery, and cache hot-path optimizations

### DIFF
--- a/BareMetalWeb.Data/WalDataProvider.cs
+++ b/BareMetalWeb.Data/WalDataProvider.cs
@@ -237,6 +237,11 @@ public sealed class WalDataProvider : IDataProvider, IDisposable
             var bytes  = _serializer.Serialize(obj, schemaVersion);
             var walKey = GetOrAllocateKey(type.Name, obj.Key);
 
+            // Capture old head pointer for cache eviction before commit changes it
+            ulong oldPtr = 0;
+            if (!isInsert)
+                _walStore.TryGetHead(walKey, out oldPtr);
+
             var commitTask = _walStore.CommitAsync(new[] { WalOp.Upsert(walKey, bytes, encryption: _walStore.Encryption) });
             if (!commitTask.IsCompleted)
                 commitTask.GetAwaiter().GetResult();
@@ -247,14 +252,12 @@ public sealed class WalDataProvider : IDataProvider, IDisposable
             if (isInsert)
                 _liveCounts.AddOrUpdate(type.Name, 1, (_, c) => c + 1);
 
-            // Evict stale deserialization cache entry (WAL pointer has changed)
-            foreach (var ck in _deserCache.Keys)
+            // Evict stale deserialization cache entry using exact old key
+            if (!isInsert && oldPtr != 0)
             {
-                if (ck.TypeName == type.Name && ck.Key == obj.Key)
-                {
-                    _deserCache.TryRemove(ck, out _);
-                    _deserCacheAccess.TryRemove(ck, out _);
-                }
+                var evictKey = (type.Name, obj.Key, oldPtr);
+                _deserCache.TryRemove(evictKey, out _);
+                _deserCacheAccess.TryRemove(evictKey, out _);
             }
 
             // ── Update secondary field indexes ────────────────────────────
@@ -334,14 +337,33 @@ public sealed class WalDataProvider : IDataProvider, IDisposable
 
     private void EvictDeserCache()
     {
-        // LRU eviction — remove ~25% of entries with oldest access times
+        // LRU eviction — remove ~25% of entries with oldest access times.
+        // Single-pass min-scan avoids O(n log n) sort on the full cache.
         int toRemove = _deserCache.Count / 4;
-        var oldest = _deserCacheAccess
-            .OrderBy(kvp => kvp.Value)
-            .Take(toRemove)
-            .Select(kvp => kvp.Key)
-            .ToList();
-        foreach (var key in oldest)
+        if (toRemove == 0) toRemove = 1;
+
+        var evictKeys = new List<((string TypeName, uint Key, ulong WalPtr) key, long access)>(toRemove);
+
+        foreach (var kvp in _deserCacheAccess)
+        {
+            if (evictKeys.Count < toRemove)
+            {
+                evictKeys.Add((kvp.Key, kvp.Value));
+                continue;
+            }
+
+            // Find the max (youngest) entry in our evict set and replace it
+            // if this entry is older (smaller tick count)
+            int maxIdx = 0;
+            for (int i = 1; i < evictKeys.Count; i++)
+                if (evictKeys[i].access > evictKeys[maxIdx].access)
+                    maxIdx = i;
+
+            if (kvp.Value < evictKeys[maxIdx].access)
+                evictKeys[maxIdx] = (kvp.Key, kvp.Value);
+        }
+
+        foreach (var (key, _) in evictKeys)
         {
             _deserCache.TryRemove(key, out _);
             _deserCacheAccess.TryRemove(key, out _);
@@ -724,6 +746,9 @@ public sealed class WalDataProvider : IDataProvider, IDisposable
         var idMap    = GetOrLoadIdMap(typeName);
         if (!idMap.TryGetValue(key, out var walKey)) return;
 
+        // Capture old head pointer for cache eviction before commit
+        _walStore.TryGetHead(walKey, out ulong oldPtr);
+
         // Load the old object before deleting so we can remove its index entries
         T? oldObj = null;
         List<PropertyInfo> indexedFields = new();
@@ -740,14 +765,12 @@ public sealed class WalDataProvider : IDataProvider, IDisposable
         // Decrement live count
         _liveCounts.AddOrUpdate(typeName, 0, (_, c) => Math.Max(0, c - 1));
 
-        // Evict deserialization cache entry
-        foreach (var ck in _deserCache.Keys)
+        // Evict deserialization cache entry using exact old key
+        if (oldPtr != 0)
         {
-            if (ck.TypeName == typeName && ck.Key == key)
-            {
-                _deserCache.TryRemove(ck, out _);
-                _deserCacheAccess.TryRemove(ck, out _);
-            }
+            var evictKey = (typeName, key, oldPtr);
+            _deserCache.TryRemove(evictKey, out _);
+            _deserCacheAccess.TryRemove(evictKey, out _);
         }
 
         // ── Remove from secondary field indexes ────────────────────────────
@@ -846,6 +869,11 @@ public sealed class WalDataProvider : IDataProvider, IDisposable
             var bytes = serializer.Serialize(record, plan, schemaVersion);
             var walKey = GetOrAllocateKey(entityName, record.Key);
 
+            // Capture old head pointer for cache eviction before commit
+            ulong oldPtr = 0;
+            if (!isInsert)
+                _walStore.TryGetHead(walKey, out oldPtr);
+
             var commitTask = _walStore.CommitAsync(new[] { WalOp.Upsert(walKey, bytes, encryption: _walStore.Encryption) });
             if (!commitTask.IsCompleted)
                 commitTask.GetAwaiter().GetResult();
@@ -855,13 +883,12 @@ public sealed class WalDataProvider : IDataProvider, IDisposable
             if (isInsert)
                 _liveCounts.AddOrUpdate(entityName, 1, (_, c) => c + 1);
 
-            foreach (var ck in _deserCache.Keys)
+            // Evict deserialization cache entry using exact old key
+            if (!isInsert && oldPtr != 0)
             {
-                if (ck.TypeName == entityName && ck.Key == record.Key)
-                {
-                    _deserCache.TryRemove(ck, out _);
-                    _deserCacheAccess.TryRemove(ck, out _);
-                }
+                var evictKey = (entityName, record.Key, oldPtr);
+                _deserCache.TryRemove(evictKey, out _);
+                _deserCacheAccess.TryRemove(evictKey, out _);
             }
 
             var keyStr = record.Key.ToString();

--- a/BareMetalWeb.Data/WalHeadMap.cs
+++ b/BareMetalWeb.Data/WalHeadMap.cs
@@ -109,6 +109,138 @@ public sealed class WalHeadMap : IDisposable
         finally { _lock.ExitReadLock(); }
     }
 
+    /// <summary>
+    /// Updates multiple heads in a single write-lock acquisition.
+    /// Keys that already exist are updated in-place; new keys trigger a single
+    /// sorted merge at the end rather than N array rebuilds.
+    /// </summary>
+    internal void BatchSetHeads(ReadOnlySpan<ulong> keys, ulong ptr)
+    {
+        if (keys.Length == 0) return;
+
+        _lock.EnterWriteLock();
+        try
+        {
+            // Fast path: all keys already exist — just update in-place
+            bool allExist = true;
+            for (int i = 0; i < keys.Length; i++)
+            {
+                int idx = Array.BinarySearch(_keysSorted, keys[i]);
+                if (idx >= 0)
+                    _headsSorted[idx] = ptr;
+                else
+                    { allExist = false; break; }
+            }
+            if (allExist) return;
+
+            // Slow path: some new keys — collect inserts and do a single merge
+            var insertKeys = new List<ulong>();
+            for (int i = 0; i < keys.Length; i++)
+            {
+                int idx = Array.BinarySearch(_keysSorted, keys[i]);
+                if (idx >= 0)
+                    _headsSorted[idx] = ptr;
+                else
+                    insertKeys.Add(keys[i]);
+            }
+
+            if (insertKeys.Count == 0) return;
+
+            insertKeys.Sort();
+            int oldLen = _keysSorted.Length;
+            int newLen = oldLen + insertKeys.Count;
+            var newKeys  = new ulong[newLen];
+            var newHeads = new ulong[newLen];
+
+            // Merge sorted _keysSorted and sorted insertKeys
+            int a = 0, b = 0, w = 0;
+            while (a < oldLen && b < insertKeys.Count)
+            {
+                if (_keysSorted[a] <= insertKeys[b])
+                {
+                    newKeys[w] = _keysSorted[a];
+                    newHeads[w] = _headsSorted[a];
+                    a++;
+                }
+                else
+                {
+                    newKeys[w] = insertKeys[b];
+                    newHeads[w] = ptr;
+                    b++;
+                }
+                w++;
+            }
+            while (a < oldLen) { newKeys[w] = _keysSorted[a]; newHeads[w] = _headsSorted[a]; a++; w++; }
+            while (b < insertKeys.Count) { newKeys[w] = insertKeys[b]; newHeads[w] = ptr; b++; w++; }
+
+            _keysSorted = newKeys;
+            _headsSorted = newHeads;
+        }
+        finally { _lock.ExitWriteLock(); }
+    }
+
+    /// <summary>
+    /// Updates multiple heads with per-key ptrs in a single write-lock acquisition.
+    /// Used during recovery where different keys map to different segment pointers.
+    /// Keys and ptrs must be pre-sorted ascending by key.
+    /// </summary>
+    internal void BatchSetHeads(ReadOnlySpan<ulong> keys, ulong[] ptrs)
+    {
+        if (keys.Length == 0) return;
+
+        _lock.EnterWriteLock();
+        try
+        {
+            // Collect new keys (not already present) and update existing ones
+            var insertKeys  = new List<ulong>();
+            var insertPtrs  = new List<ulong>();
+
+            for (int i = 0; i < keys.Length; i++)
+            {
+                int idx = Array.BinarySearch(_keysSorted, keys[i]);
+                if (idx >= 0)
+                    _headsSorted[idx] = ptrs[i];
+                else
+                {
+                    insertKeys.Add(keys[i]);
+                    insertPtrs.Add(ptrs[i]);
+                }
+            }
+
+            if (insertKeys.Count == 0) return;
+
+            int oldLen = _keysSorted.Length;
+            int newLen = oldLen + insertKeys.Count;
+            var newKeys  = new ulong[newLen];
+            var newHeads = new ulong[newLen];
+
+            // Merge sorted arrays (insertKeys are already sorted since input is sorted)
+            int a = 0, b = 0, w = 0;
+            while (a < oldLen && b < insertKeys.Count)
+            {
+                if (_keysSorted[a] <= insertKeys[b])
+                {
+                    newKeys[w] = _keysSorted[a];
+                    newHeads[w] = _headsSorted[a];
+                    a++;
+                }
+                else
+                {
+                    newKeys[w] = insertKeys[b];
+                    newHeads[w] = insertPtrs[b];
+                    b++;
+                }
+                w++;
+            }
+            while (a < oldLen) { newKeys[w] = _keysSorted[a]; newHeads[w] = _headsSorted[a]; a++; w++; }
+            while (b < insertKeys.Count) { newKeys[w] = insertKeys[b]; newHeads[w] = insertPtrs[b]; b++; w++; }
+
+            _keysSorted = newKeys;
+            _headsSorted = newHeads;
+        }
+        finally { _lock.ExitWriteLock(); }
+    }
+
     /// <inheritdoc/>
     public void Dispose() => _lock.Dispose();
 }

--- a/BareMetalWeb.Data/WalProjectionManager.cs
+++ b/BareMetalWeb.Data/WalProjectionManager.cs
@@ -20,6 +20,7 @@ public sealed class WalProjectionManager : IDisposable
 {
     private readonly ReaderWriterLockSlim _regLock = new(LockRecursionPolicy.NoRecursion);
     private readonly List<ISecondaryIndex> _indexes = new();
+    private volatile ISecondaryIndex[] _cachedSnapshot = [];
     private bool _disposed;
 
     // ── Registration ─────────────────────────────────────────────────────────
@@ -35,6 +36,7 @@ public sealed class WalProjectionManager : IDisposable
                 if (_indexes[i].TableId == index.TableId && _indexes[i].Name == index.Name)
                     return; // already registered
             _indexes.Add(index);
+            _cachedSnapshot = _indexes.ToArray();
         }
         finally { _regLock.ExitWriteLock(); }
     }
@@ -46,6 +48,7 @@ public sealed class WalProjectionManager : IDisposable
         try
         {
             _indexes.RemoveAll(idx => idx.TableId == tableId && idx.Name == name);
+            _cachedSnapshot = _indexes.ToArray();
         }
         finally { _regLock.ExitWriteLock(); }
     }
@@ -76,11 +79,8 @@ public sealed class WalProjectionManager : IDisposable
     {
         if (ops.Count == 0) return;
 
-        _regLock.EnterReadLock();
-        ISecondaryIndex[] snapshot;
-        try { snapshot = _indexes.ToArray(); }
-        finally { _regLock.ExitReadLock(); }
-
+        // Use cached snapshot — no lock, no allocation on the commit hot path
+        var snapshot = _cachedSnapshot;
         if (snapshot.Length == 0) return;
 
         foreach (var op in ops)

--- a/BareMetalWeb.Data/WalSegmentReader.cs
+++ b/BareMetalWeb.Data/WalSegmentReader.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.IO;
@@ -112,57 +113,69 @@ internal static class WalSegmentReader
             return result;
 
         Span<byte> recHeader = stackalloc byte[WalConstants.RecordHeaderBytes];
+        byte[]? pooledBuf = null;
 
-        while (fs.Position < fs.Length)
+        try
         {
-            long recordStart = fs.Position;
-            if (fs.Read(recHeader) != WalConstants.RecordHeaderBytes) break;
-
-            uint recMagic = BinaryPrimitives.ReadUInt32LittleEndian(recHeader[0..]);
-            if (recMagic != WalConstants.RecordMagic) break; // corrupt / start of footer
-
-            ushort recType    = BinaryPrimitives.ReadUInt16LittleEndian(recHeader[4..]);
-            uint   totalBytes = BinaryPrimitives.ReadUInt32LittleEndian(recHeader[8..]);
-
-            long minSize = WalConstants.RecordHeaderBytes + WalConstants.RecordTrailerBytes;
-            if (totalBytes < minSize) break;
-            if (recordStart + totalBytes > fs.Length) break; // truncated
-
-            // Read the entire record for CRC verification
-            fs.Seek(recordStart, SeekOrigin.Begin);
-            var recordBuf = new byte[totalBytes];
-            if (fs.Read(recordBuf) != (int)totalBytes) break;
-
-            if (!VerifyRecordCrc(recordBuf)) break; // CRC mismatch — treat as corrupt
-
-            if (recType == WalConstants.RecordTypeCommitBatch)
+            while (fs.Position < fs.Length)
             {
-                var span = recordBuf.AsSpan();
-                int off = WalConstants.RecordHeaderBytes;
-                // Commit batch header: TxId(8) + OpCount(4) + PayloadFlags(4) = 16
-                if (off + 16 > span.Length) break;
-                uint opCount = BinaryPrimitives.ReadUInt32LittleEndian(span[(off + 8)..]);
-                off += 16;
+                long recordStart = fs.Position;
+                if (fs.Read(recHeader) != WalConstants.RecordHeaderBytes) break;
 
-                bool corrupt = false;
-                for (uint k = 0; k < opCount; k++)
+                uint recMagic = BinaryPrimitives.ReadUInt32LittleEndian(recHeader[0..]);
+                if (recMagic != WalConstants.RecordMagic) break; // corrupt / start of footer
+
+                ushort recType    = BinaryPrimitives.ReadUInt16LittleEndian(recHeader[4..]);
+                uint   totalBytes = BinaryPrimitives.ReadUInt32LittleEndian(recHeader[8..]);
+
+                long minSize = WalConstants.RecordHeaderBytes + WalConstants.RecordTrailerBytes;
+                if (totalBytes < minSize) break;
+                if (recordStart + totalBytes > fs.Length) break; // truncated
+
+                // Read the entire record for CRC verification, using pooled buffer
+                fs.Seek(recordStart, SeekOrigin.Begin);
+                if (pooledBuf == null || pooledBuf.Length < (int)totalBytes)
                 {
-                    if (off + 44 > span.Length) { corrupt = true; break; }
-
-                    ulong key           = BinaryPrimitives.ReadUInt64LittleEndian(span[off..]);
-                    uint  compressedLen = BinaryPrimitives.ReadUInt32LittleEndian(span[(off + 32)..]);
-                    off += 44;
-
-                    result[key] = (uint)recordStart;
-
-                    off += (int)compressedLen;
-                    if (off > span.Length) { corrupt = true; break; }
+                    if (pooledBuf != null) ArrayPool<byte>.Shared.Return(pooledBuf);
+                    pooledBuf = ArrayPool<byte>.Shared.Rent((int)totalBytes);
                 }
-                if (corrupt) break;
-            }
+                if (fs.Read(pooledBuf, 0, (int)totalBytes) != (int)totalBytes) break;
 
-            // Advance to the next record
-            fs.Seek(recordStart + totalBytes, SeekOrigin.Begin);
+                if (!VerifyRecordCrc(pooledBuf.AsSpan(0, (int)totalBytes))) break;
+
+                if (recType == WalConstants.RecordTypeCommitBatch)
+                {
+                    var span = pooledBuf.AsSpan(0, (int)totalBytes);
+                    int off = WalConstants.RecordHeaderBytes;
+                    // Commit batch header: TxId(8) + OpCount(4) + PayloadFlags(4) = 16
+                    if (off + 16 > span.Length) break;
+                    uint opCount = BinaryPrimitives.ReadUInt32LittleEndian(span[(off + 8)..]);
+                    off += 16;
+
+                    bool corrupt = false;
+                    for (uint k = 0; k < opCount; k++)
+                    {
+                        if (off + 44 > span.Length) { corrupt = true; break; }
+
+                        ulong key           = BinaryPrimitives.ReadUInt64LittleEndian(span[off..]);
+                        uint  compressedLen = BinaryPrimitives.ReadUInt32LittleEndian(span[(off + 32)..]);
+                        off += 44;
+
+                        result[key] = (uint)recordStart;
+
+                        off += (int)compressedLen;
+                        if (off > span.Length) { corrupt = true; break; }
+                    }
+                    if (corrupt) break;
+                }
+
+                // Advance to the next record
+                fs.Seek(recordStart + totalBytes, SeekOrigin.Begin);
+            }
+        }
+        finally
+        {
+            if (pooledBuf != null) ArrayPool<byte>.Shared.Return(pooledBuf);
         }
 
         return result;

--- a/BareMetalWeb.Data/WalStore.cs
+++ b/BareMetalWeb.Data/WalStore.cs
@@ -124,6 +124,9 @@ public sealed class WalStore : IDisposable
 
         cancellationToken.ThrowIfCancellationRequested();
 
+        WalOp[] filledOps;
+        ulong ptr;
+
         lock (_writeLock)
         {
             ObjectDisposedException.ThrowIf(_disposed, this);
@@ -137,7 +140,7 @@ public sealed class WalStore : IDisposable
             ulong txId = _nextTxId++;
 
             // Auto-fill PrevPtr from head map where caller left it as NullPtr
-            var filledOps = new WalOp[ops.Count];
+            filledOps = new WalOp[ops.Count];
             for (int i = 0; i < ops.Count; i++)
             {
                 var op = ops[i];
@@ -153,20 +156,22 @@ public sealed class WalStore : IDisposable
             }
 
             // Write record, fsync
-            ulong ptr = _activeWriter.AppendCommitBatch(txId, filledOps);
+            ptr = _activeWriter.AppendCommitBatch(txId, filledOps);
             _activeWriter.Flush(flushToDisk: true);
 
-            // Update head map and VisibleCommitPtr (completes the "TCS" notification in spec terms)
-            foreach (var op in filledOps)
-                HeadMap.SetHead(op.Key, ptr);
+            // Batch head map update — single write-lock instead of N
+            Span<ulong> opKeys = stackalloc ulong[filledOps.Length];
+            for (int i = 0; i < filledOps.Length; i++)
+                opKeys[i] = filledOps[i].Key;
+            HeadMap.BatchSetHeads(opKeys, ptr);
 
             Volatile.Write(ref _visibleCommitPtr, ptr);
-
-            // Dispatch to secondary projections (V2 spec §4.2)
-            ProjectionManager.ApplyCommit(filledOps);
-
-            return Task.FromResult(ptr);
         }
+
+        // Dispatch to secondary projections outside the write lock
+        ProjectionManager.ApplyCommit(filledOps);
+
+        return Task.FromResult(ptr);
     }
 
     // ── Read-back helpers ─────────────────────────────────────────────────────
@@ -243,14 +248,12 @@ public sealed class WalStore : IDisposable
         var segments = DiscoverSegments();  // sorted descending
 
         // Build head map from newest segment to oldest.
-        // Skip segments entirely within the snapshot horizon (all ptrs ≤ snapshotPtr)
-        // when the snapshot was just loaded – conservative: we replay all segments.
-        var headEntries = new SortedDictionary<ulong, ulong>();
+        // Use Dictionary (O(1) inserts) instead of SortedDictionary (O(log n) inserts)
+        // and sort once at the end for BulkLoad.
+        var headEntries = new Dictionary<ulong, ulong>();
 
         foreach (var (segId, filePath) in segments)
         {
-            // If snapshot covered this segment's entire range we still scan,
-            // but SetHead will be ignored for keys already in the head map.
             Dictionary<ulong, uint>? index = WalSegmentReader.TryReadFooterIndex(filePath)
                                           ?? WalSegmentReader.LinearScanIndex(filePath);
 
@@ -266,13 +269,25 @@ public sealed class WalStore : IDisposable
 
         if (headEntries.Count > 0)
         {
+            // Build sorted arrays from WAL-derived heads
             var keys  = new ulong[headEntries.Count];
             var heads = new ulong[headEntries.Count];
             int i = 0;
             foreach (var kv in headEntries) { keys[i] = kv.Key; heads[i] = kv.Value; i++; }
-            // Merge with existing (snapshot-loaded) head map: WAL wins for keys present in both
-            foreach (var kv in headEntries)
-                HeadMap.SetHead(kv.Key, kv.Value);
+
+            // Sort by key for BulkLoad/BatchSetHeads (single sort vs O(n log n) SortedDictionary inserts)
+            Array.Sort(keys, heads);
+
+            if (_visibleCommitPtr == WalConstants.NullPtr)
+            {
+                // No snapshot — just bulk-load the WAL-derived heads directly
+                HeadMap.BulkLoad(keys, heads);
+            }
+            else
+            {
+                // Snapshot was loaded — merge WAL heads on top (single write-lock)
+                HeadMap.BatchSetHeads(keys.AsSpan(), heads);
+            }
         }
 
         // Always start a new segment; don't resume the previous active segment.


### PR DESCRIPTION
## Summary

Optimizes the WAL hot paths — commit, recovery, and deserialization cache — to reduce lock contention, allocation pressure, and algorithmic complexity.

### Changes

**CommitAsync (critical path):**
- `BatchSetHeads`: single write-lock for N head map updates instead of N individual lock acquisitions
- Moved `ProjectionManager.ApplyCommit()` outside the write lock to reduce lock hold time
- Cached projection index snapshot (`volatile` field, rebuilt on register/unregister) — eliminates `.ToArray()` per commit

**Recovery:**
- Use `BulkLoad`/`BatchSetHeads` instead of individual `SetHead()` calls (was N locks during startup)
- Replaced `SortedDictionary` with `Dictionary` + single `Array.Sort` at the end

**LinearScanIndex (segment recovery):**
- Reuse `ArrayPool<byte>` buffer across records instead of `new byte[totalBytes]` per WAL record

**Cache eviction:**
- `EvictDeserCache`: O(n) single-pass min-scan replaces LINQ `.OrderBy().Take().Select().ToList()` 
- `Save`/`Delete`/`SaveRecord`: capture old WAL pointer before commit for O(1) exact-key eviction instead of O(cache) full iteration