### PR TITLE
perf: eliminate all LINQ from production code

### DIFF
--- a/BareMetalWeb.AI/AdminAssistantService.cs
+++ b/BareMetalWeb.AI/AdminAssistantService.cs
@@ -24,8 +24,14 @@ public sealed class AdminAssistantService
     public static string BuildSystemPrompt()
     {
         var entities = DataScaffold.Entities;
-        var entityList = string.Join("\n", entities.Select(e =>
-            $"  - {e.Name} (slug: {e.Slug}, {e.Fields.Count} fields)"));
+        var sb = new System.Text.StringBuilder();
+        for (int i = 0; i < entities.Count; i++)
+        {
+            var e = entities[i];
+            if (i > 0) sb.Append('\n');
+            sb.Append($"  - {e.Name} (slug: {e.Slug}, {e.Fields.Count} fields)");
+        }
+        var entityList = sb.ToString();
 
         return $"""
             You are an AI assistant for a BareMetalWeb application.
@@ -93,8 +99,10 @@ public sealed class AdminAssistantService
 
         var options = new ChatOptions
         {
-            Tools = GetTools().Cast<AITool>().ToList()
+            Tools = new List<AITool>()
         };
+        foreach (var tool in GetTools())
+            options.Tools.Add((AITool)tool);
 
         await foreach (var update in _chatClient.GetStreamingResponseAsync(history, options)
             .ConfigureAwait(false))
@@ -186,10 +194,15 @@ public static class SystemTools
         if (idField == null || valueField == null)
             return Array.Empty<SettingSummary>();
 
-        return items.Select(e => new SettingSummary(
-            idField.Getter(e)?.ToString() ?? "",
-            valueField.Getter(e)?.ToString() ?? ""
-        )).ToArray();
+        var result = new List<SettingSummary>();
+        foreach (var e in items)
+        {
+            result.Add(new SettingSummary(
+                idField.Getter(e)?.ToString() ?? "",
+                valueField.Getter(e)?.ToString() ?? ""
+            ));
+        }
+        return result.ToArray();
     }
 }
 

--- a/BareMetalWeb.AI/EntityDesignerTools.cs
+++ b/BareMetalWeb.AI/EntityDesignerTools.cs
@@ -14,9 +14,14 @@ public static class EntityDesignerTools
     [Description("List all registered entity types with name, slug, and field count.")]
     public static IReadOnlyList<EntitySummary> ListEntities()
     {
-        return DataScaffold.Entities
-            .Select(e => new EntitySummary(e.Name, e.Slug, e.Fields.Count))
-            .ToArray();
+        var entities = DataScaffold.Entities;
+        var result = new EntitySummary[entities.Count];
+        for (int i = 0; i < entities.Count; i++)
+        {
+            var e = entities[i];
+            result[i] = new EntitySummary(e.Name, e.Slug, e.Fields.Count);
+        }
+        return result;
     }
 
     [Description("List available field types (Bool, Int32, Decimal, DateTime, StringUtf8, etc.) for entity field definitions.")]
@@ -30,10 +35,15 @@ public static class EntityDesignerTools
     {
         if (!DataScaffold.TryGetEntity(slug, out var meta)) return null;
 
-        var fields = meta.Fields.Select(f => new FieldSchemaInfo(
-            f.Name, f.Label, f.FieldType.ToString(),
-            f.Required, f.ReadOnly, f.Validation?.MaxLength ?? 0
-        )).ToArray();
+        var fields = new FieldSchemaInfo[meta.Fields.Count];
+        for (int i = 0; i < meta.Fields.Count; i++)
+        {
+            var f = meta.Fields[i];
+            fields[i] = new FieldSchemaInfo(
+                f.Name, f.Label, f.FieldType.ToString(),
+                f.Required, f.ReadOnly, f.Validation?.MaxLength ?? 0
+            );
+        }
 
         return new EntitySchemaInfo(meta.Name, meta.Slug, fields);
     }
@@ -58,10 +68,15 @@ public static class EntityDesignerTools
 
         builder.Build(); // validates the schema
 
-        var resultFields = fields.Select(f => new FieldSchemaInfo(
-            f.Name, f.Label ?? f.Name, f.Type,
-            f.Required, false, f.MaxLength
-        )).ToArray();
+        var resultFields = new FieldSchemaInfo[fields.Length];
+        for (int i = 0; i < fields.Length; i++)
+        {
+            var f = fields[i];
+            resultFields[i] = new FieldSchemaInfo(
+                f.Name, f.Label ?? f.Name, f.Type,
+                f.Required, false, f.MaxLength
+            );
+        }
 
         return new EntitySchemaInfo(entityName, slug, resultFields);
     }

--- a/BareMetalWeb.AI/QueryTools.cs
+++ b/BareMetalWeb.AI/QueryTools.cs
@@ -15,9 +15,13 @@ public static class QueryTools
     {
         if (!DataScaffold.TryGetEntity(entitySlug, out var meta)) return null;
 
-        return meta.Fields.Select(f => new FieldQueryInfo(
-            f.Name, f.FieldType.ToString(), f.IsIndexed
-        )).ToArray();
+        var result = new FieldQueryInfo[meta.Fields.Count];
+        for (int i = 0; i < meta.Fields.Count; i++)
+        {
+            var f = meta.Fields[i];
+            result[i] = new FieldQueryInfo(f.Name, f.FieldType.ToString(), f.IsIndexed);
+        }
+        return result;
     }
 
     [Description("Get valid query operators (Equals, NotEquals, Contains, StartsWith, EndsWith, In, NotIn, GreaterThan, LessThan, etc.).")]
@@ -51,18 +55,20 @@ public static class QueryTools
 
         if (filters is { Length: > 0 })
         {
-            query.Clauses = filters.Select(f =>
+            query.Clauses = new List<QueryClause>(filters.Length);
+            foreach (var f in filters)
             {
                 Enum.TryParse<QueryOperator>(f.Operator, ignoreCase: true, out var op);
-                return new QueryClause { Field = f.Field, Operator = op, Value = f.Value };
-            }).ToList();
+                query.Clauses.Add(new QueryClause { Field = f.Field, Operator = op, Value = f.Value });
+            }
         }
 
         var results = await meta.Handlers.QueryAsync(query, CancellationToken.None)
             .ConfigureAwait(false);
 
         var layout = EntityLayoutCompiler.GetOrCompile(meta);
-        var rows = results.Select(entity =>
+        var rowsList = new List<Dictionary<string, object?>>();
+        foreach (var entity in results)
         {
             var dict = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase)
             {
@@ -73,8 +79,9 @@ public static class QueryTools
                 try { dict[field.Name] = field.Getter(entity); }
                 catch { dict[field.Name] = null; }
             }
-            return dict;
-        }).ToArray();
+            rowsList.Add(dict);
+        }
+        var rows = rowsList.ToArray();
 
         return new QueryResultInfo(rows.Length, rows, null);
     }
@@ -89,13 +96,15 @@ public static class QueryTools
         QueryDefinition? query = null;
         if (filters is { Length: > 0 })
         {
+            var clauses = new List<QueryClause>(filters.Length);
+            foreach (var f in filters)
+            {
+                Enum.TryParse<QueryOperator>(f.Operator, ignoreCase: true, out var op);
+                clauses.Add(new QueryClause { Field = f.Field, Operator = op, Value = f.Value });
+            }
             query = new QueryDefinition
             {
-                Clauses = filters.Select(f =>
-                {
-                    Enum.TryParse<QueryOperator>(f.Operator, ignoreCase: true, out var op);
-                    return new QueryClause { Field = f.Field, Operator = op, Value = f.Value };
-                }).ToList()
+                Clauses = clauses
             };
         }
 

--- a/BareMetalWeb.CLI/Program.cs
+++ b/BareMetalWeb.CLI/Program.cs
@@ -177,8 +177,13 @@ internal static class Program
         // metal login --outofband → device code flow (no browser)
         // metal login → device code flow (opens browser)
         // metal login <user> <pass> → direct credentials
-        bool outOfBand = args.Any(a => a == "--outofband");
-        var filtered = args.Where(a => a != "--outofband").ToArray();
+        bool outOfBand = false;
+        foreach (var a in args)
+            if (a == "--outofband") { outOfBand = true; break; }
+        var filteredList = new List<string>();
+        foreach (var a in args)
+            if (a != "--outofband") filteredList.Add(a);
+        var filtered = filteredList.ToArray();
 
         if (filtered.Length >= 2)
             return await LoginDirect(filtered[0], filtered[1]);
@@ -205,7 +210,9 @@ internal static class Program
             if (!match.Success && _config.Url != null)
             {
                 var cookies = _cookies.GetCookies(new Uri(_config.Url));
-                var csrfCookie = cookies.FirstOrDefault(c => c.Name == "csrf_token");
+                Cookie? csrfCookie = null;
+                foreach (Cookie c in cookies)
+                    if (c.Name == "csrf_token") { csrfCookie = c; break; }
                 if (csrfCookie != null) csrfToken = csrfCookie.Value;
             }
             else if (match.Success)
@@ -485,7 +492,9 @@ internal static class Program
     {
         if (args.Length < 1) return Help(1, "Usage: metal first <type> [q=text] [field=X op=eq value=Y] [sort=F] [dir=asc|desc]");
         var slug = args[0];
-        var hasSort = args.Skip(1).Any(a => a.StartsWith("sort=", StringComparison.OrdinalIgnoreCase));
+        bool hasSort = false;
+        for (int i = 1; i < args.Length; i++)
+            if (args[i].StartsWith("sort=", StringComparison.OrdinalIgnoreCase)) { hasSort = true; break; }
         var qs = new StringBuilder("?top=1");
         if (!hasSort)
             qs.Append("&sort=CreatedOnUtc&dir=desc");
@@ -607,7 +616,7 @@ internal static class Program
         var slug = args[0];
         var format = "json";
         string? outputFile = null;
-        foreach (var a in args.Skip(1))
+        foreach (var a in args[1..])
         {
             if (a.StartsWith("--format=", StringComparison.OrdinalIgnoreCase))
                 format = a[9..].ToLowerInvariant();
@@ -672,7 +681,9 @@ internal static class Program
     {
         if (string.IsNullOrEmpty(_config.Url)) return null;
         var cookies = _cookies.GetCookies(new Uri(_config.Url));
-        return cookies.FirstOrDefault(c => c.Name == "csrf_token")?.Value;
+        foreach (Cookie c in cookies)
+            if (c.Name == "csrf_token") return c.Value;
+        return null;
     }
 
     /// Sends a request with CSRF headers attached.
@@ -721,23 +732,67 @@ internal static class Program
     {
         if (items.ValueKind != JsonValueKind.Array) { Console.WriteLine(items.ToString()); return; }
         var meta = await FetchMeta();
-        var entity = meta?.FirstOrDefault(e => string.Equals(e.Slug, slug, StringComparison.OrdinalIgnoreCase));
-        var listFields = entity?.Fields.Where(f => f.List).OrderBy(f => f.Order).Select(f => f.Name).ToArray();
+        MetaEntity? entity = null;
+        if (meta != null)
+        {
+            foreach (var e in meta)
+            {
+                if (string.Equals(e.Slug, slug, StringComparison.OrdinalIgnoreCase))
+                {
+                    entity = e;
+                    break;
+                }
+            }
+        }
+        string[]? listFields = null;
+        if (entity != null)
+        {
+            var fieldList = new List<MetaField>();
+            foreach (var f in entity.Fields)
+                if (f.List) fieldList.Add(f);
+            fieldList.Sort((a, b) => a.Order.CompareTo(b.Order));
+            var names = new List<string>();
+            foreach (var f in fieldList)
+                names.Add(f.Name);
+            listFields = names.ToArray();
+        }
 
         // Collect all rows to compute column widths
         var rows = new List<string[]>();
         string[] headers;
         if (listFields != null && listFields.Length > 0)
         {
-            headers = new[] { "Id" }.Concat(listFields).ToArray();
+            var headerList = new List<string> { "Id" };
+            foreach (var f in listFields) headerList.Add(f);
+            headers = headerList.ToArray();
         }
         else
         {
             // Fallback: use keys from first item
-            var first = items.EnumerateArray().FirstOrDefault();
-            headers = first.ValueKind == JsonValueKind.Object
-                ? first.EnumerateObject().Select(p => p.Name).Take(6).ToArray()
-                : new[] { "Value" };
+            JsonElement first = default;
+            bool hasFirst = false;
+            foreach (var elem in items.EnumerateArray())
+            {
+                first = elem;
+                hasFirst = true;
+                break;
+            }
+            if (hasFirst && first.ValueKind == JsonValueKind.Object)
+            {
+                var propNames = new List<string>();
+                int count = 0;
+                foreach (var p in first.EnumerateObject())
+                {
+                    if (count >= 6) break;
+                    propNames.Add(p.Name);
+                    count++;
+                }
+                headers = propNames.ToArray();
+            }
+            else
+            {
+                headers = new[] { "Value" };
+            }
         }
 
         foreach (var item in items.EnumerateArray())

--- a/BareMetalWeb.Core/HttpContextPageInfoExtensions.cs
+++ b/BareMetalWeb.Core/HttpContextPageInfoExtensions.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Http;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using BareMetalWeb.Rendering;
 using BareMetalWeb.Core;
 using BareMetalWeb.Rendering.Models;
@@ -61,10 +60,18 @@ public static class HttpContextPageInfoExtensions
     public static void SetStringValue(this HttpContext context, string key, string value)
     {
         var current = EnsurePageContext(context);
-        var keys = current.PageMetaDataKeys.ToList();
-        var values = current.PageMetaDataValues.ToList();
+        var keys = new List<string>(current.PageMetaDataKeys);
+        var values = new List<string>(current.PageMetaDataValues);
 
-        int index = keys.FindIndex(k => string.Equals(k, key, StringComparison.Ordinal));
+        int index = -1;
+        for (int i = 0; i < keys.Count; i++)
+        {
+            if (string.Equals(keys[i], key, StringComparison.Ordinal))
+            {
+                index = i;
+                break;
+            }
+        }
         if (index >= 0)
         {
             values[index] = value;
@@ -85,8 +92,8 @@ public static class HttpContextPageInfoExtensions
     public static void AddStringValue(this HttpContext context, string key, string value)
     {
         var current = EnsurePageContext(context);
-        var keys = current.PageMetaDataKeys.ToList();
-        var values = current.PageMetaDataValues.ToList();
+        var keys = new List<string>(current.PageMetaDataKeys);
+        var values = new List<string>(current.PageMetaDataValues);
 
         keys.Add(key);
         values.Add(value);
@@ -122,9 +129,17 @@ public static class HttpContextPageInfoExtensions
     public static void SetLoop(this HttpContext context, TemplateLoop loop)
     {
         var current = EnsurePageContext(context);
-        var loops = current.TemplateLoops?.ToList() ?? new List<TemplateLoop>();
+        var loops = current.TemplateLoops != null ? new List<TemplateLoop>(current.TemplateLoops) : new List<TemplateLoop>();
 
-        int index = loops.FindIndex(l => string.Equals(l.Key, loop.Key, StringComparison.Ordinal));
+        int index = -1;
+        for (int i = 0; i < loops.Count; i++)
+        {
+            if (string.Equals(loops[i].Key, loop.Key, StringComparison.Ordinal))
+            {
+                index = i;
+                break;
+            }
+        }
         if (index >= 0)
         {
             loops[index] = loop;
@@ -145,12 +160,11 @@ public static class HttpContextPageInfoExtensions
 
     public static void SetLoopValues(this HttpContext context, string loopKey, string valueKey, IReadOnlyList<string> values)
     {
-        var items = values
-            .Select(value => (IReadOnlyDictionary<string, string>)new Dictionary<string, string>
-            {
-                [valueKey] = value
-            })
-            .ToList();
+        var items = new List<IReadOnlyDictionary<string, string>>(values.Count);
+        for (int i = 0; i < values.Count; i++)
+        {
+            items.Add(new Dictionary<string, string> { [valueKey] = values[i] });
+        }
 
         context.SetLoop(loopKey, items);
     }
@@ -158,12 +172,20 @@ public static class HttpContextPageInfoExtensions
     public static void AddLoopItem(this HttpContext context, string loopKey, IReadOnlyDictionary<string, string> item)
     {
         var current = EnsurePageContext(context);
-        var loops = current.TemplateLoops?.ToList() ?? new List<TemplateLoop>();
+        var loops = current.TemplateLoops != null ? new List<TemplateLoop>(current.TemplateLoops) : new List<TemplateLoop>();
 
-        int index = loops.FindIndex(l => string.Equals(l.Key, loopKey, StringComparison.Ordinal));
+        int index = -1;
+        for (int i = 0; i < loops.Count; i++)
+        {
+            if (string.Equals(loops[i].Key, loopKey, StringComparison.Ordinal))
+            {
+                index = i;
+                break;
+            }
+        }
         if (index >= 0)
         {
-            var items = loops[index].Items.ToList();
+            var items = new List<IReadOnlyDictionary<string, string>>(loops[index].Items);
             items.Add(item);
             loops[index] = loops[index] with { Items = items };
         }
@@ -191,7 +213,7 @@ public static class HttpContextPageInfoExtensions
     public static void AddTableColumnTitle(this HttpContext context, string title)
     {
         var current = EnsurePageContext(context);
-        var titles = current.TableColumnTitles?.ToList() ?? new List<string>();
+        var titles = current.TableColumnTitles != null ? new List<string>(current.TableColumnTitles) : new List<string>();
         titles.Add(title);
 
         context.SetPageContext(current with
@@ -212,7 +234,7 @@ public static class HttpContextPageInfoExtensions
     public static void AddTableRow(this HttpContext context, string[] row)
     {
         var current = EnsurePageContext(context);
-        var rows = current.TableData?.ToList() ?? new List<string[]>();
+        var rows = current.TableData != null ? new List<string[]>(current.TableData) : new List<string[]>();
         rows.Add(row);
 
         context.SetPageContext(current with

--- a/BareMetalWeb.Core/HttpsRedirectMode.cs
+++ b/BareMetalWeb.Core/HttpsRedirectMode.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 
 namespace BareMetalWeb.Core;
 

--- a/BareMetalWeb.Core/StaticFileConfigOptions.cs
+++ b/BareMetalWeb.Core/StaticFileConfigOptions.cs
@@ -125,7 +125,7 @@ public sealed class StaticFileConfigOptions
         options.HideUnknownMimeFiles = config.HideUnknownMimeFiles;
         options.DefaultMimeType = config.DefaultMimeType ?? options.DefaultMimeType;
         options.DefaultFile = config.DefaultFile;
-        options.DefaultFiles = config.DefaultFiles?.ToList() ?? new List<string>();
+        options.DefaultFiles = config.DefaultFiles != null ? new List<string>(config.DefaultFiles) : new List<string>();
         options.EnableDirectoryBrowsing = config.EnableDirectoryBrowsing;
         options.DirectoryListingHideDotFiles = config.DirectoryListingHideDotFiles;
         options.DirectoryListingHideUnknownMime = config.DirectoryListingHideUnknownMime;
@@ -140,7 +140,7 @@ public sealed class StaticFileConfigOptions
         options.AllowRangeOnPrecompressed = config.AllowRangeOnPrecompressed;
         options.MaxRanges = config.MaxRanges;
         options.MetadataCacheMaxEntries = config.MetadataCacheMaxEntries;
-        options.CompressibleContentTypePrefixes = config.CompressibleContentTypePrefixes?.ToList() ?? new List<string>();
+        options.CompressibleContentTypePrefixes = config.CompressibleContentTypePrefixes != null ? new List<string>(config.CompressibleContentTypePrefixes) : new List<string>();
 
         return options;
     }

--- a/BareMetalWeb.Data/AggregateLockManager.cs
+++ b/BareMetalWeb.Data/AggregateLockManager.cs
@@ -27,7 +27,23 @@ public sealed class AggregateLockManager
         bool contended = false;
 
         // Sort deterministically to prevent deadlocks
-        var sorted = aggregateKeys.OrderBy(k => k, StringComparer.Ordinal).Distinct().ToArray();
+        var sortedList = new List<string>();
+        foreach (var k in aggregateKeys)
+        {
+            bool exists = false;
+            foreach (var s in sortedList)
+            {
+                if (StringComparer.Ordinal.Equals(s, k))
+                {
+                    exists = true;
+                    break;
+                }
+            }
+            if (!exists)
+                sortedList.Add(k);
+        }
+        sortedList.Sort(StringComparer.Ordinal);
+        var sorted = sortedList.ToArray();
 
         for (int attempt = 0; attempt <= MaxRetries; attempt++)
         {

--- a/BareMetalWeb.Data/AggregationEngine.cs
+++ b/BareMetalWeb.Data/AggregationEngine.cs
@@ -32,8 +32,15 @@ public static class AggregationEngine
 
         // Resolve getter — prefer compiled from DataFieldMetadata, fallback to EntityLayout
         Func<object, object?>? getter = null;
-        var field = meta.Fields.FirstOrDefault(f =>
-            string.Equals(f.Name, fieldName, StringComparison.OrdinalIgnoreCase));
+        DataFieldMetadata? field = null;
+        foreach (var f in meta.Fields)
+        {
+            if (string.Equals(f.Name, fieldName, StringComparison.OrdinalIgnoreCase))
+            {
+                field = f;
+                break;
+            }
+        }
         if (field != null)
         {
             getter = field.GetValueFn; // compiled delegate, no reflection
@@ -76,15 +83,29 @@ public static class AggregationEngine
             return Array.Empty<AggregateResult>();
 
         // Fast path: all are Count
-        if (aggregates.All(a => a.Function == AggregateFunction.Count))
+        bool allCount = true;
+        foreach (var a in aggregates)
+        {
+            if (a.Function != AggregateFunction.Count)
+            {
+                allCount = false;
+                break;
+            }
+        }
+        if (allCount)
         {
             var count = await meta.Handlers.CountAsync(query, cancellationToken);
-            return aggregates.Select(a => new AggregateResult(a.Function, a.FieldName, count, count)).ToArray();
+            var countResults = new AggregateResult[aggregates.Length];
+            for (int i = 0; i < aggregates.Length; i++)
+                countResults[i] = new AggregateResult(aggregates[i].Function, aggregates[i].FieldName, count, count);
+            return countResults;
         }
 
         // Resolve getters
         var layout = EntityLayoutCompiler.GetOrCompile(meta);
-        var fieldsByName = meta.Fields.ToDictionary(f => f.Name, StringComparer.OrdinalIgnoreCase);
+        var fieldsByName = new Dictionary<string, DataFieldMetadata>(StringComparer.OrdinalIgnoreCase);
+        foreach (var f in meta.Fields)
+            fieldsByName[f.Name] = f;
         var accumulators = new (Func<object, object?>? Getter, StreamingAccumulator Acc, string FieldName, AggregateFunction Fn)[aggregates.Length];
 
         for (int i = 0; i < aggregates.Length; i++)

--- a/BareMetalWeb.Data/AuditService.cs
+++ b/BareMetalWeb.Data/AuditService.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using System.Text.Json;
 using System.Threading;
@@ -68,7 +67,7 @@ public sealed class AuditService
             var changes = DetectChanges(oldEntity, newEntity);
             
             // Skip if no meaningful changes (e.g., only UpdatedOnUtc, ETag changed)
-            if (!changes.Any())
+            if (changes.Count == 0)
                 return;
 
             var auditEntry = new AuditEntry(userName)
@@ -228,8 +227,7 @@ public sealed class AuditService
         var type = typeof(T);
 
         // Get all public properties
-        var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
-            .Where(p => p.CanRead && p.CanWrite);
+        var allProperties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
 
         // Fields to skip (metadata fields that always change + sensitive credential fields)
         var skipFields = new HashSet<string>
@@ -243,8 +241,11 @@ public sealed class AuditService
             "ApiKeyHashes"
         };
 
-        foreach (var prop in properties)
+        foreach (var prop in allProperties)
         {
+            if (!prop.CanRead || !prop.CanWrite)
+                continue;
+
             if (skipFields.Contains(prop.Name))
                 continue;
 
@@ -280,7 +281,16 @@ public sealed class AuditService
         // Handle collections
         if (a is IEnumerable<object> enumA && b is IEnumerable<object> enumB)
         {
-            return enumA.SequenceEqual(enumB);
+            using var eA = enumA.GetEnumerator();
+            using var eB = enumB.GetEnumerator();
+            while (true)
+            {
+                bool hasA = eA.MoveNext();
+                bool hasB = eB.MoveNext();
+                if (!hasA && !hasB) return true;
+                if (hasA != hasB) return false;
+                if (!Equals(eA.Current, eB.Current)) return false;
+            }
         }
 
         return a.Equals(b);

--- a/BareMetalWeb.Data/BinaryObjectSerializer.cs
+++ b/BareMetalWeb.Data/BinaryObjectSerializer.cs
@@ -205,7 +205,10 @@ public sealed class BinaryObjectSerializer : ISchemaAwareObjectSerializer
     public SchemaDefinition CreateSchema(int version, IEnumerable<MemberSignature> members, BinaryArchitecture architecture, uint? expectedHash = null)
     {
         if (members is null) throw new ArgumentNullException(nameof(members));
-        var materialized = members.ToArray();
+        var materializedList = new List<MemberSignature>();
+        foreach (var m in members)
+            materializedList.Add(m);
+        var materialized = materializedList.ToArray();
         var hash = GetSignatureHash(materialized);
         if (expectedHash.HasValue && expectedHash.Value != hash)
             throw new InvalidOperationException("Schema hash does not match member signatures.");

--- a/BareMetalWeb.Data/ComputedFieldService.cs
+++ b/BareMetalWeb.Data/ComputedFieldService.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Concurrent;
-using System.Linq;
+using System.Collections.Generic;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -30,8 +30,11 @@ public static class ComputedFieldService
         ComputedTrigger trigger,
         CancellationToken cancellationToken = default)
     {
-        foreach (var field in metadata.Fields.Where(f => f.Computed != null))
+        foreach (var field in metadata.Fields)
         {
+            if (field.Computed == null)
+                continue;
+
             var config = field.Computed!;
 
             // Skip if this field doesn't match the trigger
@@ -197,7 +200,11 @@ public static class ComputedFieldService
             return GetDefaultValueForAggregate(config.Aggregate, field.Property.PropertyType);
         }
 
-        var items = collection.Cast<object>().ToList();
+        var items = new List<object>();
+        foreach (var item in collection)
+        {
+            items.Add(item);
+        }
 
         if (string.IsNullOrEmpty(config.SourceField))
         {
@@ -253,84 +260,243 @@ public static class ComputedFieldService
 
             case AggregateFunction.None:
             default:
-                return values.FirstOrDefault();
+                return values.Count > 0 ? values[0] : null;
         }
+    }
+
+    private static List<object> FilterNonNull(List<object?> values)
+    {
+        var result = new List<object>(values.Count);
+        foreach (var v in values)
+        {
+            if (v != null)
+                result.Add(v);
+        }
+        return result;
     }
 
     private static object? SumValues(List<object?> values, Type targetType)
     {
-        var numericValues = values.Where(v => v != null).ToList();
+        var numericValues = FilterNonNull(values);
         if (numericValues.Count == 0)
             return GetDefaultValueForAggregate(AggregateFunction.Sum, targetType);
 
         if (targetType == typeof(decimal) || targetType == typeof(decimal?))
-            return numericValues.Sum(v => Convert.ToDecimal(v));
+        {
+            decimal sum = 0m;
+            foreach (var v in numericValues)
+                sum += Convert.ToDecimal(v);
+            return sum;
+        }
         if (targetType == typeof(double) || targetType == typeof(double?))
-            return numericValues.Sum(v => Convert.ToDouble(v));
+        {
+            double sum = 0.0;
+            foreach (var v in numericValues)
+                sum += Convert.ToDouble(v);
+            return sum;
+        }
         if (targetType == typeof(float) || targetType == typeof(float?))
-            return (float)numericValues.Sum(v => Convert.ToDouble(v));
+        {
+            double sum = 0.0;
+            foreach (var v in numericValues)
+                sum += Convert.ToDouble(v);
+            return (float)sum;
+        }
         if (targetType == typeof(long) || targetType == typeof(long?))
-            return numericValues.Sum(v => Convert.ToInt64(v));
+        {
+            long sum = 0L;
+            foreach (var v in numericValues)
+                sum += Convert.ToInt64(v);
+            return sum;
+        }
         if (targetType == typeof(int) || targetType == typeof(int?))
-            return numericValues.Sum(v => Convert.ToInt32(v));
+        {
+            int sum = 0;
+            foreach (var v in numericValues)
+                sum += Convert.ToInt32(v);
+            return sum;
+        }
 
-        return numericValues.Sum(v => Convert.ToDecimal(v));
+        {
+            decimal sum = 0m;
+            foreach (var v in numericValues)
+                sum += Convert.ToDecimal(v);
+            return sum;
+        }
     }
 
     private static object? AverageValues(List<object?> values, Type targetType)
     {
-        var numericValues = values.Where(v => v != null).ToList();
+        var numericValues = FilterNonNull(values);
         if (numericValues.Count == 0)
             return GetDefaultValueForAggregate(AggregateFunction.Average, targetType);
 
         if (targetType == typeof(decimal) || targetType == typeof(decimal?))
-            return numericValues.Average(v => Convert.ToDecimal(v));
+        {
+            decimal sum = 0m;
+            foreach (var v in numericValues)
+                sum += Convert.ToDecimal(v);
+            return sum / numericValues.Count;
+        }
         if (targetType == typeof(double) || targetType == typeof(double?))
-            return numericValues.Average(v => Convert.ToDouble(v));
+        {
+            double sum = 0.0;
+            foreach (var v in numericValues)
+                sum += Convert.ToDouble(v);
+            return sum / numericValues.Count;
+        }
         if (targetType == typeof(float) || targetType == typeof(float?))
-            return (float)numericValues.Average(v => Convert.ToDouble(v));
+        {
+            double sum = 0.0;
+            foreach (var v in numericValues)
+                sum += Convert.ToDouble(v);
+            return (float)(sum / numericValues.Count);
+        }
 
-        return numericValues.Average(v => Convert.ToDecimal(v));
+        {
+            decimal sum = 0m;
+            foreach (var v in numericValues)
+                sum += Convert.ToDecimal(v);
+            return sum / numericValues.Count;
+        }
     }
 
     private static object? MinValue(List<object?> values, Type targetType)
     {
-        var numericValues = values.Where(v => v != null).ToList();
+        var numericValues = FilterNonNull(values);
         if (numericValues.Count == 0)
             return GetDefaultValueForAggregate(AggregateFunction.Min, targetType);
 
         if (targetType == typeof(decimal) || targetType == typeof(decimal?))
-            return numericValues.Min(v => Convert.ToDecimal(v));
+        {
+            decimal min = Convert.ToDecimal(numericValues[0]);
+            for (int i = 1; i < numericValues.Count; i++)
+            {
+                decimal val = Convert.ToDecimal(numericValues[i]);
+                if (val < min) min = val;
+            }
+            return min;
+        }
         if (targetType == typeof(double) || targetType == typeof(double?))
-            return numericValues.Min(v => Convert.ToDouble(v));
+        {
+            double min = Convert.ToDouble(numericValues[0]);
+            for (int i = 1; i < numericValues.Count; i++)
+            {
+                double val = Convert.ToDouble(numericValues[i]);
+                if (val < min) min = val;
+            }
+            return min;
+        }
         if (targetType == typeof(float) || targetType == typeof(float?))
-            return numericValues.Min(v => Convert.ToSingle(v));
+        {
+            float min = Convert.ToSingle(numericValues[0]);
+            for (int i = 1; i < numericValues.Count; i++)
+            {
+                float val = Convert.ToSingle(numericValues[i]);
+                if (val < min) min = val;
+            }
+            return min;
+        }
         if (targetType == typeof(long) || targetType == typeof(long?))
-            return numericValues.Min(v => Convert.ToInt64(v));
+        {
+            long min = Convert.ToInt64(numericValues[0]);
+            for (int i = 1; i < numericValues.Count; i++)
+            {
+                long val = Convert.ToInt64(numericValues[i]);
+                if (val < min) min = val;
+            }
+            return min;
+        }
         if (targetType == typeof(int) || targetType == typeof(int?))
-            return numericValues.Min(v => Convert.ToInt32(v));
+        {
+            int min = Convert.ToInt32(numericValues[0]);
+            for (int i = 1; i < numericValues.Count; i++)
+            {
+                int val = Convert.ToInt32(numericValues[i]);
+                if (val < min) min = val;
+            }
+            return min;
+        }
 
-        return numericValues.Min();
+        {
+            var comparer = Comparer<object>.Default;
+            object min = numericValues[0];
+            for (int i = 1; i < numericValues.Count; i++)
+            {
+                if (comparer.Compare(numericValues[i], min) < 0)
+                    min = numericValues[i];
+            }
+            return min;
+        }
     }
 
     private static object? MaxValue(List<object?> values, Type targetType)
     {
-        var numericValues = values.Where(v => v != null).ToList();
+        var numericValues = FilterNonNull(values);
         if (numericValues.Count == 0)
             return GetDefaultValueForAggregate(AggregateFunction.Max, targetType);
 
         if (targetType == typeof(decimal) || targetType == typeof(decimal?))
-            return numericValues.Max(v => Convert.ToDecimal(v));
+        {
+            decimal max = Convert.ToDecimal(numericValues[0]);
+            for (int i = 1; i < numericValues.Count; i++)
+            {
+                decimal val = Convert.ToDecimal(numericValues[i]);
+                if (val > max) max = val;
+            }
+            return max;
+        }
         if (targetType == typeof(double) || targetType == typeof(double?))
-            return numericValues.Max(v => Convert.ToDouble(v));
+        {
+            double max = Convert.ToDouble(numericValues[0]);
+            for (int i = 1; i < numericValues.Count; i++)
+            {
+                double val = Convert.ToDouble(numericValues[i]);
+                if (val > max) max = val;
+            }
+            return max;
+        }
         if (targetType == typeof(float) || targetType == typeof(float?))
-            return numericValues.Max(v => Convert.ToSingle(v));
+        {
+            float max = Convert.ToSingle(numericValues[0]);
+            for (int i = 1; i < numericValues.Count; i++)
+            {
+                float val = Convert.ToSingle(numericValues[i]);
+                if (val > max) max = val;
+            }
+            return max;
+        }
         if (targetType == typeof(long) || targetType == typeof(long?))
-            return numericValues.Max(v => Convert.ToInt64(v));
+        {
+            long max = Convert.ToInt64(numericValues[0]);
+            for (int i = 1; i < numericValues.Count; i++)
+            {
+                long val = Convert.ToInt64(numericValues[i]);
+                if (val > max) max = val;
+            }
+            return max;
+        }
         if (targetType == typeof(int) || targetType == typeof(int?))
-            return numericValues.Max(v => Convert.ToInt32(v));
+        {
+            int max = Convert.ToInt32(numericValues[0]);
+            for (int i = 1; i < numericValues.Count; i++)
+            {
+                int val = Convert.ToInt32(numericValues[i]);
+                if (val > max) max = val;
+            }
+            return max;
+        }
 
-        return numericValues.Max();
+        {
+            var comparer = Comparer<object>.Default;
+            object max = numericValues[0];
+            for (int i = 1; i < numericValues.Count; i++)
+            {
+                if (comparer.Compare(numericValues[i], max) > 0)
+                    max = numericValues[i];
+            }
+            return max;
+        }
     }
 
     private static object? GetDefaultValueForAggregate(AggregateFunction aggregate, Type targetType)

--- a/BareMetalWeb.Data/DataObjectStore.cs
+++ b/BareMetalWeb.Data/DataObjectStore.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using BareMetalWeb.Data.Interfaces;
@@ -107,7 +106,15 @@ public sealed class DataObjectStore : IDataObjectStore
     {
         return _providerCache.GetOrAdd(type, t =>
         {
-            var provider = _providersList.FirstOrDefault(p => p.CanHandle(t));
+            IDataProvider? provider = null;
+            foreach (var p in _providersList)
+            {
+                if (p.CanHandle(t))
+                {
+                    provider = p;
+                    break;
+                }
+            }
             if (provider is not null)
                 return provider;
 

--- a/BareMetalWeb.Data/DataQueryEvaluator.cs
+++ b/BareMetalWeb.Data/DataQueryEvaluator.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using BareMetalWeb.Core;
 using BareMetalWeb.Data.Interfaces;
@@ -80,29 +79,36 @@ public sealed class DataQueryEvaluator : IDataQueryEvaluator
         if (query == null || query.Sorts.Count == 0)
             return source;
 
-        IOrderedEnumerable<T>? ordered = null;
-        var comparer = new ObjectComparer();
-
+        // Collect the active sort specifications
+        var activeSorts = new List<(string Field, SortDirection Direction)>();
         foreach (var sort in query.Sorts)
         {
-            if (string.IsNullOrWhiteSpace(sort.Field))
-                continue;
-
-            if (ordered == null)
-            {
-                ordered = sort.Direction == SortDirection.Desc
-                    ? source.OrderByDescending(item => GetMemberValue(item!, sort.Field), comparer)
-                    : source.OrderBy(item => GetMemberValue(item!, sort.Field), comparer);
-            }
-            else
-            {
-                ordered = sort.Direction == SortDirection.Desc
-                    ? ordered.ThenByDescending(item => GetMemberValue(item!, sort.Field), comparer)
-                    : ordered.ThenBy(item => GetMemberValue(item!, sort.Field), comparer);
-            }
+            if (!string.IsNullOrWhiteSpace(sort.Field))
+                activeSorts.Add((sort.Field, sort.Direction));
         }
 
-        return ordered ?? source;
+        if (activeSorts.Count == 0)
+            return source;
+
+        var list = new List<T>(source is ICollection<T> col ? col.Count : 16);
+        foreach (var item in source)
+            list.Add(item);
+
+        var comparer = new ObjectComparer();
+        list.Sort((a, b) =>
+        {
+            foreach (var (field, direction) in activeSorts)
+            {
+                var va = GetMemberValue(a!, field);
+                var vb = GetMemberValue(b!, field);
+                int cmp = comparer.Compare(va, vb);
+                if (cmp != 0)
+                    return direction == SortDirection.Desc ? -cmp : cmp;
+            }
+            return 0;
+        });
+
+        return list;
     }
 
     private static bool EvaluateClause(object? memberValue, Type memberType, QueryClause clause)

--- a/BareMetalWeb.Data/DataScaffold.cs
+++ b/BareMetalWeb.Data/DataScaffold.cs
@@ -101,7 +101,15 @@ public sealed record DataEntityMetadata(
 
     /// <summary>O(1) field lookup by name (case-insensitive). Lazy-built on first access.</summary>
     public Dictionary<string, DataFieldMetadata> FieldsByName =>
-        _fieldsByName ??= Fields.ToDictionary(f => f.Name, StringComparer.OrdinalIgnoreCase);
+        _fieldsByName ??= BuildFieldsByName();
+
+    private Dictionary<string, DataFieldMetadata> BuildFieldsByName()
+    {
+        var dict = new Dictionary<string, DataFieldMetadata>(StringComparer.OrdinalIgnoreCase);
+        foreach (var f in Fields)
+            dict[f.Name] = f;
+        return dict;
+    }
 
     /// <summary>Try to find a field by name in O(1). Returns null if not found.</summary>
     public DataFieldMetadata? FindField(string name) =>
@@ -177,7 +185,12 @@ public static class DataScaffold
 
     private static IReadOnlyList<DataEntityMetadata> RebuildEntityList()
     {
-        var list = EntitiesBySlug.Values.OrderBy(e => e.NavOrder).ThenBy(e => e.Name).ToArray();
+        var list = new List<DataEntityMetadata>(EntitiesBySlug.Values);
+        list.Sort((a, b) =>
+        {
+            int cmp = a.NavOrder.CompareTo(b.NavOrder);
+            return cmp != 0 ? cmp : string.Compare(a.Name, b.Name, StringComparison.Ordinal);
+        });
         _cachedEntityList = list;
         return list;
     }
@@ -287,9 +300,16 @@ public static class DataScaffold
             {
                 // If any field uses field-level sequential generation, seed and assign here
                 // to ensure the ID survives application restarts without duplicates.
-                var seqField = metadata.Fields.FirstOrDefault(f =>
-                    f.IdGeneration == IdGenerationStrategy.Sequential &&
-                    string.Equals(f.Property.Name, nameof(BaseDataObject.Key), StringComparison.Ordinal));
+                DataFieldMetadata? seqField = null;
+                foreach (var f in metadata.Fields)
+                {
+                    if (f.IdGeneration == IdGenerationStrategy.Sequential &&
+                        string.Equals(f.Property.Name, nameof(BaseDataObject.Key), StringComparison.Ordinal))
+                    {
+                        seqField = f;
+                        break;
+                    }
+                }
 
                 if (seqField != null && !_sequenceSeeded.ContainsKey(metadata.Name))
                 {
@@ -499,8 +519,10 @@ public static class DataScaffold
 
     public static IReadOnlyList<FormField> BuildFormFields(DataEntityMetadata metadata, object? instance, bool forCreate, string? cspNonce = null)
     {
+        var sortedFields = new List<DataFieldMetadata>(metadata.Fields);
+        sortedFields.Sort((a, b) => a.Order.CompareTo(b.Order));
         var fields = new List<FormField>();
-        foreach (var field in metadata.Fields.OrderBy(f => f.Order))
+        foreach (var field in sortedFields)
         {
             if (forCreate && !field.Create)
                 continue;
@@ -771,7 +793,9 @@ public static class DataScaffold
             if (field.Lookup != null)
             {
                 var lookupOptions = GetLookupOptions(field.Lookup);
-                var lookupMap = lookupOptions.ToDictionary(k => k.Key, v => v.Value, StringComparer.OrdinalIgnoreCase);
+                var lookupMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var opt in lookupOptions)
+                    lookupMap[opt.Key] = opt.Value;
                 var key = value?.ToString() ?? string.Empty;
                 var display = lookupMap.TryGetValue(key, out var resolved) ? resolved : key;
                 rows.Add((field.Label, FormatLookupDisplay(key, display)));
@@ -799,7 +823,9 @@ public static class DataScaffold
             if (field.Lookup != null)
             {
                 var lookupOptions = GetLookupOptions(field.Lookup);
-                var lookupMap = lookupOptions.ToDictionary(k => k.Key, v => v.Value, StringComparer.OrdinalIgnoreCase);
+                var lookupMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var opt in lookupOptions)
+                    lookupMap[opt.Key] = opt.Value;
                 var key = value?.ToString() ?? string.Empty;
                 var display = lookupMap.TryGetValue(key, out var resolved) ? resolved : key;
                 var relatedUrl = TryBuildLookupUrl(field.Lookup, key, canRenderLookupLink);
@@ -857,11 +883,16 @@ public static class DataScaffold
 
     public static IReadOnlyList<string> BuildListHeaders(DataEntityMetadata metadata, bool includeActions, bool includeBulkSelection = false)
     {
-        var headers = metadata.Fields
-            .Where(f => f.List)
-            .OrderBy(f => f.Order)
-            .Select(f => f.Label)
-            .ToList();
+        var listFields = new List<DataFieldMetadata>();
+        foreach (var f in metadata.Fields)
+        {
+            if (f.List)
+                listFields.Add(f);
+        }
+        listFields.Sort((a, b) => a.Order.CompareTo(b.Order));
+        var headers = new List<string>(listFields.Count);
+        foreach (var f in listFields)
+            headers.Add(f.Label);
 
         if (includeActions)
             headers.Insert(0, "Actions");
@@ -903,9 +934,10 @@ public static class DataScaffold
 
         var result = new List<Dictionary<string, object?>>();
 
-        var properties = childType.GetProperties(BindingFlags.Public | BindingFlags.Instance)
-            .OrderBy(p => p.MetadataToken)
-            .ToArray();
+        var unsortedProps = childType.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+        var propList = new List<System.Reflection.PropertyInfo>(unsortedProps);
+        propList.Sort((a, b) => a.MetadataToken.CompareTo(b.MetadataToken));
+        var properties = propList.ToArray();
 
         foreach (var prop in properties)
         {
@@ -956,9 +988,11 @@ public static class DataScaffold
             else if (effectiveType == FormFieldType.Enum)
             {
                 fd["lookup"]     = null;
-                fd["enumValues"] = BuildEnumOptions(prop.PropertyType)
-                    .Select(o => (object)new Dictionary<string, object?> { ["value"] = o.Key, ["label"] = o.Value })
-                    .ToList();
+                var enumOpts = BuildEnumOptions(prop.PropertyType);
+                var enumList = new List<object>(enumOpts.Count);
+                foreach (var o in enumOpts)
+                    enumList.Add((object)new Dictionary<string, object?> { ["value"] = o.Key, ["label"] = o.Value });
+                fd["enumValues"] = enumList;
                 fd["lookupCopyFields"] = null;
                 fd["lookupTargetSlug"] = null;
             }
@@ -1018,7 +1052,9 @@ public static class DataScaffold
             if (value is not IEnumerable enumerable)
                 continue;
             var childFields = GetChildFieldMetadataSimple(childType);
-            var headers = childFields.Select(f => f.Label).ToArray();
+            var headers = new string[childFields.Count];
+            for (int hi = 0; hi < childFields.Count; hi++)
+                headers[hi] = childFields[hi].Label;
             var rows = new List<string[]>();
             
             foreach (var item in enumerable)
@@ -1079,7 +1115,10 @@ public static class DataScaffold
             if (listFields[fi].Lookup != null)
             {
                 var opts = GetLookupOptions(listFields[fi].Lookup!);
-                lookupMaps[fi] = opts.ToDictionary(k => k.Key, v => v.Value, StringComparer.OrdinalIgnoreCase);
+                var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var opt in opts)
+                    map[opt.Key] = opt.Value;
+                lookupMaps[fi] = map;
             }
         }
 
@@ -1165,8 +1204,12 @@ public static class DataScaffold
             return "<p class=\"text-warning\">Tree view requires a self-referencing parent field.</p>";
 
         var html = new StringBuilder();
-        var itemsList = allItems.ToList();
-        var itemsById = itemsList.ToDictionary(i => GetIdValue(i) ?? string.Empty, i => i, StringComparer.OrdinalIgnoreCase);
+        var itemsList = new List<BaseDataObject>();
+        foreach (var item in allItems)
+            itemsList.Add(item);
+        var itemsById = new Dictionary<string, BaseDataObject>(StringComparer.OrdinalIgnoreCase);
+        foreach (var item in itemsList)
+            itemsById[GetIdValue(item) ?? string.Empty] = item;
         
         // Find root items (no parent or parent not found)
         var rootItems = new List<BaseDataObject>();
@@ -1187,8 +1230,9 @@ public static class DataScaffold
         }
         else
         {
+            rootItems.Sort((a, b) => string.Compare(GetDisplayValue(metadata, a), GetDisplayValue(metadata, b), StringComparison.Ordinal));
             html.Append("<ul class=\"bm-data-tree-list\">");
-            foreach (var root in rootItems.OrderBy(i => GetDisplayValue(metadata, i)))
+            foreach (var root in rootItems)
             {
                 RenderTreeNode(html, metadata, root, itemsList, selectedId, basePath, 0);
             }
@@ -1251,11 +1295,13 @@ public static class DataScaffold
         var children = new List<BaseDataObject>();
         if (metadata.ParentField != null)
         {
-            children = allItems.Where(child =>
+            foreach (var child in allItems)
             {
                 var parentId = metadata.ParentField.GetValueFn(child)?.ToString();
-                return string.Equals(parentId, itemId, StringComparison.OrdinalIgnoreCase);
-            }).OrderBy(c => GetDisplayValue(metadata, c)).ToList();
+                if (string.Equals(parentId, itemId, StringComparison.OrdinalIgnoreCase))
+                    children.Add(child);
+            }
+            children.Sort((a, b) => string.Compare(GetDisplayValue(metadata, a), GetDisplayValue(metadata, b), StringComparison.Ordinal));
         }
 
         var hasChildren = children.Count > 0;
@@ -1300,7 +1346,9 @@ public static class DataScaffold
         if (string.IsNullOrWhiteSpace(selectedId))
             return false;
 
-        var itemsById = allItems.ToDictionary(i => GetIdValue(i) ?? string.Empty, i => i, StringComparer.OrdinalIgnoreCase);
+        var itemsById = new Dictionary<string, BaseDataObject>(StringComparer.OrdinalIgnoreCase);
+        foreach (var i in allItems)
+            itemsById[GetIdValue(i) ?? string.Empty] = i;
         var itemId = GetIdValue(item) ?? string.Empty;
 
         // Check if selectedId is a descendant of itemId
@@ -1338,8 +1386,12 @@ public static class DataScaffold
             return "<p class=\"text-warning\">Org chart view requires a self-referencing parent field.</p>";
 
         var html = new StringBuilder();
-        var itemsList = allItems.ToList();
-        var itemsById = itemsList.ToDictionary(i => GetIdValue(i) ?? string.Empty, i => i, StringComparer.OrdinalIgnoreCase);
+        var itemsList = new List<BaseDataObject>();
+        foreach (var item in allItems)
+            itemsList.Add(item);
+        var itemsById = new Dictionary<string, BaseDataObject>(StringComparer.OrdinalIgnoreCase);
+        foreach (var item in itemsList)
+            itemsById[GetIdValue(item) ?? string.Empty] = item;
 
         // Find the selected item or default to first root
         BaseDataObject? rootItem = null;
@@ -1350,11 +1402,15 @@ public static class DataScaffold
         else
         {
             // Find first root item (no parent)
-            rootItem = itemsList.FirstOrDefault(i =>
+            foreach (var i in itemsList)
             {
                 var parentId = metadata.ParentField.GetValueFn(i)?.ToString();
-                return string.IsNullOrWhiteSpace(parentId) || !itemsById.ContainsKey(parentId);
-            });
+                if (string.IsNullOrWhiteSpace(parentId) || !itemsById.ContainsKey(parentId))
+                {
+                    rootItem = i;
+                    break;
+                }
+            }
         }
 
         html.Append("<div class=\"bm-orgchart-container\">");
@@ -1395,10 +1451,17 @@ public static class DataScaffold
         var selectedClass = isSelected ? " bm-orgchart-card-selected" : string.Empty;
         
         // Find a field that might represent title/role (look for common names)
-        var titleField = metadata.Fields.FirstOrDefault(f =>
-            f.Name.Contains("Title", StringComparison.OrdinalIgnoreCase) ||
-            f.Name.Contains("Role", StringComparison.OrdinalIgnoreCase) ||
-            f.Name.Contains("Position", StringComparison.OrdinalIgnoreCase));
+        DataFieldMetadata? titleField = null;
+        foreach (var f in metadata.Fields)
+        {
+            if (f.Name.Contains("Title", StringComparison.OrdinalIgnoreCase) ||
+                f.Name.Contains("Role", StringComparison.OrdinalIgnoreCase) ||
+                f.Name.Contains("Position", StringComparison.OrdinalIgnoreCase))
+            {
+                titleField = f;
+                break;
+            }
+        }
         var titleValue = titleField != null ? titleField.GetValueFn(item)?.ToString() : null;
         
         // Render the current node
@@ -1422,11 +1485,14 @@ public static class DataScaffold
         // Find children
         if (metadata.ParentField != null)
         {
-            var children = allItems.Where(child =>
+            var children = new List<BaseDataObject>();
+            foreach (var child in allItems)
             {
                 var parentId = metadata.ParentField.GetValueFn(child)?.ToString();
-                return string.Equals(parentId, itemId, StringComparison.OrdinalIgnoreCase);
-            }).OrderBy(c => GetDisplayValue(metadata, c)).ToList();
+                if (string.Equals(parentId, itemId, StringComparison.OrdinalIgnoreCase))
+                    children.Add(child);
+            }
+            children.Sort((a, b) => string.Compare(GetDisplayValue(metadata, a), GetDisplayValue(metadata, b), StringComparison.Ordinal));
 
             if (children.Count > 0)
             {
@@ -1444,10 +1510,19 @@ public static class DataScaffold
     private static DataFieldMetadata? FindDayEnumField(DataEntityMetadata metadata)
     {
         // Prefer enum fields whose name or label contains "day" (e.g. Day, DayOfWeek, WeekDay)
-        return metadata.Fields.FirstOrDefault(f =>
-                f.FieldType == FormFieldType.Enum &&
-                f.Name.Contains("day", StringComparison.OrdinalIgnoreCase))
-            ?? metadata.Fields.FirstOrDefault(f => f.FieldType == FormFieldType.Enum);
+        DataFieldMetadata? dayField = null;
+        DataFieldMetadata? anyEnum = null;
+        foreach (var f in metadata.Fields)
+        {
+            if (f.FieldType != FormFieldType.Enum) continue;
+            anyEnum ??= f;
+            if (f.Name.Contains("day", StringComparison.OrdinalIgnoreCase))
+            {
+                dayField = f;
+                break;
+            }
+        }
+        return dayField ?? anyEnum;
     }
 
     public static bool CanShowTimetableView(DataEntityMetadata metadata)
@@ -1456,18 +1531,27 @@ public static class DataScaffold
         var dayField = FindDayEnumField(metadata);
 
         // Check for TimeOnly or DateTime field
-        var timeField = metadata.Fields.FirstOrDefault(f =>
-            f.FieldType == FormFieldType.TimeOnly ||
-            f.FieldType == FormFieldType.DateTime);
+        DataFieldMetadata? timeField = null;
+        foreach (var f in metadata.Fields)
+        {
+            if (f.FieldType == FormFieldType.TimeOnly || f.FieldType == FormFieldType.DateTime)
+            {
+                timeField = f;
+                break;
+            }
+        }
 
         return dayField != null && timeField != null;
     }
 
     public static bool CanShowTimelineView(DataEntityMetadata metadata)
     {
-        return metadata.Fields.Any(f =>
-            f.FieldType == FormFieldType.DateOnly ||
-            f.FieldType == FormFieldType.DateTime);
+        foreach (var f in metadata.Fields)
+        {
+            if (f.FieldType == FormFieldType.DateOnly || f.FieldType == FormFieldType.DateTime)
+                return true;
+        }
+        return false;
     }
 
     /// <summary>
@@ -1481,9 +1565,12 @@ public static class DataScaffold
 
     public static bool CanShowCalendarView(DataEntityMetadata metadata)
     {
-        return metadata.Fields.Any(f =>
-            f.FieldType == FormFieldType.DateOnly ||
-            f.FieldType == FormFieldType.DateTime);
+        foreach (var f in metadata.Fields)
+        {
+            if (f.FieldType == FormFieldType.DateOnly || f.FieldType == FormFieldType.DateTime)
+                return true;
+        }
+        return false;
     }
 
     public static string BuildTimetableHtml(
@@ -1497,23 +1584,38 @@ public static class DataScaffold
         // Find the day and time fields
         var dayField = FindDayEnumField(metadata);
 
-        var timeField = metadata.Fields.FirstOrDefault(f =>
-            f.FieldType == FormFieldType.TimeOnly ||
-            f.FieldType == FormFieldType.DateTime);
+        DataFieldMetadata? timeField = null;
+        foreach (var f in metadata.Fields)
+        {
+            if (f.FieldType == FormFieldType.TimeOnly || f.FieldType == FormFieldType.DateTime)
+            {
+                timeField = f;
+                break;
+            }
+        }
 
         if (dayField == null || timeField == null)
             return "<p class=\"text-warning\">Timetable view requires a Day (DayOfWeek) field and a Time field.</p>";
 
         var html = new StringBuilder();
-        var itemsList = allItems.ToList();
+        var itemsList = new List<BaseDataObject>();
+        foreach (var item in allItems)
+            itemsList.Add(item);
 
         // Group by day using the integer value of the enum so any day-of-week enum type works
-        var groupedByDay = itemsList
-            .GroupBy(item => Convert.ToInt32(dayField.GetValueFn(item) ?? 0))
-            .OrderBy(g => g.Key)
-            .ToList();
+        var dayGroups = new SortedDictionary<int, List<BaseDataObject>>();
+        foreach (var item in itemsList)
+        {
+            var dayKey = Convert.ToInt32(dayField.GetValueFn(item) ?? 0);
+            if (!dayGroups.TryGetValue(dayKey, out var group))
+            {
+                group = new List<BaseDataObject>();
+                dayGroups[dayKey] = group;
+            }
+            group.Add(item);
+        }
 
-        if (groupedByDay.Count == 0)
+        if (dayGroups.Count == 0)
         {
             html.Append("<p class=\"text-muted mb-0\">No items found.</p>");
             return html.ToString();
@@ -1521,16 +1623,20 @@ public static class DataScaffold
 
         html.Append("<div class=\"bm-timetable-container\">");
 
-        foreach (var dayGroup in groupedByDay)
+        foreach (var dayGroupEntry in dayGroups)
         {
-            var dayName = Enum.GetName(dayField.Property.PropertyType, dayGroup.Key) ?? dayGroup.Key.ToString();
+            var dayKey = dayGroupEntry.Key;
+            var dayGroup = dayGroupEntry.Value;
+            var dayName = Enum.GetName(dayField.Property.PropertyType, dayKey) ?? dayKey.ToString();
             html.Append($"<div class=\"bm-timetable-day-section mb-4\">");
             html.Append($"<h3 class=\"bm-timetable-day-header\">{WebUtility.HtmlEncode(dayName)}</h3>");
 
             // Sort items by time within this day
-            var sortedItems = timeField.FieldType == FormFieldType.TimeOnly
-                ? dayGroup.OrderBy(item => CoerceTimeOnly(timeField.GetValueFn(item))).ToList()
-                : dayGroup.OrderBy(item => (DateTime)(timeField.GetValueFn(item) ?? DateTime.MinValue)).ToList();
+            var sortedItems = new List<BaseDataObject>(dayGroup);
+            if (timeField.FieldType == FormFieldType.TimeOnly)
+                sortedItems.Sort((a, b) => CoerceTimeOnly(timeField.GetValueFn(a)).CompareTo(CoerceTimeOnly(timeField.GetValueFn(b))));
+            else
+                sortedItems.Sort((a, b) => ((DateTime)(timeField.GetValueFn(a) ?? DateTime.MinValue)).CompareTo((DateTime)(timeField.GetValueFn(b) ?? DateTime.MinValue)));
 
             html.Append("<table class=\"table table-striped table-hover\">");
             html.Append("<thead><tr>");
@@ -1542,7 +1648,13 @@ public static class DataScaffold
             html.Append($"<th scope=\"col\">{WebUtility.HtmlEncode(timeField.Label)}</th>");
             
             // Add other list fields
-            foreach (var field in metadata.Fields.Where(f => f.List && f != dayField && f != timeField))
+            var otherListFields = new List<DataFieldMetadata>();
+            foreach (var f in metadata.Fields)
+            {
+                if (f.List && f != dayField && f != timeField)
+                    otherListFields.Add(f);
+            }
+            foreach (var field in otherListFields)
             {
                 html.Append($"<th scope=\"col\">{WebUtility.HtmlEncode(field.Label)}</th>");
             }
@@ -1584,7 +1696,7 @@ public static class DataScaffold
                 html.Append($"<td>{WebUtility.HtmlEncode(timeDisplay)}</td>");
 
                 // Other list fields
-                foreach (var field in metadata.Fields.Where(f => f.List && f != dayField && f != timeField))
+                foreach (var field in otherListFields)
                 {
                     var rawValue = field.GetValueFn(item);
                     string displayValue;
@@ -1592,7 +1704,9 @@ public static class DataScaffold
                     if (field.Lookup != null)
                     {
                         var lookupOptions = GetLookupOptions(field.Lookup);
-                        var lookupMap = lookupOptions.ToDictionary(k => k.Key, v => v.Value, StringComparer.OrdinalIgnoreCase);
+                        var lookupMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                        foreach (var opt in lookupOptions)
+                            lookupMap[opt.Key] = opt.Value;
                         var key = rawValue?.ToString() ?? string.Empty;
                         var display = lookupMap.TryGetValue(key, out var resolved) ? resolved : key;
                         var relatedUrl = TryBuildLookupUrl(field.Lookup, key, canRenderLookupLink);
@@ -1630,10 +1744,17 @@ public static class DataScaffold
     private static string GetDisplayValue(DataEntityMetadata metadata, BaseDataObject item)
     {
         // Try to find a Name field
-        var nameField = metadata.Fields.FirstOrDefault(f =>
-            string.Equals(f.Name, "Name", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(f.Name, "Title", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(f.Name, "DisplayName", StringComparison.OrdinalIgnoreCase));
+        DataFieldMetadata? nameField = null;
+        foreach (var f in metadata.Fields)
+        {
+            if (string.Equals(f.Name, "Name", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(f.Name, "Title", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(f.Name, "DisplayName", StringComparison.OrdinalIgnoreCase))
+            {
+                nameField = f;
+                break;
+            }
+        }
 
         if (nameField != null)
         {
@@ -1708,7 +1829,9 @@ public static class DataScaffold
     public static List<string> ApplyValuesFromForm(DataEntityMetadata metadata, object instance, IDictionary<string, string?> values, bool forCreate)
     {
         var errors = new List<string>();
-        foreach (var field in metadata.Fields.OrderBy(f => f.Order))
+        var sortedFields = new List<DataFieldMetadata>(metadata.Fields);
+        sortedFields.Sort((a, b) => a.Order.CompareTo(b.Order));
+        foreach (var field in sortedFields)
         {
             if (field.ReadOnly)
                 continue;
@@ -1813,7 +1936,9 @@ public static class DataScaffold
     public static List<string> ApplyValuesFromJson(DataEntityMetadata metadata, object instance, IDictionary<string, JsonElement> values, bool forCreate, bool allowMissing)
     {
         var errors = new List<string>();
-        foreach (var field in metadata.Fields.OrderBy(f => f.Order))
+        var sortedFields = new List<DataFieldMetadata>(metadata.Fields);
+        sortedFields.Sort((a, b) => a.Order.CompareTo(b.Order));
+        foreach (var field in sortedFields)
         {
             if (field.ReadOnly)
                 continue;
@@ -1957,9 +2082,11 @@ public static class DataScaffold
         if (!effectiveType.IsEnum)
             return Array.Empty<KeyValuePair<string, string>>();
 
-        return Enum.GetNames(effectiveType)
-            .Select(name => new KeyValuePair<string, string>(name, DeCamelcaseWithId(name)))
-            .ToArray();
+        var names = Enum.GetNames(effectiveType);
+        var result = new KeyValuePair<string, string>[names.Length];
+        for (int i = 0; i < names.Length; i++)
+            result[i] = new KeyValuePair<string, string>(names[i], DeCamelcaseWithId(names[i]));
+        return result;
     }
 
     private static IReadOnlyList<KeyValuePair<string, string>> GetLookupOptions(DataLookupConfig lookup)
@@ -2134,7 +2261,13 @@ public static class DataScaffold
                 var q = new QueryDefinition();
                 q.Clauses.Add(new QueryClause { Field = lookup.ValueField, Operator = QueryOperator.Equals, Value = currentValue });
                 q.Top = 1;
-                entity = QueryByType(lookup.TargetType, q, lookup.TargetSlug).Cast<object>().FirstOrDefault();
+                object? firstResult = null;
+                foreach (var item in QueryByType(lookup.TargetType, q, lookup.TargetSlug))
+                {
+                    firstResult = item;
+                    break;
+                }
+                entity = firstResult;
             }
 
             if (entity == null)
@@ -2362,9 +2495,10 @@ public static class DataScaffold
     private static IReadOnlyList<ChildFieldMeta> GetChildFieldMetadataSimple([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type childType)
     {
         var fields = new List<ChildFieldMeta>();
-        var properties = childType.GetProperties(BindingFlags.Public | BindingFlags.Instance)
-            .OrderBy(p => p.MetadataToken)
-            .ToArray();
+        var unsortedProps = childType.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+        var propsList = new List<System.Reflection.PropertyInfo>(unsortedProps);
+        propsList.Sort((a, b) => a.MetadataToken.CompareTo(b.MetadataToken));
+        var properties = propsList.ToArray();
 
         foreach (var prop in properties)
         {
@@ -2396,9 +2530,10 @@ public static class DataScaffold
     private static IReadOnlyList<ChildFieldMeta> GetChildFieldMetadata([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type childType)
     {
         var fields = new List<ChildFieldMeta>();
-        var properties = childType.GetProperties(BindingFlags.Public | BindingFlags.Instance)
-            .OrderBy(p => p.MetadataToken)
-            .ToArray();
+        var unsortedProps2 = childType.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+        var propsList2 = new List<System.Reflection.PropertyInfo>(unsortedProps2);
+        propsList2.Sort((a, b) => a.MetadataToken.CompareTo(b.MetadataToken));
+        var properties = propsList2.ToArray();
 
         foreach (var prop in properties)
         {
@@ -2710,8 +2845,10 @@ public static class DataScaffold
         sb.Append("var tbody=table.querySelector('tbody');" );
         sb.Append("var lookupMaps=");
         var lookupMaps = new Dictionary<string, Dictionary<string, string>>(StringComparer.OrdinalIgnoreCase);
-        foreach (var child in childFields.Where(child => child.LookupOptions != null))
+        foreach (var child in childFields)
         {
+            if (child.LookupOptions == null)
+                continue;
             var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             foreach (var option in child.LookupOptions!)
             {
@@ -2753,7 +2890,12 @@ public static class DataScaffold
         sb.Append("recalcModal();");
 
         // CopyFromParent: for new rows, look up parent-form entity and pre-fill this field
-        var copyFromParentFields = childFields.Where(c => c.CopyFromParentField != null).ToList();
+        var copyFromParentFields = new List<ChildFieldMeta>();
+        foreach (var c in childFields)
+        {
+            if (c.CopyFromParentField != null)
+                copyFromParentFields.Add(c);
+        }
         if (copyFromParentFields.Count > 0)
         {
             sb.Append("if(idx===null){");
@@ -2815,7 +2957,9 @@ public static class DataScaffold
                     var displayText = ToDisplayString(value, child.FieldType);
                     if (child.LookupOptions != null)
                     {
-                        var map = child.LookupOptions.ToDictionary(k => k.Key, v => v.Value, StringComparer.OrdinalIgnoreCase);
+                        var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                        foreach (var opt in child.LookupOptions)
+                            map[opt.Key] = opt.Value;
                         var key = value?.ToString() ?? string.Empty;
                         displayText = map.TryGetValue(key, out var resolved) ? resolved : key;
                     }
@@ -3425,9 +3569,12 @@ public static class DataScaffold
         try
         {
             var typedList = (IList)Activator.CreateInstance(listType)!;
-            var props = childType.GetProperties(BindingFlags.Public | BindingFlags.Instance)
-                .Where(p => p.CanRead && p.CanWrite)
-                .ToDictionary(p => p.Name, p => p, StringComparer.OrdinalIgnoreCase);
+            var props = new Dictionary<string, System.Reflection.PropertyInfo>(StringComparer.OrdinalIgnoreCase);
+            foreach (var p in childType.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            {
+                if (p.CanRead && p.CanWrite)
+                    props[p.Name] = p;
+            }
 
             foreach (var row in element.EnumerateArray())
             {
@@ -3499,9 +3646,10 @@ public static class DataScaffold
             return null;
 
         var fields = new List<DataFieldMetadata>();
-        var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
-            .OrderBy(p => p.MetadataToken)
-            .ToArray();
+        var unsortedProps = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+        var propsList = new List<System.Reflection.PropertyInfo>(unsortedProps);
+        propsList.Sort((a, b) => a.MetadataToken.CompareTo(b.MetadataToken));
+        var properties = propsList.ToArray();
         for (int i = 0; i < properties.Length; i++)
         {
             var prop = properties[i];
@@ -3692,6 +3840,15 @@ public static class DataScaffold
             ));
         }
 
+        fields.Sort((a, b) => a.Order.CompareTo(b.Order));
+        commands.Sort((a, b) => a.Order.CompareTo(b.Order));
+        var docRelFields = new List<DataFieldMetadata>();
+        foreach (var f in fields)
+        {
+            if (f.RelatedDocument != null)
+                docRelFields.Add(f);
+        }
+
         return new DataEntityMetadata(
             type,
             name,
@@ -3703,12 +3860,12 @@ public static class DataScaffold
             idGeneration,
             viewType,
             parentField,
-            fields.OrderBy(f => f.Order).ToList(),
+            fields,
             handlers,
-            commands.OrderBy(c => c.Order).ToList(),
+            commands,
             defaultSortField,
             defaultSortDirection,
-            fields.Where(f => f.RelatedDocument != null).ToList()
+            docRelFields
         );
     }
 
@@ -3848,7 +4005,10 @@ public static class DataScaffold
     private static async ValueTask<IEnumerable<BaseDataObject>> QueryTypedAsync<T>(QueryDefinition? query, CancellationToken cancellationToken) where T : BaseDataObject
     {
         var results = await DataStoreProvider.Current.QueryAsync<T>(query, cancellationToken);
-        return results.Cast<BaseDataObject>().ToList();
+        var list = new List<BaseDataObject>();
+        foreach (var item in results)
+            list.Add(item);
+        return list;
     }
 
     private static async ValueTask<int> CountTypedAsync<T>(QueryDefinition? query, CancellationToken cancellationToken) where T : BaseDataObject

--- a/BareMetalWeb.Data/DomainEventDispatcher.cs
+++ b/BareMetalWeb.Data/DomainEventDispatcher.cs
@@ -240,8 +240,15 @@ public static class DomainEventDispatcher
 
     private static string GetField(BaseDataObject obj, DataEntityMetadata meta, string fieldName)
     {
-        var field = meta.Fields.FirstOrDefault(f =>
-            string.Equals(f.Name, fieldName, StringComparison.OrdinalIgnoreCase));
+        DataFieldMetadata? field = null;
+        foreach (var f in meta.Fields)
+        {
+            if (string.Equals(f.Name, fieldName, StringComparison.OrdinalIgnoreCase))
+            {
+                field = f;
+                break;
+            }
+        }
         return field?.GetValueFn?.Invoke(obj)?.ToString() ?? string.Empty;
     }
 

--- a/BareMetalWeb.Data/EntityLayoutCompiler.cs
+++ b/BareMetalWeb.Data/EntityLayoutCompiler.cs
@@ -44,18 +44,33 @@ public static class EntityLayoutCompiler
     public static EntityLayout Compile(DataEntityMetadata meta, out IReadOnlyList<string> warnings)
     {
         var warns = new List<string>();
-        var metaFieldsByName = meta.Fields.ToDictionary(f => f.Name, StringComparer.Ordinal);
+        var metaFieldsByName = new Dictionary<string, DataFieldMetadata>(StringComparer.Ordinal);
+        foreach (var f in meta.Fields)
+            metaFieldsByName[f.Name] = f;
 
-        var props = meta.Type
-            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
-            .Where(p => p.CanRead && p.CanWrite)
-            .OrderBy(p => p.Name, StringComparer.Ordinal)
-            .ToArray();
+        var allProps = meta.Type
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance);
+        var propList = new List<PropertyInfo>();
+        foreach (var p in allProps)
+        {
+            if (p.CanRead && p.CanWrite)
+                propList.Add(p);
+        }
+        propList.Sort((a, b) => StringComparer.Ordinal.Compare(a.Name, b.Name));
+        var props = propList.ToArray();
 
         if (props.Length == 0)
             warns.Add($"Entity '{meta.Name}' has no public read/write properties.");
 
-        bool hasKey = props.Any(p => p.Name == "Key" && p.PropertyType == typeof(uint));
+        bool hasKey = false;
+        foreach (var p in props)
+        {
+            if (p.Name == "Key" && p.PropertyType == typeof(uint))
+            {
+                hasKey = true;
+                break;
+            }
+        }
         if (!hasKey)
             warns.Add($"Entity '{meta.Name}' is missing a uint Key property.");
 

--- a/BareMetalWeb.Data/ExpressionEngine/CalculatedFieldService.cs
+++ b/BareMetalWeb.Data/ExpressionEngine/CalculatedFieldService.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using BareMetalWeb.Core;
@@ -41,7 +40,14 @@ public static class CalculatedFieldService
         // Evict half the cache when it exceeds the max size
         if (_compiledExpressions.Count >= MaxExpressionCacheSize)
         {
-            var keysToRemove = _compiledExpressions.Keys.Take(MaxExpressionCacheSize / 2).ToArray();
+            int count = 0;
+            int target = MaxExpressionCacheSize / 2;
+            var keysToRemove = new List<string>(target);
+            foreach (var key in _compiledExpressions.Keys)
+            {
+                keysToRemove.Add(key);
+                if (++count >= target) break;
+            }
             foreach (var key in keysToRemove)
                 _compiledExpressions.TryRemove(key, out _);
         }

--- a/BareMetalWeb.Data/ExpressionEngine/ExpressionNode.cs
+++ b/BareMetalWeb.Data/ExpressionEngine/ExpressionNode.cs
@@ -297,7 +297,13 @@ public sealed class FunctionNode : ExpressionNode
 
     public override string ToJavaScript()
     {
-        var args = string.Join(", ", System.Linq.Enumerable.Select(Arguments, a => a.ToJavaScript()));
+        var argsSb = new System.Text.StringBuilder();
+        for (int i = 0; i < Arguments.Count; i++)
+        {
+            if (i > 0) argsSb.Append(", ");
+            argsSb.Append(Arguments[i].ToJavaScript());
+        }
+        var args = argsSb.ToString();
 
         return FunctionName.ToLowerInvariant() switch
         {
@@ -313,15 +319,20 @@ public sealed class FunctionNode : ExpressionNode
         };
     }
 
-    public override Dictionary<string, object?> ToJsonAst() =>
-        new()
+    public override Dictionary<string, object?> ToJsonAst()
+    {
+        var argsArray = new Dictionary<string, object?>[Arguments.Count];
+        for (int i = 0; i < Arguments.Count; i++)
+            argsArray[i] = Arguments[i].ToJsonAst();
+        return new()
         {
             ["t"] = "fn",
             // Function name is lowercased so the client-side tree-walker can switch on
             // lowercase strings regardless of how the author capitalised the expression.
             ["fn"] = FunctionName.ToLowerInvariant(),
-            ["args"] = System.Linq.Enumerable.Select(Arguments, a => a.ToJsonAst()).ToArray()
+            ["args"] = argsArray
         };
+    }
 
     private object? EvaluateRound(IReadOnlyDictionary<string, object?> context)
     {
@@ -347,7 +358,12 @@ public sealed class FunctionNode : ExpressionNode
             values.Add(ConvertToDecimal(arg.Evaluate(context)));
         }
 
-        return values.Min();
+        decimal minVal = values[0];
+        for (int i = 1; i < values.Count; i++)
+        {
+            if (values[i] < minVal) minVal = values[i];
+        }
+        return minVal;
     }
 
     private object? EvaluateMax(IReadOnlyDictionary<string, object?> context)
@@ -361,7 +377,12 @@ public sealed class FunctionNode : ExpressionNode
             values.Add(ConvertToDecimal(arg.Evaluate(context)));
         }
 
-        return values.Max();
+        decimal maxVal = values[0];
+        for (int i = 1; i < values.Count; i++)
+        {
+            if (values[i] > maxVal) maxVal = values[i];
+        }
+        return maxVal;
     }
 
     private object? EvaluateAbs(IReadOnlyDictionary<string, object?> context)
@@ -548,6 +569,11 @@ public sealed class DotAccessNode : ExpressionNode
         return $"await bmwRelatedLookup('{LookupField}', '{Path[0]}')";
     }
 
-    public override Dictionary<string, object?> ToJsonAst() =>
-        new() { ["t"] = "dot", ["fk"] = LookupField, ["path"] = Path.ToArray() };
+    public override Dictionary<string, object?> ToJsonAst()
+    {
+        var pathArray = new string[Path.Count];
+        for (int i = 0; i < Path.Count; i++)
+            pathArray[i] = Path[i];
+        return new() { ["t"] = "dot", ["fk"] = LookupField, ["path"] = pathArray };
+    }
 }

--- a/BareMetalWeb.Data/ExpressionEngine/ServerLookupResolver.cs
+++ b/BareMetalWeb.Data/ExpressionEngine/ServerLookupResolver.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -36,8 +35,15 @@ public sealed class ServerLookupResolver : ILookupResolver
 
         if (!string.IsNullOrEmpty(currentEntitySlug) && DataScaffold.TryGetEntity(currentEntitySlug, out var currentMeta))
         {
-            var fkFieldMeta = currentMeta!.Fields.FirstOrDefault(f =>
-                string.Equals(f.Name, foreignKeyField, StringComparison.OrdinalIgnoreCase));
+            DataFieldMetadata? fkFieldMeta = null;
+            foreach (var f in currentMeta!.Fields)
+            {
+                if (string.Equals(f.Name, foreignKeyField, StringComparison.OrdinalIgnoreCase))
+                {
+                    fkFieldMeta = f;
+                    break;
+                }
+            }
 
             if (fkFieldMeta?.Lookup != null)
             {
@@ -111,8 +117,15 @@ public sealed class ServerLookupResolver : ILookupResolver
         DataEntityMetadata? currentMeta = null;
         if (!string.IsNullOrEmpty(startEntitySlug) && DataScaffold.TryGetEntity(startEntitySlug, out var startMeta))
         {
-            var firstFkFieldMeta = startMeta!.Fields.FirstOrDefault(f =>
-                string.Equals(f.Name, firstFkField, StringComparison.OrdinalIgnoreCase));
+            DataFieldMetadata? firstFkFieldMeta = null;
+            foreach (var f in startMeta!.Fields)
+            {
+                if (string.Equals(f.Name, firstFkField, StringComparison.OrdinalIgnoreCase))
+                {
+                    firstFkFieldMeta = f;
+                    break;
+                }
+            }
             if (firstFkFieldMeta?.Lookup != null)
                 currentMeta = DataScaffold.GetEntityByType(firstFkFieldMeta.Lookup.TargetType);
         }
@@ -137,10 +150,17 @@ public sealed class ServerLookupResolver : ILookupResolver
                 return null;
 
             DataEntityMetadata? nextMeta = null;
-            var lookupAttr = currentEntity.GetType()
-                .GetProperties(BindingFlags.Public | BindingFlags.Instance)
-                .FirstOrDefault(p => string.Equals(p.Name, nextFkField, StringComparison.OrdinalIgnoreCase))
-                ?.GetCustomAttribute<DataLookupAttribute>();
+            PropertyInfo? lookupProp = null;
+            foreach (var p in currentEntity.GetType()
+                .GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            {
+                if (string.Equals(p.Name, nextFkField, StringComparison.OrdinalIgnoreCase))
+                {
+                    lookupProp = p;
+                    break;
+                }
+            }
+            var lookupAttr = lookupProp?.GetCustomAttribute<DataLookupAttribute>();
             if (lookupAttr != null)
                 nextMeta = DataScaffold.GetEntityByType(lookupAttr.TargetType);
 

--- a/BareMetalWeb.Data/LocalFolderBinaryDataProvider.cs
+++ b/BareMetalWeb.Data/LocalFolderBinaryDataProvider.cs
@@ -4,7 +4,7 @@ using System.Buffers.Binary;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
+
 using System.Reflection;
 using System.Text.Json;
 using System.Threading;
@@ -404,7 +404,16 @@ public sealed class LocalFolderBinaryDataProvider : IDataProvider
 
             if (existing == null)
             {
-                schemaVersion = cache.Versions.Count == 0 ? 1 : cache.Versions.Keys.Max() + 1;
+                schemaVersion = 1;
+                if (cache.Versions.Count > 0)
+                {
+                    var maxKey = int.MinValue;
+                    foreach (var k in cache.Versions.Keys)
+                    {
+                        if (k > maxKey) maxKey = k;
+                    }
+                    schemaVersion = maxKey + 1;
+                }
                 var schemaFile = BuildSchemaFile(currentSchema, schemaVersion);
                 cache.Versions[schemaVersion] = schemaFile;
                 cache.HashToVersion[currentSchema.Hash] = schemaVersion;
@@ -498,12 +507,18 @@ public sealed class LocalFolderBinaryDataProvider : IDataProvider
     private void ClearSingletonFlagsOnOtherRecords<T>(T obj) where T : BaseDataObject
     {
         var type = typeof(T);
-        var singletonProps = type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
-            .Where(p => p.PropertyType == typeof(bool)
-                        && p.GetCustomAttribute<SingletonFlagAttribute>() != null
-                        && p.CanRead && p.CanWrite
-                        && true.Equals(p.GetValue(obj)))
-            .ToList();
+        var allProps = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+        var singletonProps = new List<PropertyInfo>();
+        foreach (var p in allProps)
+        {
+            if (p.PropertyType == typeof(bool)
+                && p.GetCustomAttribute<SingletonFlagAttribute>() != null
+                && p.CanRead && p.CanWrite
+                && true.Equals(p.GetValue(obj)))
+            {
+                singletonProps.Add(p);
+            }
+        }
 
         if (singletonProps.Count == 0)
             return;
@@ -638,11 +653,24 @@ public sealed class LocalFolderBinaryDataProvider : IDataProvider
                             return Array.Empty<T>();
                         }
 
-                        var filtered = candidates.Where(item => _queryEvaluator.Matches(item, query));
+                        var filtered = new List<T>();
+                        foreach (var item in candidates)
+                        {
+                            if (_queryEvaluator.Matches(item, query))
+                                filtered.Add(item);
+                        }
                         var sorted = _queryEvaluator.ApplySorts(filtered, query);
-                        if (skip > 0 || top != int.MaxValue)
-                            sorted = sorted.Skip(skip).Take(top);
-                        return sorted.ToList();
+                        var resultList = new List<T>();
+                        var skipped = 0;
+                        var taken = 0;
+                        foreach (var item in sorted)
+                        {
+                            if (skipped < skip) { skipped++; continue; }
+                            resultList.Add(item);
+                            taken++;
+                            if (taken >= top) break;
+                        }
+                        return resultList;
                     }
                 }
             }
@@ -736,11 +764,24 @@ public sealed class LocalFolderBinaryDataProvider : IDataProvider
             }
         }
 
-        var filteredAll = all.Where(item => _queryEvaluator.Matches(item, query));
+        var filteredAll = new List<T>();
+        foreach (var item in all)
+        {
+            if (_queryEvaluator.Matches(item, query))
+                filteredAll.Add(item);
+        }
         var sortedAll = _queryEvaluator.ApplySorts(filteredAll, query);
-        if (skip > 0 || top != int.MaxValue)
-            sortedAll = sortedAll.Skip(skip).Take(top);
-        return sortedAll.ToList();
+        var resultAll = new List<T>();
+        var skippedAll = 0;
+        var takenAll = 0;
+        foreach (var item in sortedAll)
+        {
+            if (skippedAll < skip) { skippedAll++; continue; }
+            resultAll.Add(item);
+            takenAll++;
+            if (takenAll >= top) break;
+        }
+        return resultAll;
     }
 
     public ValueTask<IEnumerable<T>> QueryAsync<T>(QueryDefinition? query = null, CancellationToken cancellationToken = default) where T : BaseDataObject
@@ -1057,7 +1098,14 @@ public sealed class LocalFolderBinaryDataProvider : IDataProvider
         }
 
         if (cache.Versions.Count > 0)
-            cache.CurrentVersion = cache.Versions.Keys.Max();
+        {
+            var maxVer = int.MinValue;
+            foreach (var k in cache.Versions.Keys)
+            {
+                if (k > maxVer) maxVer = k;
+            }
+            cache.CurrentVersion = maxVer;
+        }
 
         return cache;
     }
@@ -1111,15 +1159,20 @@ public sealed class LocalFolderBinaryDataProvider : IDataProvider
     }
 
     private static SchemaDefinitionFile BuildSchemaFile(SchemaDefinition schema, int version)
-        => new SchemaDefinitionFile
+    {
+        var members = new List<MemberSignatureFile>(schema.Members.Length);
+        foreach (var m in schema.Members)
+        {
+            members.Add(new MemberSignatureFile { Name = m.Name, TypeName = m.TypeName, BlittableSize = m.BlittableSize });
+        }
+        return new SchemaDefinitionFile
         {
             Version = version,
             Hash = schema.Hash,
             Architecture = schema.Architecture.ToString(),
-            Members = schema.Members
-                .Select(m => new MemberSignatureFile { Name = m.Name, TypeName = m.TypeName, BlittableSize = m.BlittableSize })
-                .ToList()
+            Members = members
         };
+    }
 
     private static bool TryParseSchemaVersion(Type type, string fileName, out int version)
     {
@@ -1149,9 +1202,16 @@ public sealed class LocalFolderBinaryDataProvider : IDataProvider
 
     private MemberSignature[] GetCachedSchemaMembers(Type type, SchemaDefinitionFile schemaFile)
         => _schemaMemberCache.GetOrAdd((type, schemaFile.Version), _ =>
-            schemaFile.Members
-                .Select(m => new MemberSignature(m.Name, m.TypeName, AssumePublicMembers(_serializer.ResolveTypeName(m.TypeName)), m.BlittableSize))
-                .ToArray());
+        {
+            var members = schemaFile.Members;
+            var result = new MemberSignature[members.Count];
+            for (var i = 0; i < members.Count; i++)
+            {
+                var m = members[i];
+                result[i] = new MemberSignature(m.Name, m.TypeName, AssumePublicMembers(_serializer.ResolveTypeName(m.TypeName)), m.BlittableSize);
+            }
+            return result;
+        });
 
     private static SchemaDefinition BuildSchemaFor(ISchemaAwareObjectSerializer serializer, Type type)
         => serializer.BuildSchema(type);

--- a/BareMetalWeb.Data/ModuleRegistry.cs
+++ b/BareMetalWeb.Data/ModuleRegistry.cs
@@ -64,8 +64,24 @@ public static class ModuleRegistry
         if (modules.Count == 0) return true;
 
         // Find owning module
-        var owner = modules.FirstOrDefault(m =>
-            m.EntitySlugs.Contains(entitySlug, StringComparer.OrdinalIgnoreCase));
+        ModuleInfo? owner = null;
+        foreach (var m in modules)
+        {
+            bool found = false;
+            foreach (var slug in m.EntitySlugs)
+            {
+                if (StringComparer.OrdinalIgnoreCase.Equals(slug, entitySlug))
+                {
+                    found = true;
+                    break;
+                }
+            }
+            if (found)
+            {
+                owner = m;
+                break;
+            }
+        }
 
         // Unowned entities are always enabled
         if (owner == null) return true;
@@ -91,8 +107,11 @@ public static class ModuleRegistry
         }
 
         // Check isolated modules don't reference external entities
-        foreach (var mod in modules.Where(m => string.Equals(m.Isolation, "isolated", StringComparison.OrdinalIgnoreCase)))
+        foreach (var mod in modules)
         {
+            if (!string.Equals(mod.Isolation, "isolated", StringComparison.OrdinalIgnoreCase))
+                continue;
+
             foreach (var slug in mod.EntitySlugs)
             {
                 if (!DataScaffold.TryGetEntity(slug, out var meta)) continue;
@@ -101,8 +120,15 @@ public static class ModuleRegistry
                 {
                     if (field.Lookup == null) continue;
                     // Resolve target entity slug from lookup type
-                    var lookupSlug = DataScaffold.Entities
-                        .FirstOrDefault(e => e.Type == field.Lookup.TargetType)?.Slug;
+                    string? lookupSlug = null;
+                    foreach (var e in DataScaffold.Entities)
+                    {
+                        if (e.Type == field.Lookup.TargetType)
+                        {
+                            lookupSlug = e.Slug;
+                            break;
+                        }
+                    }
                     if (string.IsNullOrEmpty(lookupSlug)) continue;
 
                     if (entityOwner.TryGetValue(lookupSlug, out var targetModule) &&
@@ -117,12 +143,22 @@ public static class ModuleRegistry
         }
 
         // Check dependencies are satisfied
-        foreach (var mod in modules.Where(m => m.Enabled))
+        foreach (var mod in modules)
         {
+            if (!mod.Enabled)
+                continue;
+
             foreach (var dep in mod.Dependencies)
             {
-                var depMod = modules.FirstOrDefault(m =>
-                    string.Equals(m.ModuleId, dep, StringComparison.OrdinalIgnoreCase));
+                ModuleInfo? depMod = null;
+                foreach (var m in modules)
+                {
+                    if (string.Equals(m.ModuleId, dep, StringComparison.OrdinalIgnoreCase))
+                    {
+                        depMod = m;
+                        break;
+                    }
+                }
 
                 if (depMod == null)
                     violations.Add($"Missing dependency: {mod.ModuleId} requires {dep} (not found)");
@@ -141,19 +177,28 @@ public static class ModuleRegistry
     public static async ValueTask<ModulePackage> ExportAsync(string moduleId, CancellationToken ct)
     {
         var modules = await GetModulesAsync(ct);
-        var mod = modules.FirstOrDefault(m =>
-            string.Equals(m.ModuleId, moduleId, StringComparison.OrdinalIgnoreCase))
-            ?? throw new InvalidOperationException($"Module '{moduleId}' not found.");
+        ModuleInfo? mod = null;
+        foreach (var m in modules)
+        {
+            if (string.Equals(m.ModuleId, moduleId, StringComparison.OrdinalIgnoreCase))
+            {
+                mod = m;
+                break;
+            }
+        }
+        if (mod == null) throw new InvalidOperationException($"Module '{moduleId}' not found.");
 
         var schemas = new List<ModuleEntitySchema>();
         foreach (var slug in mod.EntitySlugs)
         {
             if (!DataScaffold.TryGetEntity(slug, out var meta)) continue;
+            var fieldSchemas = new List<ModuleFieldSchema>();
+            foreach (var f in meta.Fields)
+                fieldSchemas.Add(new ModuleFieldSchema(f.Name, f.Label, f.FieldType.ToString(), f.Required, f.IsIndexed));
             schemas.Add(new ModuleEntitySchema(
                 Slug: slug,
                 EntityName: meta.Name,
-                Fields: meta.Fields.Select(f => new ModuleFieldSchema(
-                    f.Name, f.Label, f.FieldType.ToString(), f.Required, f.IsIndexed)).ToList()));
+                Fields: fieldSchemas));
         }
 
         return new ModulePackage(
@@ -169,8 +214,15 @@ public static class ModuleRegistry
 
     private static string GetField(BaseDataObject obj, DataEntityMetadata meta, string fieldName)
     {
-        var field = meta.Fields.FirstOrDefault(f =>
-            string.Equals(f.Name, fieldName, StringComparison.OrdinalIgnoreCase));
+        DataFieldMetadata? field = null;
+        foreach (var f in meta.Fields)
+        {
+            if (string.Equals(f.Name, fieldName, StringComparison.OrdinalIgnoreCase))
+            {
+                field = f;
+                break;
+            }
+        }
         return field?.GetValueFn?.Invoke(obj)?.ToString() ?? string.Empty;
     }
 

--- a/BareMetalWeb.Data/PermissionResolver.cs
+++ b/BareMetalWeb.Data/PermissionResolver.cs
@@ -93,8 +93,7 @@ public static class PermissionResolver
             var user = await DataScaffold.LoadAsync(userMeta, principalKey, ct) as BaseDataObject;
             if (user != null)
             {
-                var permsField = userMeta.Fields.FirstOrDefault(f =>
-                    string.Equals(f.Name, "Permissions", StringComparison.OrdinalIgnoreCase));
+                var permsField = FindFieldByName(userMeta.Fields, "Permissions");
                 if (permsField?.GetValueFn != null)
                 {
                     var rawPerms = permsField.GetValueFn(user);
@@ -190,7 +189,10 @@ public static class PermissionResolver
             return Array.Empty<BaseDataObject>();
 
         var items = await meta.Handlers.QueryAsync(null, ct);
-        return items.ToList();
+        var list = new List<BaseDataObject>();
+        foreach (var item in items)
+            list.Add(item);
+        return list;
     }
 
     private static readonly ConcurrentDictionary<string, Func<object, object?>?> _getterCache = new();
@@ -201,8 +203,7 @@ public static class PermissionResolver
         var getter = _getterCache.GetOrAdd(key, _ =>
         {
             if (!DataScaffold.TryGetEntity(entitySlug, out var meta)) return null;
-            var field = meta.Fields.FirstOrDefault(f =>
-                string.Equals(f.Name, fieldName, StringComparison.OrdinalIgnoreCase));
+            var field = FindFieldByName(meta.Fields, fieldName);
             return field?.GetValueFn;
         });
         return getter?.Invoke(obj)?.ToString() ?? string.Empty;
@@ -219,6 +220,16 @@ public static class PermissionResolver
         if (string.IsNullOrWhiteSpace(value)) yield break;
         foreach (var part in value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
             yield return part;
+    }
+
+    private static DataFieldMetadata? FindFieldByName(IReadOnlyList<DataFieldMetadata> fields, string name)
+    {
+        foreach (var f in fields)
+        {
+            if (string.Equals(f.Name, name, StringComparison.OrdinalIgnoreCase))
+                return f;
+        }
+        return null;
     }
 }
 

--- a/BareMetalWeb.Data/PropertyAccessorFactory.cs
+++ b/BareMetalWeb.Data/PropertyAccessorFactory.cs
@@ -12,10 +12,15 @@ file static class IsExternalInitDetector
 {
     private const string ModreqFullName = "System.Runtime.CompilerServices.IsExternalInit";
 
-    internal static bool IsInitOnlySetter(MethodInfo setter) =>
-        setter.ReturnParameter
-              .GetRequiredCustomModifiers()
-              .Any(t => t.FullName == ModreqFullName);
+    internal static bool IsInitOnlySetter(MethodInfo setter)
+    {
+        foreach (var t in setter.ReturnParameter.GetRequiredCustomModifiers())
+        {
+            if (t.FullName == ModreqFullName)
+                return true;
+        }
+        return false;
+    }
 }
 
 /// <summary>

--- a/BareMetalWeb.Data/QueryPlanner.cs
+++ b/BareMetalWeb.Data/QueryPlanner.cs
@@ -65,10 +65,10 @@ public sealed class QueryPlanner
             JoinInfo: null));
 
         // 3. Reorder joins by estimated cardinality of the TO entity (smallest first)
-        var orderedJoins = query.Joins
-            .Select(j => (Join: j, Estimate: EstimateCardinality(j.ToEntity)))
-            .OrderBy(x => x.Estimate)
-            .ToList();
+        var orderedJoins = new List<(ReportJoin Join, int Estimate)>();
+        foreach (var j in query.Joins)
+            orderedJoins.Add((j, EstimateCardinality(j.ToEntity)));
+        orderedJoins.Sort((a, b) => a.Estimate.CompareTo(b.Estimate));
 
         foreach (var (join, estimate) in orderedJoins)
         {
@@ -111,14 +111,42 @@ public sealed class QueryPlanner
         }
 
         // 4. Determine aggregate streaming eligibility
-        var canStreamAggregate = query.Columns.Any(c =>
-            c.Aggregate != AggregateFunction.None) && query.Joins.Count == 0;
+        bool canStreamAggregate = false;
+        if (query.Joins.Count == 0)
+        {
+            foreach (var c in query.Columns)
+            {
+                if (c.Aggregate != AggregateFunction.None)
+                {
+                    canStreamAggregate = true;
+                    break;
+                }
+            }
+        }
 
         // 5. Post-join filter step (filters referencing cross-entity computed fields)
-        var hasPostJoinFilters = query.Filters.Any(f =>
-            !string.IsNullOrEmpty(f.Entity) &&
-            !string.Equals(f.Entity, query.RootEntity, StringComparison.OrdinalIgnoreCase) &&
-            query.Joins.All(j => !string.Equals(j.ToEntity, f.Entity, StringComparison.OrdinalIgnoreCase)));
+        bool hasPostJoinFilters = false;
+        foreach (var f in query.Filters)
+        {
+            if (string.IsNullOrEmpty(f.Entity) ||
+                string.Equals(f.Entity, query.RootEntity, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            bool referencesJoin = false;
+            foreach (var j in query.Joins)
+            {
+                if (string.Equals(j.ToEntity, f.Entity, StringComparison.OrdinalIgnoreCase))
+                {
+                    referencesJoin = true;
+                    break;
+                }
+            }
+            if (!referencesJoin)
+            {
+                hasPostJoinFilters = true;
+                break;
+            }
+        }
 
         if (hasPostJoinFilters)
         {
@@ -197,8 +225,12 @@ public sealed class QueryPlanner
         if (!DataScaffold.TryGetEntity(entitySlug, out var meta))
             return false;
 
-        return meta.Fields.Any(f =>
-            string.Equals(f.Name, fieldName, StringComparison.OrdinalIgnoreCase) && f.IsIndexed);
+        foreach (var f in meta.Fields)
+        {
+            if (string.Equals(f.Name, fieldName, StringComparison.OrdinalIgnoreCase) && f.IsIndexed)
+                return true;
+        }
+        return false;
     }
 
     private static QueryOperator MapOperator(string op)

--- a/BareMetalWeb.Data/ReportExecutor.cs
+++ b/BareMetalWeb.Data/ReportExecutor.cs
@@ -40,14 +40,21 @@ public sealed class ReportExecutor
 
         var query = new ReportQuery().From(definition.RootEntity ?? string.Empty);
 
-        foreach (var join in definition.Joins ?? Enumerable.Empty<ReportJoin>())
-            query.Join(join.FromEntity, join.FromField, join.ToEntity, join.ToField);
+        if (definition.Joins != null)
+        {
+            foreach (var join in definition.Joins)
+                query.Join(join.FromEntity, join.FromField, join.ToEntity, join.ToField);
+        }
 
-        foreach (var col in definition.Columns ?? Enumerable.Empty<ReportColumn>())
-            query.SelectColumn(col.Entity, col.Field, col.Label, col.Format, col.Aggregate);
+        if (definition.Columns != null)
+        {
+            foreach (var col in definition.Columns)
+                query.SelectColumn(col.Entity, col.Field, col.Label, col.Format, col.Aggregate);
+        }
 
         // Apply stored filters, substituting runtime parameters
-        foreach (var filter in definition.Filters ?? Enumerable.Empty<ReportFilter>())
+        if (definition.Filters == null) { /* no filters */ }
+        else foreach (var filter in definition.Filters)
         {
             var value = SubstituteParameter(filter.Value, runtimeParameters);
             query.Where($"{filter.Entity}.{filter.Field}", filter.Operator, value);
@@ -80,16 +87,23 @@ public sealed class ReportExecutor
 
         // Load root entity rows with pushed-down filters
         plan.PushedFilters.TryGetValue(rootSlug, out var rootPushedFilter);
-        var rootRows = (await rootMeta.Handlers.QueryAsync(rootPushedFilter, cancellationToken))
-            .Take(MaxEntityLoadSize).ToList();
+        var rootRowsRaw = await rootMeta.Handlers.QueryAsync(rootPushedFilter, cancellationToken);
+        var rootRows = new List<BaseDataObject>();
+        foreach (var r in rootRowsRaw)
+        {
+            if (rootRows.Count >= MaxEntityLoadSize) break;
+            rootRows.Add(r);
+        }
 
         // Start: each combined row is a dict of entitySlug -> BaseDataObject
-        var combined = rootRows
-            .Select(r => new Dictionary<string, BaseDataObject>(StringComparer.OrdinalIgnoreCase)
+        var combined = new List<Dictionary<string, BaseDataObject>>(rootRows.Count);
+        foreach (var r in rootRows)
+        {
+            combined.Add(new Dictionary<string, BaseDataObject>(StringComparer.OrdinalIgnoreCase)
             {
                 [rootSlug] = r
-            })
-            .ToList();
+            });
+        }
 
         // Process joins (INNER JOIN semantics)
         foreach (var join in query.Joins)
@@ -102,8 +116,13 @@ public sealed class ReportExecutor
 
             // Load join entity rows with pushed-down filters
             plan.PushedFilters.TryGetValue(join.ToEntity, out var joinPushedFilter);
-            var joinRows = (await joinMeta.Handlers.QueryAsync(joinPushedFilter, cancellationToken))
-                .Take(MaxEntityLoadSize).ToList();
+            var joinRowsRaw = await joinMeta.Handlers.QueryAsync(joinPushedFilter, cancellationToken);
+            var joinRows = new List<BaseDataObject>();
+            foreach (var r in joinRowsRaw)
+            {
+                if (joinRows.Count >= MaxEntityLoadSize) break;
+                joinRows.Add(r);
+            }
 
             // Build hash map: toField value -> list of matching join rows
             var toAccessor = FindAccessor(joinMeta, join.ToField);
@@ -199,34 +218,58 @@ public sealed class ReportExecutor
         // Apply filters
         var filters = query.Filters;
         if (filters.Count > 0)
-            combined = combined.Where(row => PassesFilters(row, filters)).ToList();
+        {
+            var filtered = new List<Dictionary<string, BaseDataObject>>(combined.Count);
+            foreach (var row in combined)
+            {
+                if (PassesFilters(row, filters))
+                    filtered.Add(row);
+            }
+            combined = filtered;
+        }
 
         // Resolve columns
         var columns = query.Columns;
         if (columns.Count == 0)
         {
             // Default: emit all root entity fields
-            columns = rootMeta.Fields
-                .Select(f => new ReportColumn
+            var defaultColumns = new List<ReportColumn>(rootMeta.Fields.Count);
+            foreach (var f in rootMeta.Fields)
+            {
+                defaultColumns.Add(new ReportColumn
                 {
                     Entity = rootSlug,
                     Field = f.Name,
                     Label = f.Label
-                })
-                .ToList();
+                });
+            }
+            columns = defaultColumns;
         }
 
-        var headers = columns
-            .Select(c => string.IsNullOrWhiteSpace(c.Label) ? $"{c.Entity}.{c.Field}" : c.Label)
-            .ToArray();
+        var headers = new string[columns.Count];
+        for (int i = 0; i < columns.Count; i++)
+        {
+            var c = columns[i];
+            headers[i] = string.IsNullOrWhiteSpace(c.Label) ? $"{c.Entity}.{c.Field}" : c.Label;
+        }
 
         // Project rows
-        var projected = combined
-            .Select(row => ProjectRow(row, columns))
-            .ToList();
+        var projected = new List<string?[]>(combined.Count);
+        foreach (var row in combined)
+        {
+            projected.Add(ProjectRow(row, columns));
+        }
 
         // Aggregation
-        bool hasAggregates = columns.Any(c => c.Aggregate != AggregateFunction.None);
+        bool hasAggregates = false;
+        foreach (var c in columns)
+        {
+            if (c.Aggregate != AggregateFunction.None)
+            {
+                hasAggregates = true;
+                break;
+            }
+        }
         if (hasAggregates)
             projected = AggregateRows(projected, columns);
 
@@ -237,9 +280,8 @@ public sealed class ReportExecutor
             var colIdx = FindColumnIndex(headers, sortField);
             if (colIdx >= 0)
             {
-                projected = query.SortDescending
-                    ? projected.OrderByDescending(r => r[colIdx], StringComparer.OrdinalIgnoreCase).ToList()
-                    : projected.OrderBy(r => r[colIdx], StringComparer.OrdinalIgnoreCase).ToList();
+                int sortDir = query.SortDescending ? -1 : 1;
+                projected.Sort((a, b) => sortDir * StringComparer.OrdinalIgnoreCase.Compare(a[colIdx], b[colIdx]));
             }
         }
 
@@ -274,8 +316,15 @@ public sealed class ReportExecutor
     private static PropertyInfo? FindAccessor(DataEntityMetadata meta, string fieldName)
     {
         // Check DataField metadata first
-        var field = meta.Fields.FirstOrDefault(f =>
-            string.Equals(f.Name, fieldName, StringComparison.OrdinalIgnoreCase));
+        DataFieldMetadata? field = null;
+        foreach (var f in meta.Fields)
+        {
+            if (string.Equals(f.Name, fieldName, StringComparison.OrdinalIgnoreCase))
+            {
+                field = f;
+                break;
+            }
+        }
         if (field != null)
             return field.Property;
 
@@ -402,23 +451,30 @@ public sealed class ReportExecutor
         IReadOnlyList<ReportColumn> columns)
     {
         // Group-by columns are those without an aggregate function
-        var groupByIndices = columns
-            .Select((c, i) => (c, i))
-            .Where(x => x.c.Aggregate == AggregateFunction.None)
-            .Select(x => x.i)
-            .ToArray();
+        var groupByList = new List<int>();
+        for (int i = 0; i < columns.Count; i++)
+        {
+            if (columns[i].Aggregate == AggregateFunction.None)
+                groupByList.Add(i);
+        }
+        var groupByIndices = groupByList.ToArray();
 
-        var aggIndices = columns
-            .Select((c, i) => (c, i))
-            .Where(x => x.c.Aggregate != AggregateFunction.None)
-            .Select(x => (x.c, x.i))
-            .ToArray();
+        var aggList = new List<(ReportColumn c, int i)>();
+        for (int i = 0; i < columns.Count; i++)
+        {
+            if (columns[i].Aggregate != AggregateFunction.None)
+                aggList.Add((columns[i], i));
+        }
+        var aggIndices = aggList.ToArray();
 
         // Group rows by group-by column values
         var groups = new Dictionary<string, List<string?[]>>(StringComparer.Ordinal);
         foreach (var row in rows)
         {
-            var key = string.Join("\x00", groupByIndices.Select(i => row[i] ?? string.Empty));
+            var keyParts = new string[groupByIndices.Length];
+            for (int gi = 0; gi < groupByIndices.Length; gi++)
+                keyParts[gi] = row[groupByIndices[gi]] ?? string.Empty;
+            var key = string.Join("\x00", keyParts);
             if (!groups.TryGetValue(key, out var group))
                 groups[key] = group = new List<string?[]>();
             group.Add(row);

--- a/BareMetalWeb.Data/SearchIndexing.cs
+++ b/BareMetalWeb.Data/SearchIndexing.cs
@@ -5,7 +5,7 @@ using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
+
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -603,7 +603,20 @@ public sealed class SearchIndexManager
         var metadata = GetOrCreateTypeMetadata(type);
         
         // Determine which index to use
-        var useKind = preferredKind ?? (metadata.IndexKinds.FirstOrDefault());
+        IndexKind useKind;
+        if (preferredKind.HasValue)
+        {
+            useKind = preferredKind.Value;
+        }
+        else
+        {
+            useKind = IndexKind.Inverted;
+            foreach (var k in metadata.IndexKinds)
+            {
+                useKind = k;
+                break;
+            }
+        }
         
         var results = new HashSet<uint>();
         lock (index.Sync)
@@ -842,7 +855,9 @@ public sealed class SearchIndexManager
         index.PrefixTree.Clear();
         
         // Load all objects once to avoid calling loadAll multiple times
-        var allObjects = loadAll().ToList();
+        var allObjects = new List<BaseDataObject>();
+        foreach (var obj in loadAll())
+            allObjects.Add(obj);
         if (allObjects.Count == 0)
             return;
         
@@ -1497,7 +1512,11 @@ public sealed class SearchIndexManager
         {
             if (index.GraphIndex == null) return Array.Empty<uint>();
             if (!index.GraphIndex.Forward.TryGetValue(nodeId, out var edges)) return Array.Empty<uint>();
-            return edges.Select(e => e.TargetId).ToArray();
+            var result = new uint[edges.Count];
+            int idx = 0;
+            foreach (var e in edges)
+                result[idx++] = e.TargetId;
+            return result;
         }
     }
 
@@ -1512,7 +1531,11 @@ public sealed class SearchIndexManager
         {
             if (index.GraphIndex == null) return Array.Empty<uint>();
             if (!index.GraphIndex.Reverse.TryGetValue(nodeId, out var edges)) return Array.Empty<uint>();
-            return edges.Select(e => e.TargetId).ToArray();
+            var result = new uint[edges.Count];
+            int idx = 0;
+            foreach (var e in edges)
+                result[idx++] = e.TargetId;
+            return result;
         }
     }
 

--- a/BareMetalWeb.Data/SettingsService.cs
+++ b/BareMetalWeb.Data/SettingsService.cs
@@ -46,7 +46,15 @@ public static class SettingsService
         };
 
         var settings = DataStoreProvider.Current.Query<AppSetting>(query);
-        var setting = settings.FirstOrDefault(s => string.Equals(s.SettingId, settingId, StringComparison.OrdinalIgnoreCase));
+        AppSetting? setting = null;
+        foreach (var s in settings)
+        {
+            if (string.Equals(s.SettingId, settingId, StringComparison.OrdinalIgnoreCase))
+            {
+                setting = s;
+                break;
+            }
+        }
         if (setting != null)
         {
             cache[settingId] = setting.Value;
@@ -87,9 +95,13 @@ public static class SettingsService
         string createdBy,
         CancellationToken cancellationToken = default)
     {
-        var existing = (await store.QueryAsync<AppSetting>(null, cancellationToken).ConfigureAwait(false))
-            .GroupBy(s => s.SettingId, StringComparer.OrdinalIgnoreCase)
-            .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
+        var existing = new Dictionary<string, AppSetting>(StringComparer.OrdinalIgnoreCase);
+        var allSettings = await store.QueryAsync<AppSetting>(null, cancellationToken).ConfigureAwait(false);
+        foreach (var s in allSettings)
+        {
+            if (!existing.ContainsKey(s.SettingId))
+                existing[s.SettingId] = s;
+        }
 
         foreach (var (settingId, value, description) in defaults)
         {

--- a/BareMetalWeb.Data/SystemPrincipal.cs
+++ b/BareMetalWeb.Data/SystemPrincipal.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 
 namespace BareMetalWeb.Data;

--- a/BareMetalWeb.Data/Users.cs
+++ b/BareMetalWeb.Data/Users.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -21,7 +20,12 @@ public static class Users
 
         var normalized = email.Trim();
         var users = await DataStoreProvider.Current.QueryAsync<User>(null, cancellationToken).ConfigureAwait(false);
-        return users.FirstOrDefault(user => string.Equals(user.Email, normalized, StringComparison.OrdinalIgnoreCase));
+        foreach (var user in users)
+        {
+            if (string.Equals(user.Email, normalized, StringComparison.OrdinalIgnoreCase))
+                return user;
+        }
+        return null;
     }
 
     public static async ValueTask<User?> FindByUserNameAsync(string userName, CancellationToken cancellationToken = default)
@@ -31,7 +35,12 @@ public static class Users
 
         var normalized = userName.Trim();
         var users = await DataStoreProvider.Current.QueryAsync<User>(null, cancellationToken).ConfigureAwait(false);
-        return users.FirstOrDefault(user => string.Equals(user.UserName, normalized, StringComparison.OrdinalIgnoreCase));
+        foreach (var user in users)
+        {
+            if (string.Equals(user.UserName, normalized, StringComparison.OrdinalIgnoreCase))
+                return user;
+        }
+        return null;
     }
 
     public static async ValueTask<User?> FindByEmailOrUserNameAsync(string value, CancellationToken cancellationToken = default)
@@ -41,8 +50,13 @@ public static class Users
 
         var normalized = value.Trim();
         var users = await DataStoreProvider.Current.QueryAsync<User>(null, cancellationToken).ConfigureAwait(false);
-        return users.FirstOrDefault(user => string.Equals(user.Email, normalized, StringComparison.OrdinalIgnoreCase)
-            || string.Equals(user.UserName, normalized, StringComparison.OrdinalIgnoreCase));
+        foreach (var user in users)
+        {
+            if (string.Equals(user.Email, normalized, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(user.UserName, normalized, StringComparison.OrdinalIgnoreCase))
+                return user;
+        }
+        return null;
     }
 
     public static async ValueTask<bool> ExistsByEmailOrUserNameAsync(string value, CancellationToken cancellationToken = default)

--- a/BareMetalWeb.Data/ValidationService.cs
+++ b/BareMetalWeb.Data/ValidationService.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Reflection;
 using BareMetalWeb.Core;
 using BareMetalWeb.Data.ExpressionEngine;
@@ -41,12 +40,16 @@ public static class ValidationService
     [RequiresUnreferencedCode("Attribute scanning requires property metadata to be preserved.")]
     public static ValidationConfig? BuildValidationConfig(PropertyInfo property)
     {
-        var validators = property.GetCustomAttributes()
-            .OfType<ValidationAttribute>()
-            .ToList();
+        var validators = new List<ValidationAttribute>();
+        foreach (var attr in property.GetCustomAttributes())
+        {
+            if (attr is ValidationAttribute va)
+                validators.Add(va);
+        }
 
-        var expressionRules = property.GetCustomAttributes<ValidationRuleAttribute>()
-            .ToList();
+        var expressionRules = new List<ValidationRuleAttribute>();
+        foreach (var rule in property.GetCustomAttributes<ValidationRuleAttribute>())
+            expressionRules.Add(rule);
 
         if (validators.Count == 0 && expressionRules.Count == 0)
             return null;
@@ -107,7 +110,12 @@ public static class ValidationService
     public static IReadOnlyList<ValidationRuleAttribute> GetEntityRules(Type entityType)
     {
         return _entityRulesCache.GetOrAdd(entityType, static t =>
-            t.GetCustomAttributes<ValidationRuleAttribute>().ToList());
+        {
+            var rules = new List<ValidationRuleAttribute>();
+            foreach (var rule in t.GetCustomAttributes<ValidationRuleAttribute>())
+                rules.Add(rule);
+            return rules;
+        });
     }
 
     /// <summary>

--- a/BareMetalWeb.Data/VectorIndex.cs
+++ b/BareMetalWeb.Data/VectorIndex.cs
@@ -194,7 +194,10 @@ internal sealed class VectorSegment
         while (results.Count > topK)
             results.Remove(results.Max);
 
-        return results.Select(r => (r.Id, r.Dist)).ToList();
+        var output = new List<(uint Id, float Distance)>(results.Count);
+        foreach (var r in results)
+            output.Add((r.Id, r.Dist));
+        return output;
     }
 
     /// <summary>Greedy best-first search returning nearest candidate IDs.</summary>
@@ -235,7 +238,15 @@ internal sealed class VectorSegment
             }
         }
 
-        return bestList.Take(count).Select(b => b.Id).ToList();
+        var output = new List<uint>(Math.Min(count, bestList.Count));
+        int taken = 0;
+        foreach (var b in bestList)
+        {
+            if (taken >= count) break;
+            output.Add(b.Id);
+            taken++;
+        }
+        return output;
     }
 
     /// <summary>Prune neighbour list to diverse subset via Vamana alpha-pruning.</summary>
@@ -245,11 +256,13 @@ internal sealed class VectorSegment
             return candidates;
 
         // Sort by distance to query
-        var ranked = candidates
-            .Where(id => _nodes.ContainsKey(id))
-            .Select(id => (Id: id, Dist: ComputeDistance(query, _nodes[id].Embedding)))
-            .OrderBy(x => x.Dist)
-            .ToList();
+        var ranked = new List<(uint Id, float Dist)>();
+        foreach (var id in candidates)
+        {
+            if (_nodes.ContainsKey(id))
+                ranked.Add((id, ComputeDistance(query, _nodes[id].Embedding)));
+        }
+        ranked.Sort((a, b) => a.Dist.CompareTo(b.Dist));
 
         var result = new List<uint>();
         foreach (var (id, dist) in ranked)
@@ -280,13 +293,17 @@ internal sealed class VectorSegment
     private void TrimNeighbours(VectorNode node)
     {
         if (node.Neighbours.Count <= MaxDegree) return;
-        var sorted = node.Neighbours
-            .Where(id => _nodes.ContainsKey(id))
-            .Select(id => (Id: id, Dist: ComputeDistance(node.Embedding, _nodes[id].Embedding)))
-            .OrderBy(x => x.Dist)
-            .Take(MaxDegree)
-            .Select(x => x.Id)
-            .ToList();
+        var sortable = new List<(uint Id, float Dist)>();
+        foreach (var id in node.Neighbours)
+        {
+            if (_nodes.ContainsKey(id))
+                sortable.Add((id, ComputeDistance(node.Embedding, _nodes[id].Embedding)));
+        }
+        sortable.Sort((a, b) => a.Dist.CompareTo(b.Dist));
+        int trimCount = Math.Min(MaxDegree, sortable.Count);
+        var sorted = new List<uint>(trimCount);
+        for (int i = 0; i < trimCount; i++)
+            sorted.Add(sortable[i].Id);
         node.Neighbours.Clear();
         node.Neighbours.AddRange(sorted);
     }
@@ -361,7 +378,15 @@ public sealed class VectorIndexManager
                 seg.Delete(objectId);
 
             // Find a segment with capacity, or create a new one
-            var target = segments.FirstOrDefault(s => s.LiveCount < MaxSegmentSize);
+            VectorSegment? target = null;
+            foreach (var s in segments)
+            {
+                if (s.LiveCount < MaxSegmentSize)
+                {
+                    target = s;
+                    break;
+                }
+            }
             if (target == null)
             {
                 target = new VectorSegment(def.Dimension, def.Metric, def.MaxDegree);
@@ -407,12 +432,14 @@ public sealed class VectorIndexManager
             }
             else
             {
-                selectedSegments = segments
-                    .Select(s => (Seg: s, Dist: CentroidDistance(query, s.Centroid, def.Metric)))
-                    .OrderBy(x => x.Dist)
-                    .Take(maxSegments)
-                    .Select(x => x.Seg)
-                    .ToList();
+                var rankedSegments = new List<(VectorSegment Seg, float Dist)>(segments.Count);
+                foreach (var s in segments)
+                    rankedSegments.Add((s, CentroidDistance(query, s.Centroid, def.Metric)));
+                rankedSegments.Sort((a, b) => a.Dist.CompareTo(b.Dist));
+                int takeCount = Math.Min(maxSegments, rankedSegments.Count);
+                selectedSegments = new List<VectorSegment>(takeCount);
+                for (int i = 0; i < takeCount; i++)
+                    selectedSegments.Add(rankedSegments[i].Seg);
             }
         }
 
@@ -427,7 +454,15 @@ public sealed class VectorIndexManager
                 allResults.Add((dist, id));
         }
 
-        return allResults.Take(topK).Select(r => (r.Id, r.Dist)).ToList();
+        var output = new List<(uint Id, float Distance)>(Math.Min(topK, allResults.Count));
+        int resultsTaken = 0;
+        foreach (var r in allResults)
+        {
+            if (resultsTaken >= topK) break;
+            output.Add((r.Id, r.Dist));
+            resultsTaken++;
+        }
+        return output;
     }
 
     /// <summary>Returns the number of indexed vectors for an entity/field pair.</summary>
@@ -436,13 +471,21 @@ public sealed class VectorIndexManager
         var key = (entityType, field);
         if (!_indexes.TryGetValue(key, out var segments)) return 0;
         lock (segments)
-            return segments.Sum(s => s.LiveCount);
+        {
+            int total = 0;
+            foreach (var s in segments)
+                total += s.LiveCount;
+            return total;
+        }
     }
 
     /// <summary>Gets all registered index definitions.</summary>
     public IReadOnlyCollection<(string EntityType, string Field, VectorIndexDefinition Def)> GetDefinitions()
     {
-        return _definitions.Select(kv => (kv.Key.EntityType, kv.Key.Field, kv.Value)).ToArray();
+        var result = new List<(string EntityType, string Field, VectorIndexDefinition Def)>();
+        foreach (var kv in _definitions)
+            result.Add((kv.Key.EntityType, kv.Key.Field, kv.Value));
+        return result.ToArray();
     }
 
     private static float CentroidDistance(float[] query, float[] centroid, DistanceMetric metric)

--- a/BareMetalWeb.Data/WalDataProvider.cs
+++ b/BareMetalWeb.Data/WalDataProvider.cs
@@ -4,7 +4,6 @@ using System.Buffers.Binary;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Text.Json;
@@ -207,7 +206,12 @@ public sealed class WalDataProvider : IDataProvider, IDisposable
 
             if (existing == null)
             {
-                schemaVersion = cache.Versions.Count == 0 ? 1 : cache.Versions.Keys.Max() + 1;
+                int maxVer = int.MinValue;
+                foreach (var k in cache.Versions.Keys)
+                {
+                    if (k > maxVer) maxVer = k;
+                }
+                schemaVersion = cache.Versions.Count == 0 ? 1 : maxVer + 1;
                 var schemaFile = BuildSchemaFile(currentSchema, schemaVersion);
                 cache.Versions[schemaVersion]           = schemaFile;
                 cache.HashToVersion[currentSchema.Hash] = schemaVersion;
@@ -466,13 +470,32 @@ public sealed class WalDataProvider : IDataProvider, IDisposable
                         loaded.Add(obj);
                 }
 
-                IEnumerable<T> filtered = needRecheck
-                    ? loaded.Where(item => _queryEvaluator.Matches(item, query))
-                    : loaded;
-                var sorted = _queryEvaluator.ApplySorts(filtered, query);
+                List<T> filtered;
+                if (needRecheck)
+                {
+                    filtered = new List<T>(loaded.Count);
+                    foreach (var item in loaded)
+                    {
+                        if (_queryEvaluator.Matches(item, query))
+                            filtered.Add(item);
+                    }
+                }
+                else
+                {
+                    filtered = loaded;
+                }
+                var sortedList = new List<T>();
+                foreach (var item in _queryEvaluator.ApplySorts(filtered, query))
+                    sortedList.Add(item);
                 if (skip > 0 || top != DefaultQueryLimit)
-                    sorted = sorted.Skip(skip).Take(top);
-                return sorted.ToList();
+                {
+                    int end = Math.Min(skip + top, sortedList.Count);
+                    var paged = new List<T>(Math.Max(0, end - skip));
+                    for (int i = skip; i < end; i++)
+                        paged.Add(sortedList[i]);
+                    return paged;
+                }
+                return sortedList;
             }
         }
         // ── Full scan (no usable index) ───────────────────────────────────────
@@ -512,11 +535,11 @@ public sealed class WalDataProvider : IDataProvider, IDisposable
                     foreach (var (objKey, _) in idMap)
                         allKeys.Add(objKey);
                     allKeys.Reverse();
-                    var descPage = allKeys.Skip(skip).Take(top).ToList();
-                    var descResults = new List<T>(descPage.Count);
-                    foreach (var key in descPage)
+                    int descEnd = Math.Min(skip + top, allKeys.Count);
+                    var descResults = new List<T>(Math.Max(0, descEnd - skip));
+                    for (int i = skip; i < descEnd; i++)
                     {
-                        var obj = Load<T>(key);
+                        var obj = Load<T>(allKeys[i]);
                         if (obj != null) descResults.Add(obj);
                     }
                     return descResults;
@@ -560,11 +583,11 @@ public sealed class WalDataProvider : IDataProvider, IDisposable
                             return sort.Direction == SortDirection.Desc ? -cmp : cmp;
                         });
 
-                        var sortPage = keysWithValues.Skip(skip).Take(top).ToList();
-                        var sortResults = new List<T>(sortPage.Count);
-                        foreach (var (key, _) in sortPage)
+                        int sortEnd = Math.Min(skip + top, keysWithValues.Count);
+                        var sortResults = new List<T>(Math.Max(0, sortEnd - skip));
+                        for (int i = skip; i < sortEnd; i++)
                         {
-                            var obj = Load<T>(key);
+                            var obj = Load<T>(keysWithValues[i].Key);
                             if (obj != null)
                                 sortResults.Add(obj);
                         }
@@ -610,10 +633,18 @@ public sealed class WalDataProvider : IDataProvider, IDisposable
 
         if (!canShortCircuit)
         {
-            IEnumerable<T> sorted = _queryEvaluator.ApplySorts(scanResults, query);
+            var sortedList = new List<T>();
+            foreach (var item in _queryEvaluator.ApplySorts(scanResults, query))
+                sortedList.Add(item);
             if (skip > 0 || top != int.MaxValue)
-                sorted = sorted.Skip(skip).Take(top);
-            return sorted.ToList();
+            {
+                int end = Math.Min(skip + top, sortedList.Count);
+                var paged = new List<T>(Math.Max(0, end - skip));
+                for (int i = skip; i < end; i++)
+                    paged.Add(sortedList[i]);
+                return paged;
+            }
+            return sortedList;
         }
 
         return scanResults;
@@ -1012,10 +1043,15 @@ public sealed class WalDataProvider : IDataProvider, IDisposable
             });
         }
 
-        IEnumerable<DataRecord> output = results;
-        if (skip > 0) output = output.Skip(skip);
-        if (top < DefaultQueryLimit) output = output.Take(top);
-        return output;
+        if (skip > 0 || top < DefaultQueryLimit)
+        {
+            int end = (top < DefaultQueryLimit) ? Math.Min(skip + top, results.Count) : results.Count;
+            var paged = new List<DataRecord>(Math.Max(0, end - skip));
+            for (int i = skip; i < end; i++)
+                paged.Add(results[i]);
+            return paged;
+        }
+        return results;
     }
 
     /// <summary>Queries <see cref="DataRecord"/> entities asynchronously.</summary>
@@ -1028,7 +1064,10 @@ public sealed class WalDataProvider : IDataProvider, IDisposable
         var entityName = schema.EntityName;
         if (query == null || query.Clauses.Count == 0)
             return _liveCounts.TryGetValue(entityName, out var c) ? c : GetOrLoadIdMap(entityName).Count;
-        return QueryRecords(schema, query).Count();
+        int count = 0;
+        foreach (var _ in QueryRecords(schema, query))
+            count++;
+        return count;
     }
 
     /// <summary>Counts <see cref="DataRecord"/> entities asynchronously.</summary>
@@ -1426,7 +1465,14 @@ public sealed class WalDataProvider : IDataProvider, IDisposable
         }
 
         if (cache.Versions.Count > 0)
-            cache.CurrentVersion = cache.Versions.Keys.Max();
+        {
+            int maxVersion = int.MinValue;
+            foreach (var key in cache.Versions.Keys)
+            {
+                if (key > maxVersion) maxVersion = key;
+            }
+            cache.CurrentVersion = maxVersion;
+        }
 
         return cache;
     }
@@ -1494,15 +1540,24 @@ public sealed class WalDataProvider : IDataProvider, IDisposable
             Version      = version,
             Hash         = schema.Hash,
             Architecture = schema.Architecture.ToString(),
-            Members      = schema.Members
-                .Select(m => new MemberSignatureFile
-                {
-                    Name          = m.Name,
-                    TypeName      = m.TypeName,
-                    BlittableSize = m.BlittableSize,
-                })
-                .ToList()
+            Members      = BuildMemberSignatureFiles(schema.Members)
         };
+
+    private static List<MemberSignatureFile> BuildMemberSignatureFiles(MemberSignature[] members)
+    {
+        var list = new List<MemberSignatureFile>(members.Length);
+        for (int i = 0; i < members.Length; i++)
+        {
+            var m = members[i];
+            list.Add(new MemberSignatureFile
+            {
+                Name          = m.Name,
+                TypeName      = m.TypeName,
+                BlittableSize = m.BlittableSize,
+            });
+        }
+        return list;
+    }
 
     private static bool TryParseSchemaVersion(Type type, string fileName, out int version)
     {
@@ -1547,12 +1602,19 @@ public sealed class WalDataProvider : IDataProvider, IDisposable
         }
 
         var schemaMembers = _schemaMemberCache.GetOrAdd((type, schemaVersion), _ =>
-            schemaFile.Members
-                .Select(m => new MemberSignature(
+        {
+            var members = schemaFile.Members;
+            var arr = new MemberSignature[members.Count];
+            for (int i = 0; i < members.Count; i++)
+            {
+                var m = members[i];
+                arr[i] = new MemberSignature(
                     m.Name, m.TypeName,
                     AssumePublicMembers(_serializer.ResolveTypeName(m.TypeName)),
-                    m.BlittableSize))
-                .ToArray());
+                    m.BlittableSize);
+            }
+            return arr;
+        });
 
         var arch   = ParseArchitecture(schemaFile.Architecture);
         var schema = _serializer.CreateSchema(schemaFile.Version, schemaMembers, arch, schemaFile.Hash);
@@ -1569,12 +1631,18 @@ public sealed class WalDataProvider : IDataProvider, IDisposable
     private void ClearSingletonFlagsOnOtherRecords<T>(T obj) where T : BaseDataObject
     {
         var type           = typeof(T);
-        var singletonProps = type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
-            .Where(p => p.PropertyType == typeof(bool)
-                        && p.GetCustomAttribute<SingletonFlagAttribute>() != null
-                        && p.CanRead && p.CanWrite
-                        && true.Equals(p.GetValue(obj)))
-            .ToList();
+        var allProps = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+        var singletonProps = new List<PropertyInfo>();
+        foreach (var p in allProps)
+        {
+            if (p.PropertyType == typeof(bool)
+                && p.GetCustomAttribute<SingletonFlagAttribute>() != null
+                && p.CanRead && p.CanWrite
+                && true.Equals(p.GetValue(obj)))
+            {
+                singletonProps.Add(p);
+            }
+        }
 
         if (singletonProps.Count == 0) return;
 

--- a/BareMetalWeb.Data/WalReplayValidator.cs
+++ b/BareMetalWeb.Data/WalReplayValidator.cs
@@ -118,12 +118,21 @@ public sealed class WalReplayValidator
                 }
 
                 // Check for keys in replay but not in live
-                int extra = replayHeadMap.Keys.Count(k =>
+                int extra = 0;
+                foreach (var k in replayHeadMap.Keys)
                 {
+                    bool foundInLive = false;
                     for (int i = 0; i < liveKeys.Length; i++)
-                        if (liveKeys[i] == k) return false;
-                    return true;
-                });
+                    {
+                        if (liveKeys[i] == k)
+                        {
+                            foundInLive = true;
+                            break;
+                        }
+                    }
+                    if (!foundInLive)
+                        extra++;
+                }
 
                 result.HeadMapMismatches = mismatches;
                 result.MissingFromReplay = missing;

--- a/BareMetalWeb.DataBrowser/Program.cs
+++ b/BareMetalWeb.DataBrowser/Program.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
+
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -88,12 +88,14 @@ internal static class Program
             foreach (var srcEntity in pkg.Entities)
             {
                 var entityId = srcEntity.EntityId;
-                var entityFields = pkg.Fields
-                    .Where(f => string.Equals(f.EntityId, entityId, StringComparison.OrdinalIgnoreCase))
-                    .ToList();
-                var entityIndexes = pkg.Indexes
-                    .Where(i => string.Equals(i.EntityId, entityId, StringComparison.OrdinalIgnoreCase))
-                    .ToList();
+                var entityFields = new List<FieldDefinition>();
+                foreach (var f in pkg.Fields)
+                    if (string.Equals(f.EntityId, entityId, StringComparison.OrdinalIgnoreCase))
+                        entityFields.Add(f);
+                var entityIndexes = new List<IndexDefinition>();
+                foreach (var i in pkg.Indexes)
+                    if (string.Equals(i.EntityId, entityId, StringComparison.OrdinalIgnoreCase))
+                        entityIndexes.Add(i);
                 var model = compiler.Compile(srcEntity, entityFields, entityIndexes,
                     Array.Empty<ActionDefinition>(), Array.Empty<ActionCommandDefinition>(), out _);
                 if (model == null) continue;
@@ -106,8 +108,17 @@ internal static class Program
         }
         foreach (var model in compiledModels)
         {
-            if (model.Fields.Any(f => f.FieldType == Rendering.Models.FormFieldType.LookupList
-                && !string.IsNullOrWhiteSpace(f.LookupEntitySlug)))
+            bool hasLookup = false;
+            foreach (var f in model.Fields)
+            {
+                if (f.FieldType == Rendering.Models.FormFieldType.LookupList
+                    && !string.IsNullOrWhiteSpace(f.LookupEntitySlug))
+                {
+                    hasLookup = true;
+                    break;
+                }
+            }
+            if (hasLookup)
             {
                 var schema = EntitySchemaFactory.FromModel(model);
                 var updated = model.ToEntityMetadata(walProvider, schema);
@@ -267,8 +278,9 @@ internal static class Program
         // Discover entities from two sources:
         // 1. DataScaffold-registered types (known C# entity classes)
         // 2. Subdirectories in the Paged folder (entities with stored data)
-        var registered = DataScaffold.Entities
-            .ToDictionary(e => e.Name, StringComparer.OrdinalIgnoreCase);
+        var registered = new Dictionary<string, DataEntityMetadata>(StringComparer.OrdinalIgnoreCase);
+        foreach (var e in DataScaffold.Entities)
+            registered[e.Name] = e;
 
         var onDisk = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var pagedRoot = Path.Combine(_dataRoot, "Paged");
@@ -280,8 +292,10 @@ internal static class Program
         foreach (var (entity, _) in IndexStore.ListTrackedIndexes(_provider))
             onDisk.Add(entity);
 
-        var all = registered.Keys.Union(onDisk, StringComparer.OrdinalIgnoreCase)
-            .OrderBy(n => n).ToList();
+        var allSet = new HashSet<string>(registered.Keys, StringComparer.OrdinalIgnoreCase);
+        foreach (var name in onDisk) allSet.Add(name);
+        var all = new List<string>(allSet);
+        all.Sort(StringComparer.OrdinalIgnoreCase);
 
         if (all.Count == 0)
         {
@@ -290,18 +304,19 @@ internal static class Program
         }
 
         var headers = new[] { "Entity", "Slug", "Fields", "OnDisk", "Registered" };
-        var rows = all.Select(name =>
+        var rows = new List<string[]>();
+        foreach (var name in all)
         {
             registered.TryGetValue(name, out var meta);
-            return new[]
+            rows.Add(new[]
             {
                 name,
                 meta?.Slug ?? "-",
                 meta?.Fields.Count.ToString() ?? "-",
                 onDisk.Contains(name) ? "yes" : "no",
                 meta != null ? "yes" : "no"
-            };
-        }).ToList();
+            });
+        }
 
         PrintTable(headers, rows);
         Console.WriteLine($"\n{all.Count} entity type(s).");
@@ -314,10 +329,15 @@ internal static class Program
     {
         var filterEntity = args.Length > 0 && !args[0].StartsWith("--") ? args[0] : null;
 
-        var entries = IndexStore.ListTrackedIndexes(_provider)
-            .Where(e => filterEntity == null || string.Equals(e.EntityName, filterEntity, StringComparison.OrdinalIgnoreCase))
-            .OrderBy(e => e.EntityName).ThenBy(e => e.FieldName)
-            .ToList();
+        var entries = new List<(string EntityName, string FieldName)>();
+        foreach (var e in IndexStore.ListTrackedIndexes(_provider))
+            if (filterEntity == null || string.Equals(e.EntityName, filterEntity, StringComparison.OrdinalIgnoreCase))
+                entries.Add(e);
+        entries.Sort((a, b) =>
+        {
+            int cmp = string.Compare(a.EntityName, b.EntityName, StringComparison.Ordinal);
+            return cmp != 0 ? cmp : string.Compare(a.FieldName, b.FieldName, StringComparison.Ordinal);
+        });
 
         if (entries.Count == 0)
         {
@@ -328,11 +348,12 @@ internal static class Program
         }
 
         var headers = new[] { "Entity", "Field", "Snapshot pages", "Log pages", "Sequence" };
-        var rows = entries.Select(e =>
+        var rows = new List<string[]>();
+        foreach (var e in entries)
         {
             var (snap, log, seq) = _indexStore.ReadIndexStats(e.EntityName, e.FieldName);
-            return new[] { e.EntityName, e.FieldName, snap.ToString(), log.ToString(), seq.ToString() };
-        }).ToList();
+            rows.Add(new[] { e.EntityName, e.FieldName, snap.ToString(), log.ToString(), seq.ToString() });
+        }
 
         PrintTable(headers, rows);
         Console.WriteLine($"\n{entries.Count} index(es).");
@@ -357,13 +378,33 @@ internal static class Program
         }
 
         var headers = new[] { "Key", "IDs" };
-        var rows = index.OrderBy(kv => kv.Key)
-            .Select(kv => new[] { kv.Key, string.Join(", ", kv.Value.Take(10)) +
-                (kv.Value.Count > 10 ? $"  …+{kv.Value.Count - 10}" : "") })
-            .ToList();
+        var sortedEntries = new List<KeyValuePair<string, HashSet<uint>>>(index);
+        sortedEntries.Sort((a, b) => string.Compare(a.Key, b.Key, StringComparison.Ordinal));
+        var rows = new List<string[]>();
+        foreach (var kv in sortedEntries)
+        {
+            string idsDisplay;
+            if (kv.Value.Count <= 10)
+                idsDisplay = string.Join(", ", kv.Value);
+            else
+            {
+                var first10 = new List<uint>();
+                int t = 0;
+                foreach (var id in kv.Value)
+                {
+                    if (t >= 10) break;
+                    first10.Add(id);
+                    t++;
+                }
+                idsDisplay = string.Join(", ", first10) + $"  …+{kv.Value.Count - 10}";
+            }
+            rows.Add(new[] { kv.Key, idsDisplay });
+        }
 
         PrintTable(headers, rows);
-        Console.WriteLine($"\n{index.Count} key(s),  {index.Values.Sum(v => v.Count)} total ID(s).");
+        int totalIds = 0;
+        foreach (var v in index.Values) totalIds += v.Count;
+        Console.WriteLine($"\n{index.Count} key(s),  {totalIds} total ID(s).");
         return 0;
     }
 
@@ -376,7 +417,9 @@ internal static class Program
 
         var entity = args[0];
         var field = args[1];
-        bool raw = args.Contains("--raw", StringComparer.OrdinalIgnoreCase);
+        bool raw = false;
+        foreach (var arg in args)
+            if (string.Equals(arg, "--raw", StringComparison.OrdinalIgnoreCase)) { raw = true; break; }
 
         var entries = _indexStore.ReadRawLogEntries(entity, field);
         if (entries.Count == 0)
@@ -386,14 +429,15 @@ internal static class Program
         }
 
         var headers = new[] { "Timestamp (UTC)", "Op", "Key", "ID", "Expires (UTC)" };
-        var rows = entries.Select(e =>
+        var rows = new List<string[]>();
+        foreach (var e in entries)
         {
             var ts = new DateTime(e.Ticks, DateTimeKind.Utc).ToString("yyyy-MM-dd HH:mm:ss.fff");
             var exp = e.ExpiresAtUtcTicks.HasValue && e.ExpiresAtUtcTicks.Value > 0
                 ? new DateTime(e.ExpiresAtUtcTicks.Value, DateTimeKind.Utc).ToString("yyyy-MM-dd HH:mm:ss")
                 : "-";
-            return new[] { ts, e.Op.ToString(), e.Key, e.Id, exp };
-        }).ToList();
+            rows.Add(new[] { ts, e.Op.ToString(), e.Key, e.Id, exp });
+        }
 
         PrintTable(headers, rows);
         Console.WriteLine($"\n{entries.Count} WAL log entry(ies).");
@@ -445,7 +489,7 @@ internal static class Program
     {
         RequireWriteMode();
 
-        var indexes = IndexStore.ListTrackedIndexes(_provider).ToList();
+        var indexes = new List<(string EntityName, string FieldName)>(IndexStore.ListTrackedIndexes(_provider));
         if (indexes.Count == 0)
         {
             Console.WriteLine("No indexes tracked.");
@@ -488,17 +532,23 @@ internal static class Program
         {
             var query = new QueryDefinition { Top = top };
             var results = await meta.Handlers.QueryAsync(query, CancellationToken.None);
-            var list = results.ToList();
+            var list = new List<BaseDataObject>(results);
             if (list.Count == 0)
             {
                 Console.WriteLine("No records found.");
                 return 0;
             }
 
-            var listFields = meta.Fields.Where(f => f.List).OrderBy(f => f.Order).Take(5).ToList();
-            var colNames = new[] { "Id" }.Concat(listFields.Select(f => f.Name)).ToArray();
+            var listFieldsAll = new List<DataFieldMetadata>();
+            foreach (var f in meta.Fields) if (f.List) listFieldsAll.Add(f);
+            listFieldsAll.Sort((a, b) => a.Order.CompareTo(b.Order));
+            var listFields = listFieldsAll.Count > 5 ? listFieldsAll.GetRange(0, 5) : listFieldsAll;
+            var colNamesList = new List<string> { "Id" };
+            foreach (var f in listFields) colNamesList.Add(f.Name);
+            var colNames = colNamesList.ToArray();
 
-            var rows = list.Select(obj =>
+            var rows = new List<string[]>();
+            foreach (var obj in list)
             {
                 var cells = new string[colNames.Length];
                 cells[0] = obj.Key.ToString();
@@ -507,8 +557,8 @@ internal static class Program
                     var val = listFields[i].GetValueFn(obj);
                     cells[i + 1] = FormatValue(val);
                 }
-                return cells;
-            }).ToList();
+                rows.Add(cells);
+            }
 
             PrintTable(colNames, rows);
             Console.WriteLine($"\n{list.Count} record(s) (top={top}).");
@@ -524,10 +574,16 @@ internal static class Program
             }
 
             var headers = new[] { "Id", "Clustered location" };
-            var rows = index.OrderBy(kv => kv.Key)
-                .Take(top)
-                .Select(kv => new[] { kv.Key, kv.Value })
-                .ToList();
+            var sortedKvs = new List<KeyValuePair<string, string>>(index);
+            sortedKvs.Sort((a, b) => string.Compare(a.Key, b.Key, StringComparison.Ordinal));
+            var rows = new List<string[]>();
+            int count = 0;
+            foreach (var kv in sortedKvs)
+            {
+                if (count >= top) break;
+                rows.Add(new[] { kv.Key, kv.Value });
+                count++;
+            }
 
             PrintTable(headers, rows);
             Console.WriteLine($"\n{Math.Min(index.Count, top)} of {index.Count} record(s) shown.");
@@ -571,8 +627,11 @@ internal static class Program
         Console.WriteLine($"  Updated: {obj.UpdatedOnUtc:yyyy-MM-dd HH:mm:ss} UTC");
         Console.WriteLine();
 
-        var allFields = meta.Fields.OrderBy(f => f.Order).ToList();
-        var maxLabel = allFields.Count > 0 ? allFields.Max(f => f.Label.Length) : 10;
+        var allFields = new List<DataFieldMetadata>(meta.Fields);
+        allFields.Sort((a, b) => a.Order.CompareTo(b.Order));
+        int maxLabel = 10;
+        foreach (var f in allFields)
+            if (f.Label.Length > maxLabel) maxLabel = f.Label.Length;
         maxLabel = Math.Max(maxLabel, 10);
 
         foreach (var field in allFields)
@@ -611,8 +670,15 @@ internal static class Program
 
         foreach (var (key, value) in pairs)
         {
-            var field = meta.Fields.FirstOrDefault(f =>
-                string.Equals(f.Name, key, StringComparison.OrdinalIgnoreCase));
+            DataFieldMetadata? field = null;
+            foreach (var f in meta.Fields)
+            {
+                if (string.Equals(f.Name, key, StringComparison.OrdinalIgnoreCase))
+                {
+                    field = f;
+                    break;
+                }
+            }
 
             if (field == null)
             {
@@ -723,9 +789,13 @@ internal static class Program
 
     static DataEntityMetadata? FindEntityMetadata(string entityNameOrSlug)
     {
-        return DataScaffold.Entities.FirstOrDefault(e =>
-            string.Equals(e.Name, entityNameOrSlug, StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(e.Slug, entityNameOrSlug, StringComparison.OrdinalIgnoreCase));
+        foreach (var e in DataScaffold.Entities)
+        {
+            if (string.Equals(e.Name, entityNameOrSlug, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(e.Slug, entityNameOrSlug, StringComparison.OrdinalIgnoreCase))
+                return e;
+        }
+        return null;
     }
 
     static void RequireWriteMode()
@@ -758,7 +828,8 @@ internal static class Program
                 items.Add(item?.ToString() ?? "");
             if (items.Count == 0)
                 return "[]";
-            var joined = "[" + string.Join(", ", items.Take(5)) + (items.Count > 5 ? $", …+{items.Count - 5}" : "") + "]";
+            var displayItems = items.Count > 5 ? items.GetRange(0, 5) : items;
+            var joined = "[" + string.Join(", ", displayItems) + (items.Count > 5 ? $", …+{items.Count - 5}" : "") + "]";
             return joined.Length > 80 ? joined[..77] + "…" : joined;
         }
         var s = val.ToString() ?? "";

--- a/BareMetalWeb.Host/AgentApiHandlers.cs
+++ b/BareMetalWeb.Host/AgentApiHandlers.cs
@@ -68,7 +68,10 @@ public static class AgentApiHandlers
         {
             var entities = DataScaffold.Entities;
             if (entities.Count == 0) return "No entities registered.";
-            return "Available entities:\n" + string.Join("\n", entities.Select(e => $"• {e.Slug} ({e.Name})"));
+            var entityLines = new List<string>(entities.Count);
+            foreach (var e in entities)
+                entityLines.Add($"• {e.Slug} ({e.Name})");
+            return "Available entities:\n" + string.Join("\n", entityLines);
         }
 
         // Status
@@ -87,7 +90,9 @@ public static class AgentApiHandlers
             var slug = ExtractEntitySlug(lower, "schema ");
             if (!DataScaffold.TryGetEntity(slug, out var meta))
                 return $"Entity '{slug}' not found. Type 'entities' to see available types.";
-            var fields = meta.Fields.Select(f => $"  {f.Name} ({f.FieldType})");
+            var fields = new List<string>(meta.Fields.Count);
+            foreach (var f in meta.Fields)
+                fields.Add($"  {f.Name} ({f.FieldType})");
             return $"Schema for {meta.Name}:\n{string.Join("\n", fields)}";
         }
 
@@ -112,14 +117,17 @@ public static class AgentApiHandlers
             var store = DataStoreProvider.Current;
             var query = new QueryDefinition { Top = 10 };
             var items = await store.QueryAsync<DataRecord>(query, ct);
-            var list = items.ToList();
+            var list = new List<DataRecord>();
+            foreach (var item in items)
+                list.Add(item);
             if (list.Count == 0)
                 return $"No {meta.Name} found.";
-            var lines = list.Select(item =>
+            var lines = new List<string>(list.Count);
+            foreach (var item in list)
             {
                 var name = item.Key.ToString();
-                return $"• [{item.Key}] {name}";
-            });
+                lines.Add($"• [{item.Key}] {name}");
+            }
             return $"{meta.Name} (top 10):\n{string.Join("\n", lines)}";
         }
 
@@ -161,10 +169,14 @@ public static class AgentApiHandlers
                 }
             };
             var items = await store.QueryAsync<DataRecord>(query, ct);
-            var list = items.ToList();
+            var list = new List<DataRecord>();
+            foreach (var item in items)
+                list.Add(item);
             if (list.Count == 0)
                 return $"No {meta.Name} matching '{term}'.";
-            var lines = list.Select(item => $"• [{item.Key}] {item.Key.ToString()}");
+            var lines = new List<string>(list.Count);
+            foreach (var item in list)
+                lines.Add($"• [{item.Key}] {item.Key.ToString()}");
             return $"Results for '{term}' in {meta.Name}:\n{string.Join("\n", lines)}";
         }
 

--- a/BareMetalWeb.Host/BareMetalWebExtensions.cs
+++ b/BareMetalWeb.Host/BareMetalWebExtensions.cs
@@ -110,17 +110,25 @@ public static class BareMetalWebExtensions
             msg => logger.LogInfo($"[RuntimeEntityRegistry] {msg}")).ConfigureAwait(false);
 
         // Permissions
-        var entityPermissions = DataScaffold.Entities
-            .SelectMany(e => (e.Permissions ?? string.Empty)
+        var permSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var e in DataScaffold.Entities)
+        {
+            foreach (var perm in (e.Permissions ?? string.Empty)
                 .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToArray();
+            {
+                permSet.Add(perm);
+            }
+        }
+        var entityPermissions = new string[permSet.Count];
+        permSet.CopyTo(entityPermissions);
         var rootPermissionSet = new HashSet<string>(entityPermissions, StringComparer.OrdinalIgnoreCase)
         {
             "admin",
             "monitoring"
         };
-        await ProgramSetup.EnsureRootPermissionsAsync(logger, rootPermissionSet.ToArray());
+        var rootPermsArray = new string[rootPermissionSet.Count];
+        rootPermissionSet.CopyTo(rootPermsArray);
+        await ProgramSetup.EnsureRootPermissionsAsync(logger, rootPermsArray);
 
         // Rendering
         IHtmlFragmentStore fragmentStore = new HtmlFragmentStore();
@@ -272,7 +280,7 @@ public static class BareMetalWebExtensions
             var list = addresses is null || addresses.Count == 0
                 ? (app.Urls ?? Array.Empty<string>())
                 : addresses;
-            var display = list.Any() ? string.Join(", ", list) : "unknown";
+            var display = list.Count > 0 ? string.Join(", ", list) : "unknown";
             logger.LogInfo($"BareMetalWeb server is ready — PID {Environment.ProcessId} — listening for requests on {display}");
             Console.WriteLine($"BareMetalWeb server is ready — PID {Environment.ProcessId} — listening for requests on {display}");
 
@@ -280,7 +288,15 @@ public static class BareMetalWebExtensions
             logger.LogInfo(httpsConfig);
             Console.WriteLine(httpsConfig);
 
-            var httpsAddress = list.FirstOrDefault(a => a.StartsWith("https://", StringComparison.OrdinalIgnoreCase));
+            string? httpsAddress = null;
+            foreach (var a in list)
+            {
+                if (a.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+                {
+                    httpsAddress = a;
+                    break;
+                }
+            }
             appInfo.HttpsEndpointAvailable = !string.IsNullOrWhiteSpace(httpsAddress);
             if (appInfo.HttpsEndpointAvailable && Uri.TryCreate(httpsAddress, UriKind.Absolute, out var httpsUri))
             {

--- a/BareMetalWeb.Host/BareMetalWebServer.cs
+++ b/BareMetalWeb.Host/BareMetalWebServer.cs
@@ -139,10 +139,10 @@ public class BareMetalWebServer : IBareWebHost
 
             _menuCache.Remove(cacheKey);
         }
-        foreach (var rte in routes.Where(kvp => kvp.Value.PageInfo is not null && kvp.Value.PageInfo.PageMetaData.ShowOnNavBar))
+        foreach (var rte in routes)
         {
             var pageInfo = rte.Value.PageInfo;
-            if (pageInfo == null)
+            if (pageInfo == null || !pageInfo.PageMetaData.ShowOnNavBar)
                 continue;
 
             if (!TryParseRoute(rte.Key, out var verb, out var path))
@@ -157,7 +157,7 @@ public class BareMetalWebServer : IBareWebHost
 
             // Build menu options here
             string href = path;
-            string label = pageInfo.PageContext.PageMetaDataValues.FirstOrDefault() ?? path.Trim('/');
+            string label = (pageInfo.PageContext.PageMetaDataValues.Length > 0 ? pageInfo.PageContext.PageMetaDataValues[0] : null) ?? path.Trim('/');
             bool rightAligned = pageInfo.PageContext.NavAlignment == NavAlignment.Right;
             bool highlightAsButton = pageInfo.PageContext.NavRenderStyle == NavRenderStyle.Button;
             var permissionsNeeded = pageInfo.PageMetaData.PermissionsNeeded ?? string.Empty;
@@ -180,7 +180,15 @@ public class BareMetalWebServer : IBareWebHost
                 if (isAnonymous)
                     continue;
 
-                bool hasPermission = requiredPermissions.All(userPermissions.Contains);
+                bool hasPermission = true;
+                for (int i = 0; i < requiredPermissions.Length; i++)
+                {
+                    if (!userPermissions.Contains(requiredPermissions[i]))
+                    {
+                        hasPermission = false;
+                        break;
+                    }
+                }
                 if (!hasPermission)
                     continue;
             }
@@ -204,8 +212,11 @@ public class BareMetalWebServer : IBareWebHost
                 subGroup: pageInfo.PageContext.NavSubGroup));
         }
 
-        foreach (var entity in DataScaffold.Entities.Where(e => e.ShowOnNav))
+        foreach (var entity in DataScaffold.Entities)
         {
+            if (!entity.ShowOnNav)
+                continue;
+
             var permissionsNeeded = entity.Permissions?.Trim() ?? string.Empty;
             bool requiresAnonymous = string.Equals(permissionsNeeded, "AnonymousOnly", StringComparison.OrdinalIgnoreCase);
             bool requiresAuthenticated = string.Equals(permissionsNeeded, "Authenticated", StringComparison.OrdinalIgnoreCase);
@@ -226,7 +237,16 @@ public class BareMetalWebServer : IBareWebHost
                 if (isAnonymous)
                     continue;
 
-                if (!requiredPermissions.All(userPermissions.Contains))
+                bool allPermissionsMatch = true;
+                for (int i = 0; i < requiredPermissions.Length; i++)
+                {
+                    if (!userPermissions.Contains(requiredPermissions[i]))
+                    {
+                        allPermissionsMatch = false;
+                        break;
+                    }
+                }
+                if (!allPermissionsMatch)
                     continue;
             }
 
@@ -287,11 +307,16 @@ public class BareMetalWebServer : IBareWebHost
     {
         if (_sortedRoutes == null || _sortedRoutesVersion != _routesVersion)
         {
-            _sortedRoutes = routes
-                .Where(r => _compiledRoutes.ContainsKey(r.Key))
-                .Select(r => (r.Key, r.Value, _compiledRoutes[r.Key]))
-                .OrderByDescending(r => r.Item3.LiteralSegmentCount)
-                .ToList();
+            var tempList = new List<(string Key, RouteHandlerData Data, CompiledRoute Compiled)>();
+            foreach (var r in routes)
+            {
+                if (_compiledRoutes.ContainsKey(r.Key))
+                {
+                    tempList.Add((r.Key, r.Value, _compiledRoutes[r.Key]));
+                }
+            }
+            tempList.Sort((a, b) => b.Compiled.LiteralSegmentCount.CompareTo(a.Compiled.LiteralSegmentCount));
+            _sortedRoutes = tempList;
             _sortedRoutesVersion = _routesVersion;
         }
         return _sortedRoutes;
@@ -460,7 +485,11 @@ public class BareMetalWebServer : IBareWebHost
                         return;
                     }
                     await injectedPage.Handler(context);
-                    BufferedLogger.LogInfo($"{path}|{method}|{compiled.Verb}|{string.Join(", ", parameters.Select(p => $"{p.Key}={p.Value}"))}|200|{sourceIp}");
+                    var paramParts = new string[parameters.Count];
+                    int paramIdx = 0;
+                    foreach (var p in parameters)
+                        paramParts[paramIdx++] = $"{p.Key}={p.Value}";
+                    BufferedLogger.LogInfo($"{path}|{method}|{compiled.Verb}|{string.Join(", ", paramParts)}|200|{sourceIp}");
                     return;
                 }
             }
@@ -488,7 +517,11 @@ public class BareMetalWebServer : IBareWebHost
                         return;
                     }
                     await injectedPage.Handler(context);
-                    BufferedLogger.LogInfo($"{path}|{method}|{compiled.Verb}|{string.Join(", ", parameters.Select(p => $"{p.Key}={p.Value}"))}|200|{sourceIp}");
+                    var paramParts2 = new string[parameters.Count];
+                    int paramIdx2 = 0;
+                    foreach (var p in parameters)
+                        paramParts2[paramIdx2++] = $"{p.Key}={p.Value}";
+                    BufferedLogger.LogInfo($"{path}|{method}|{compiled.Verb}|{string.Join(", ", paramParts2)}|200|{sourceIp}");
                     return;
                 }
             }
@@ -599,13 +632,20 @@ public class BareMetalWebServer : IBareWebHost
 
         var userPermissions = new HashSet<string>(user!.Permissions ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
 
-        return requiredPermissions.All(userPermissions.Contains);
+        for (int i = 0; i < requiredPermissions.Length; i++)
+        {
+            if (!userPermissions.Contains(requiredPermissions[i]))
+                return false;
+        }
+        return true;
     }
 
     private static async ValueTask<bool> RootUserExistsAsync(CancellationToken cancellationToken = default)
     {
         var users = await DataStoreProvider.Current.QueryAsync<User>(RootUserQuery, cancellationToken).ConfigureAwait(false);
-        return users.Any();
+        foreach (var _ in users)
+            return true;
+        return false;
     }
 
     private async ValueTask<bool> ShouldForceSetupAsync(string requestPath, CancellationToken cancellationToken = default)
@@ -683,8 +723,27 @@ public class BareMetalWebServer : IBareWebHost
         if (CorsAllowedOrigins.Length == 0)
             return false;
 
-        bool allowAny = CorsAllowedOrigins.Any(o => o == "*");
-        bool allowOrigin = allowAny || CorsAllowedOrigins.Any(o => string.Equals(o, origin, StringComparison.OrdinalIgnoreCase));
+        bool allowAny = false;
+        for (int i = 0; i < CorsAllowedOrigins.Length; i++)
+        {
+            if (CorsAllowedOrigins[i] == "*")
+            {
+                allowAny = true;
+                break;
+            }
+        }
+        bool allowOrigin = allowAny;
+        if (!allowOrigin)
+        {
+            for (int i = 0; i < CorsAllowedOrigins.Length; i++)
+            {
+                if (string.Equals(CorsAllowedOrigins[i], origin, StringComparison.OrdinalIgnoreCase))
+                {
+                    allowOrigin = true;
+                    break;
+                }
+            }
+        }
         if (!allowOrigin)
             return false;
 

--- a/BareMetalWeb.Host/BasketApiHandlers.cs
+++ b/BareMetalWeb.Host/BasketApiHandlers.cs
@@ -24,14 +24,19 @@ public static class BasketApiHandlers
         var items = await LoadBasketItems(basket.Key.ToString(), context.RequestAborted);
 
         context.Response.ContentType = "application/json";
+        decimal basketTotal = 0;
+        foreach (var i in items) basketTotal += i.LineTotal;
+        var itemProjections = new List<object>(items.Count);
+        foreach (var i in items)
+            itemProjections.Add(new { key = i.Key, productId = i.ProductId, productName = i.ProductName, quantity = i.Quantity, unitPrice = i.UnitPrice, lineTotal = i.LineTotal });
         await context.Response.WriteAsync(JsonSerializer.Serialize(new
         {
             basketKey = basket.Key,
             userId,
             status = basket.Status.ToString(),
             itemCount = items.Count,
-            total = items.Sum(i => i.LineTotal),
-            items = items.Select(i => new { key = i.Key, productId = i.ProductId, productName = i.ProductName, quantity = i.Quantity, unitPrice = i.UnitPrice, lineTotal = i.LineTotal })
+            total = basketTotal,
+            items = itemProjections
         }));
     }
 
@@ -58,7 +63,15 @@ public static class BasketApiHandlers
 
         // Check if product already in basket — update quantity
         var existing = await LoadBasketItems(basket.Key.ToString(), context.RequestAborted);
-        var existingItem = existing.FirstOrDefault(i => i.ProductId == productId);
+        BasketItem? existingItem = null;
+        foreach (var i in existing)
+        {
+            if (i.ProductId == productId)
+            {
+                existingItem = i;
+                break;
+            }
+        }
         if (existingItem != null)
         {
             existingItem.Quantity += quantity;
@@ -81,7 +94,9 @@ public static class BasketApiHandlers
         // Update basket totals
         var allItems = await LoadBasketItems(basket.Key.ToString(), context.RequestAborted);
         basket.ItemCount = allItems.Count;
-        basket.Total = allItems.Sum(i => i.LineTotal);
+        decimal allItemsTotal = 0;
+        foreach (var i in allItems) allItemsTotal += i.LineTotal;
+        basket.Total = allItemsTotal;
         if (DataScaffold.TryGetEntity("baskets", out var basketMeta))
             await basketMeta.Handlers.SaveAsync(basket, context.RequestAborted);
 
@@ -141,7 +156,12 @@ public static class BasketApiHandlers
         qd.Clauses.Add(new QueryClause { Field = "UserId", Operator = QueryOperator.Equals, Value = userId });
         qd.Clauses.Add(new QueryClause { Field = "Status", Operator = QueryOperator.Equals, Value = "Open" });
         var results = await meta.Handlers.QueryAsync(qd, ct);
-        var existing = results.Cast<Basket>().FirstOrDefault();
+        Basket? existing = null;
+        foreach (var obj in results)
+        {
+            existing = (Basket)obj;
+            break;
+        }
         if (existing != null) return existing;
 
         var basket = (Basket)meta.Handlers.Create();
@@ -161,7 +181,10 @@ public static class BasketApiHandlers
         var qd = new QueryDefinition();
         qd.Clauses.Add(new QueryClause { Field = "BasketId", Operator = QueryOperator.Equals, Value = basketKey });
         var results = await meta.Handlers.QueryAsync(qd, ct);
-        return results.Cast<BasketItem>().ToList();
+        var list = new List<BasketItem>();
+        foreach (var obj in results)
+            list.Add((BasketItem)obj);
+        return list;
     }
 
     private static string GetAnonymousId(HttpContext context)

--- a/BareMetalWeb.Host/BinaryApiHandlers.cs
+++ b/BareMetalWeb.Host/BinaryApiHandlers.cs
@@ -51,13 +51,16 @@ public static class BinaryApiHandlers
     private static MetadataWireSerializer.FieldPlan[] BuildPlanFromMetadata(DataEntityMetadata meta)
     {
         // Build a lookup from metadata fields for getter/setter reuse
-        var metaFieldsByName = meta.Fields.ToDictionary(f => f.Name, StringComparer.Ordinal);
+        var metaFieldsByName = new Dictionary<string, DataFieldMetadata>(StringComparer.Ordinal);
+        foreach (var f in meta.Fields)
+            metaFieldsByName[f.Name] = f;
 
         // Collect ALL public properties on the CLR type — same set the BinaryObjectSerializer uses.
         // Sort by name (Ordinal compare) to match binary serializer member ordering.
-        var props = meta.Type.GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance)
-            .OrderBy(p => p.Name, StringComparer.Ordinal)
-            .ToArray();
+        var unsortedProps = meta.Type.GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
+        var propsList = new List<System.Reflection.PropertyInfo>(unsortedProps);
+        propsList.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.Ordinal));
+        var props = propsList.ToArray();
 
         var descriptors = new List<MetadataWireSerializer.FieldPlanDescriptor>(props.Length);
         foreach (var prop in props)
@@ -160,7 +163,9 @@ public static class BinaryApiHandlers
         {
             var queryDef = LookupApiHandlers.BuildQueryFromRequest(context, meta);
             var entities = await meta.Handlers.QueryAsync(queryDef, context.RequestAborted);
-            var list = entities.Cast<object>().ToList();
+            var list = new List<object>();
+            foreach (var e in entities)
+                list.Add((object)e);
             var plan = GetOrBuildPlan(meta);
             await WriteListResponse(context, list, plan);
         }
@@ -186,7 +191,9 @@ public static class BinaryApiHandlers
         {
             var queryDef = LookupApiHandlers.BuildQueryFromRequest(context, meta);
             var entities = await meta.Handlers.QueryAsync(queryDef, context.RequestAborted);
-            var list = entities.Cast<object>().ToList();
+            var list = new List<object>();
+            foreach (var e in entities)
+                list.Add((object)e);
             var plan = GetOrBuildPlan(meta);
 
             // Build raw ordinal array: each row is field values in plan order
@@ -221,7 +228,13 @@ public static class BinaryApiHandlers
             context.Response.StatusCode = 200;
             context.Response.ContentType = "application/x-bmw-raw";
             context.Response.Headers["Content-Encoding"] = "br";
-            context.Response.Headers["X-BMW-Fields"] = string.Join(",", plan.Select(p => p.Name));
+            var fieldNamesSb = new System.Text.StringBuilder();
+            for (int i = 0; i < plan.Length; i++)
+            {
+                if (i > 0) fieldNamesSb.Append(',');
+                fieldNamesSb.Append(plan[i].Name);
+            }
+            context.Response.Headers["X-BMW-Fields"] = fieldNamesSb.ToString();
             context.Response.ContentLength = compressed.Length;
             await context.Response.Body.WriteAsync(compressed, context.RequestAborted);
         }
@@ -246,9 +259,16 @@ public static class BinaryApiHandlers
             // Find aggregation definitions where EntityId matches
             var entityDefs = await DataStoreProvider.Current
                 .QueryAsync<BareMetalWeb.Runtime.EntityDefinition>(null, context.RequestAborted);
-            var entityDef = entityDefs.FirstOrDefault(e =>
-                string.Equals(e.Slug, typeSlug, StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(e.Name?.Replace(' ', '-').ToLowerInvariant(), typeSlug, StringComparison.OrdinalIgnoreCase));
+            BareMetalWeb.Runtime.EntityDefinition? entityDef = null;
+            foreach (var e in entityDefs)
+            {
+                if (string.Equals(e.Slug, typeSlug, StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(e.Name?.Replace(' ', '-').ToLowerInvariant(), typeSlug, StringComparison.OrdinalIgnoreCase))
+                {
+                    entityDef = e;
+                    break;
+                }
+            }
 
             if (entityDef == null)
             {
@@ -262,9 +282,10 @@ public static class BinaryApiHandlers
             {
                 Clauses = { new QueryClause { Field = "EntityId", Operator = QueryOperator.Equals, Value = entityDef.EntityId } }
             };
-            var aggs = (await DataStoreProvider.Current
+            var aggs = new List<BareMetalWeb.Runtime.AggregationDefinition>();
+            foreach (var a in await DataStoreProvider.Current
                 .QueryAsync<BareMetalWeb.Runtime.AggregationDefinition>(aggQuery, context.RequestAborted))
-                .ToList();
+                aggs.Add(a);
 
             context.Response.StatusCode = 200;
             context.Response.ContentType = "application/json";
@@ -596,8 +617,20 @@ public static class BinaryApiHandlers
                 {
                     var userPerms = new HashSet<string>(user.Permissions ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
                     var required = permissionsNeeded.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-                    if (required.Length > 0 && !required.All(userPerms.Contains))
-                        return (null, typeSlug, (403, "Access denied."));
+                    if (required.Length > 0)
+                    {
+                        bool allPresent = true;
+                        foreach (var r in required)
+                        {
+                            if (!userPerms.Contains(r))
+                            {
+                                allPresent = false;
+                                break;
+                            }
+                        }
+                        if (!allPresent)
+                            return (null, typeSlug, (403, "Access denied."));
+                    }
                 }
             }
         }

--- a/BareMetalWeb.Host/CheckoutApiHandlers.cs
+++ b/BareMetalWeb.Host/CheckoutApiHandlers.cs
@@ -39,7 +39,12 @@ public static class CheckoutApiHandlers
         bqd.Clauses.Add(new QueryClause { Field = "UserId", Operator = QueryOperator.Equals, Value = userId });
         bqd.Clauses.Add(new QueryClause { Field = "Status", Operator = QueryOperator.Equals, Value = "Open" });
         var baskets = await basketMeta.Handlers.QueryAsync(bqd, context.RequestAborted);
-        var basket = baskets.Cast<Basket>().FirstOrDefault();
+        Basket? basket = null;
+        foreach (var obj in baskets)
+        {
+            basket = (Basket)obj;
+            break;
+        }
         if (basket == null)
         {
             context.Response.StatusCode = 400;
@@ -50,7 +55,10 @@ public static class CheckoutApiHandlers
         // Load items
         var iqd = new QueryDefinition();
         iqd.Clauses.Add(new QueryClause { Field = "BasketId", Operator = QueryOperator.Equals, Value = basket.Key.ToString() });
-        var items = (await itemMeta.Handlers.QueryAsync(iqd, context.RequestAborted)).Cast<BasketItem>().ToList();
+        var itemResults = await itemMeta.Handlers.QueryAsync(iqd, context.RequestAborted);
+        var items = new List<BasketItem>();
+        foreach (var obj in itemResults)
+            items.Add((BasketItem)obj);
         if (items.Count == 0)
         {
             context.Response.StatusCode = 400;
@@ -74,11 +82,16 @@ public static class CheckoutApiHandlers
         order.Email = email;
         order.ShippingAddress = address;
         order.PaymentMethod = Enum.TryParse<PaymentMethod>(method, true, out var pmEnum) ? pmEnum : PaymentMethod.Stripe;
-        order.Subtotal = items.Sum(i => i.LineTotal);
+        decimal subtotal = 0;
+        foreach (var i in items) subtotal += i.LineTotal;
+        order.Subtotal = subtotal;
         order.Tax = Math.Round(order.Subtotal * 0.20m, 2); // 20% tax (configurable in future)
         order.Total = order.Subtotal + order.Tax;
         order.ItemCount = items.Count;
-        order.ItemsJson = JsonSerializer.Serialize(items.Select(i => new { i.ProductId, i.ProductName, i.Quantity, i.UnitPrice, i.LineTotal }));
+        var itemsSummary = new List<object>(items.Count);
+        foreach (var i in items)
+            itemsSummary.Add(new { i.ProductId, i.ProductName, i.Quantity, i.UnitPrice, i.LineTotal });
+        order.ItemsJson = JsonSerializer.Serialize(itemsSummary);
         order.PlacedAtUtc = DateTime.UtcNow;
         order.Status = OrderStatus.Pending;
         await orderMeta.Handlers.SaveAsync(order, context.RequestAborted);

--- a/BareMetalWeb.Host/ClientRequestTracker.cs
+++ b/BareMetalWeb.Host/ClientRequestTracker.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
+
 using System.Threading;
 using System.Threading.Tasks;
 using BareMetalWeb.Core.Interfaces;
@@ -128,50 +128,82 @@ public sealed class ClientRequestTracker : IClientRequestTracker
 
     public IReadOnlyList<KeyValuePair<string, ClientRequestStats>> GetTopClients(int count)
     {
-        return _stats
-            .OrderByDescending(kvp => kvp.Value.Count)
-            .ThenByDescending(kvp => kvp.Value.LastSeenUtc)
-            .Take(count)
-            .ToList();
+        var list = new List<KeyValuePair<string, ClientRequestStats>>(_stats);
+        list.Sort((a, b) =>
+        {
+            int cmp = b.Value.Count.CompareTo(a.Value.Count);
+            if (cmp != 0) return cmp;
+            return b.Value.LastSeenUtc.CompareTo(a.Value.LastSeenUtc);
+        });
+        if (list.Count > count)
+            list.RemoveRange(count, list.Count - count);
+        return list;
     }
 
     public void GetTopClientsTable(int count, out string[] tableColumns, out string[][] tableRows)
     {
         var top = GetTopClients(count);
         tableColumns = new[] { "IP Address", "Requests", "Last Seen (UTC)" };
-        tableRows = top.Count == 0
-            ? new[] { new[] { "No requests recorded.", "", "" } }
-            : top.Select(kvp => new[]
+        if (top.Count == 0)
+        {
+            tableRows = new[] { new[] { "No requests recorded.", "", "" } };
+        }
+        else
+        {
+            tableRows = new string[top.Count][];
+            for (int i = 0; i < top.Count; i++)
             {
-                kvp.Key,
-                kvp.Value.Count.ToString(),
-                kvp.Value.LastSeenUtc.ToString("O")
-            }).ToArray();
+                tableRows[i] = new[]
+                {
+                    top[i].Key,
+                    top[i].Value.Count.ToString(),
+                    top[i].Value.LastSeenUtc.ToString("O")
+                };
+            }
+        }
     }
 
     public IReadOnlyList<KeyValuePair<string, ClientRequestStats>> GetSuspiciousClients(int count)
     {
         var nowUtc = DateTime.UtcNow;
-        return _stats
-            .Where(kvp => kvp.Value.IsSuspicious || kvp.Value.BlockedUntilUtc > nowUtc)
-            .OrderByDescending(kvp => kvp.Value.Count)
-            .ThenByDescending(kvp => kvp.Value.LastSeenUtc)
-            .Take(count)
-            .ToList();
+        var filtered = new List<KeyValuePair<string, ClientRequestStats>>();
+        foreach (var kvp in _stats)
+        {
+            if (kvp.Value.IsSuspicious || kvp.Value.BlockedUntilUtc > nowUtc)
+                filtered.Add(kvp);
+        }
+        filtered.Sort((a, b) =>
+        {
+            int cmp = b.Value.Count.CompareTo(a.Value.Count);
+            if (cmp != 0) return cmp;
+            return b.Value.LastSeenUtc.CompareTo(a.Value.LastSeenUtc);
+        });
+        if (filtered.Count > count)
+            filtered.RemoveRange(count, filtered.Count - count);
+        return filtered;
     }
 
     public void GetSuspiciousClientsTable(int count, out string[] tableColumns, out string[][] tableRows)
     {
         var suspicious = GetSuspiciousClients(count);
         tableColumns = new[] { "IP Address", "Requests", "Last Seen (UTC)" };
-        tableRows = suspicious.Count == 0
-            ? new[] { new[] { "No suspicious IPs recorded.", "", "" } }
-            : suspicious.Select(kvp => new[]
+        if (suspicious.Count == 0)
+        {
+            tableRows = new[] { new[] { "No suspicious IPs recorded.", "", "" } };
+        }
+        else
+        {
+            tableRows = new string[suspicious.Count][];
+            for (int i = 0; i < suspicious.Count; i++)
             {
-                kvp.Key,
-                kvp.Value.Count.ToString(),
-                kvp.Value.LastSeenUtc.ToString("O")
-            }).ToArray();
+                tableRows[i] = new[]
+                {
+                    suspicious[i].Key,
+                    suspicious[i].Value.Count.ToString(),
+                    suspicious[i].Value.LastSeenUtc.ToString("O")
+                };
+            }
+        }
     }
 
     public async Task RunPruningAsync(CancellationToken token)
@@ -213,9 +245,12 @@ public sealed class ClientRequestTracker : IClientRequestTracker
         if (overflow <= 0)
             return pruned;
 
-        foreach (var kvp in _stats.OrderBy(k => k.Value.LastSeenUtc).Take(overflow))
+        var list = new List<KeyValuePair<string, ClientRequestStats>>(_stats);
+        list.Sort((a, b) => a.Value.LastSeenUtc.CompareTo(b.Value.LastSeenUtc));
+        int removeCount = Math.Min(overflow, list.Count);
+        for (int i = 0; i < removeCount; i++)
         {
-            if (_stats.TryRemove(kvp.Key, out _))
+            if (_stats.TryRemove(list[i].Key, out _))
                 pruned++;
         }
 

--- a/BareMetalWeb.Host/DeltaApiHandlers.cs
+++ b/BareMetalWeb.Host/DeltaApiHandlers.cs
@@ -252,7 +252,7 @@ public static class DeltaApiHandlers
             FieldType.Float32 => (float)el.GetDouble(),
             FieldType.Float64 => el.GetDouble(),
             FieldType.Decimal => el.GetDecimal(),
-            FieldType.Char => el.GetString()?.FirstOrDefault() ?? '\0',
+            FieldType.Char => el.GetString() is { Length: > 0 } charStr ? charStr[0] : '\0',
             FieldType.StringUtf8 => el.GetString(),
             FieldType.Guid => Guid.Parse(el.GetString()!),
             FieldType.DateTime => DateTime.Parse(el.GetString()!),

--- a/BareMetalWeb.Host/EntraIdService.cs
+++ b/BareMetalWeb.Host/EntraIdService.cs
@@ -264,7 +264,9 @@ public static class EntraIdService
             }
         }
 
-        user.Permissions = permissions.ToArray();
+        var permArray = new string[permissions.Count];
+        permissions.CopyTo(permArray);
+        user.Permissions = permArray;
         user.IsActive = true;
 
         await Users.SaveAsync(user, cancellationToken).ConfigureAwait(false);

--- a/BareMetalWeb.Host/GraphQLHandler.cs
+++ b/BareMetalWeb.Host/GraphQLHandler.cs
@@ -229,7 +229,16 @@ public static class GraphQLHandler
         var row = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
 
         // Always include id if requested or no selection
-        if (selectedFields.Count == 0 || selectedFields.Any(f => f.Equals("id", StringComparison.OrdinalIgnoreCase)))
+        bool hasIdField = false;
+        foreach (var sf in selectedFields)
+        {
+            if (sf.Equals("id", StringComparison.OrdinalIgnoreCase))
+            {
+                hasIdField = true;
+                break;
+            }
+        }
+        if (selectedFields.Count == 0 || hasIdField)
         {
             if (item is BaseDataObject bdo) row["id"] = bdo.Key;
         }
@@ -237,9 +246,20 @@ public static class GraphQLHandler
         foreach (var f in meta.Fields)
         {
             var camel = ToCamel(f.Name);
-            if (selectedFields.Count > 0 && !selectedFields.Any(s => s.Equals(camel, StringComparison.OrdinalIgnoreCase)
-                                                                   || s.Equals(f.Name, StringComparison.OrdinalIgnoreCase)))
-                continue;
+            if (selectedFields.Count > 0)
+            {
+                bool fieldSelected = false;
+                foreach (var s in selectedFields)
+                {
+                    if (s.Equals(camel, StringComparison.OrdinalIgnoreCase)
+                        || s.Equals(f.Name, StringComparison.OrdinalIgnoreCase))
+                    {
+                        fieldSelected = true;
+                        break;
+                    }
+                }
+                if (!fieldSelected) continue;
+            }
 
             try { row[camel] = f.GetValueFn(item)?.ToString(); }
             catch { row[camel] = null; }

--- a/BareMetalWeb.Host/LookupApiHandlers.cs
+++ b/BareMetalWeb.Host/LookupApiHandlers.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
+
 using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -43,7 +43,7 @@ public static class LookupApiHandlers
         }
 
         var traverse = context.Request.Query.TryGetValue("traverseRelationships", out var tvVal)
-            && string.Equals(tvVal.FirstOrDefault(), "true", StringComparison.OrdinalIgnoreCase);
+            && string.Equals(tvVal.Count > 0 ? tvVal[0] : null, "true", StringComparison.OrdinalIgnoreCase);
 
         try
         {
@@ -91,7 +91,7 @@ public static class LookupApiHandlers
         }
 
         var traverse = context.Request.Query.TryGetValue("traverseRelationships", out var tvVal)
-            && string.Equals(tvVal.FirstOrDefault(), "true", StringComparison.OrdinalIgnoreCase);
+            && string.Equals(tvVal.Count > 0 ? tvVal[0] : null, "true", StringComparison.OrdinalIgnoreCase);
 
         try
         {
@@ -139,13 +139,17 @@ public static class LookupApiHandlers
                 return;
             }
 
-            ids = idsElement.EnumerateArray()
-                .Where(e => e.ValueKind == JsonValueKind.String)
-                .Select(e => e.GetString()!)
-                .Where(s => !string.IsNullOrWhiteSpace(s))
-                .Distinct()
-                .Take(500) // Cap batch size to prevent resource exhaustion
-                .ToList();
+            ids = new List<string>();
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var e in idsElement.EnumerateArray())
+            {
+                if (ids.Count >= 500) break;
+                if (e.ValueKind != JsonValueKind.String) continue;
+                var s = e.GetString()!;
+                if (string.IsNullOrWhiteSpace(s)) continue;
+                if (!seen.Add(s)) continue;
+                ids.Add(s);
+            }
         }
         catch (JsonException)
         {
@@ -160,7 +164,7 @@ public static class LookupApiHandlers
         }
 
         var traverse = context.Request.Query.TryGetValue("traverseRelationships", out var tvVal)
-            && string.Equals(tvVal.FirstOrDefault(), "true", StringComparison.OrdinalIgnoreCase);
+            && string.Equals(tvVal.Count > 0 ? tvVal[0] : null, "true", StringComparison.OrdinalIgnoreCase);
 
         try
         {
@@ -218,8 +222,15 @@ public static class LookupApiHandlers
                 return;
             }
 
-            var field = meta.Fields.FirstOrDefault(f => 
-                string.Equals(f.Name, fieldName, StringComparison.OrdinalIgnoreCase) && f.View);
+            DataFieldMetadata? field = null;
+            foreach (var f in meta.Fields)
+            {
+                if (string.Equals(f.Name, fieldName, StringComparison.OrdinalIgnoreCase) && f.View)
+                {
+                    field = f;
+                    break;
+                }
+            }
             
             if (field == null)
             {
@@ -360,7 +371,14 @@ public static class LookupApiHandlers
 
         var userPermissions = new HashSet<string>(user.Permissions ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
         var required = permissionsNeeded.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-        return required.Length == 0 || required.All(userPermissions.Contains);
+        if (required.Length == 0)
+            return true;
+        foreach (var perm in required)
+        {
+            if (!userPermissions.Contains(perm))
+                return false;
+        }
+        return true;
     }
 
     private static string? GetRouteValue(HttpContext context, string key)
@@ -381,9 +399,9 @@ public static class LookupApiHandlers
     {
         var queryDef = new QueryDefinition();
 
-        var viewableFields = new HashSet<string>(
-            meta.ViewFields.Select(f => f.Name),
-            StringComparer.OrdinalIgnoreCase);
+        var viewableFields = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var f in meta.ViewFields)
+            viewableFields.Add(f.Name);
 
         // Parse filters from query string: ?filter=field:value
         var filters = context.Request.Query["filter"];
@@ -470,8 +488,15 @@ public static class LookupApiHandlers
         if (!DataScaffold.TryGetEntity(sourceSlug, out var sourceMeta))
             return false;
 
-        var field = sourceMeta!.Fields.FirstOrDefault(f =>
-            string.Equals(f.Name, sourceFieldName, StringComparison.OrdinalIgnoreCase));
+        DataFieldMetadata? field = null;
+        foreach (var f in sourceMeta!.Fields)
+        {
+            if (string.Equals(f.Name, sourceFieldName, StringComparison.OrdinalIgnoreCase))
+            {
+                field = f;
+                break;
+            }
+        }
 
         if (field?.Lookup == null)
             return false;
@@ -517,8 +542,9 @@ public static class LookupApiHandlers
 
         int traversed = 0;
         const int MaxTraversals = 20; // Cap FK loads per entity to prevent N+1 explosion
-        foreach (var field in meta.Fields.Where(f => f.View && f.Lookup != null))
+        foreach (var field in meta.Fields)
         {
+            if (!field.View || field.Lookup == null) continue;
             if (traversed >= MaxTraversals) break;
 
             if (!result.TryGetValue(field.Name, out var rawValue) || rawValue == null)

--- a/BareMetalWeb.Host/McpRouteHandler.cs
+++ b/BareMetalWeb.Host/McpRouteHandler.cs
@@ -141,10 +141,17 @@ internal static class McpRouteHandler
 
     private static object BuildInitializeResult()
     {
-        var rawVersion = typeof(McpRouteHandler).Assembly
-            .GetCustomAttributes(typeof(System.Reflection.AssemblyInformationalVersionAttribute), false)
-            .Cast<System.Reflection.AssemblyInformationalVersionAttribute>()
-            .FirstOrDefault()?.InformationalVersion ?? "1.0";
+        string? rawVersion = null;
+        foreach (var attr in typeof(McpRouteHandler).Assembly
+            .GetCustomAttributes(typeof(System.Reflection.AssemblyInformationalVersionAttribute), false))
+        {
+            if (attr is System.Reflection.AssemblyInformationalVersionAttribute infoAttr)
+            {
+                rawVersion = infoAttr.InformationalVersion;
+                break;
+            }
+        }
+        rawVersion ??= "1.0";
 
         // Trim SHA suffix (e.g. "1.0.0+abc1234" → "1.0.0")
         var plusIdx = rawVersion.IndexOf('+');
@@ -172,18 +179,26 @@ internal static class McpRouteHandler
             var name = entity.Name;
 
             // Field map for create/update input schemas
-            var writableFields = entity.Fields
-                .Where(f => f.FieldType != FormFieldType.CustomHtml
-                         && f.FieldType != FormFieldType.Button
-                         && f.FieldType != FormFieldType.Link
-                         && !f.ReadOnly)
-                .ToList();
+            var writableFields = new List<DataFieldMetadata>();
+            foreach (var f in entity.Fields)
+            {
+                if (f.FieldType != FormFieldType.CustomHtml
+                    && f.FieldType != FormFieldType.Button
+                    && f.FieldType != FormFieldType.Link
+                    && !f.ReadOnly)
+                {
+                    writableFields.Add(f);
+                }
+            }
 
             var fieldProps = BuildFieldProperties(writableFields);
-            var requiredCreateFields = writableFields
-                .Where(f => f.Required && f.Create)
-                .Select(f => f.Name)
-                .ToArray();
+            var requiredCreateList = new List<string>();
+            foreach (var f in writableFields)
+            {
+                if (f.Required && f.Create)
+                    requiredCreateList.Add(f.Name);
+            }
+            var requiredCreateFields = requiredCreateList.ToArray();
 
             // query_{slug}
             tools.Add(MakeTool(
@@ -329,7 +344,9 @@ internal static class McpRouteHandler
         var query = BuildQueryDefinition(arguments);
         var svc = new QueryService();
         var results = await svc.QueryAsync(slug, query, ct).ConfigureAwait(false);
-        var list = results.ToList();
+        var list = new List<Dictionary<string, object?>>();
+        foreach (var item in results)
+            list.Add(item);
         return BuildToolTextResult(JsonSerializer.Serialize(list, _jsonOptions));
     }
 
@@ -544,8 +561,15 @@ internal static class McpRouteHandler
             return segment;
 
         // Try matching with original slug casing
-        var match = DataScaffold.Entities.FirstOrDefault(e =>
-            string.Equals(ToToolSegment(e.Slug), segment, StringComparison.OrdinalIgnoreCase));
+        DataEntityMetadata? match = null;
+        foreach (var e in DataScaffold.Entities)
+        {
+            if (string.Equals(ToToolSegment(e.Slug), segment, StringComparison.OrdinalIgnoreCase))
+            {
+                match = e;
+                break;
+            }
+        }
 
         return match?.Slug ?? segment;
     }

--- a/BareMetalWeb.Host/OpenApiHandler.cs
+++ b/BareMetalWeb.Host/OpenApiHandler.cs
@@ -35,10 +35,14 @@ internal static class OpenApiHandler
 
         var userPermissions = user?.Permissions ?? Array.Empty<string>();
 
-        var accessibleEntities = DataScaffold.Entities
-            .Where(e => IsEntityAccessible(e, user, userPermissions))
-            .OrderBy(e => e.Slug)
-            .ToArray();
+        var filteredEntities = new List<DataEntityMetadata>();
+        foreach (var e in DataScaffold.Entities)
+        {
+            if (IsEntityAccessible(e, user, userPermissions))
+                filteredEntities.Add(e);
+        }
+        filteredEntities.Sort((a, b) => string.Compare(a.Slug, b.Slug, StringComparison.Ordinal));
+        var accessibleEntities = filteredEntities.ToArray();
 
         var document = BuildDocument(context, accessibleEntities);
 
@@ -283,7 +287,9 @@ internal static class OpenApiHandler
         var properties = new Dictionary<string, object?>(StringComparer.Ordinal);
         var required = new List<string>();
 
-        foreach (var field in entity.Fields.OrderBy(f => f.Order))
+        var sortedFields = new List<DataFieldMetadata>(entity.Fields);
+        sortedFields.Sort((a, b) => a.Order.CompareTo(b.Order));
+        foreach (var field in sortedFields)
         {
             // Skip fields that are not viewable
             if (!field.View && !field.Edit && !field.Create)
@@ -352,10 +358,15 @@ internal static class OpenApiHandler
         if (enumValues.Count == 0)
             return SimpleSchema("string", null);
 
+        var keys = new string[enumValues.Count];
+        var ki = 0;
+        foreach (var kv in enumValues)
+            keys[ki++] = kv.Key;
+
         return new Dictionary<string, object?>
         {
             ["type"] = "string",
-            ["enum"] = enumValues.Select(kv => kv.Key).ToArray()
+            ["enum"] = keys
         };
     }
 
@@ -371,10 +382,20 @@ internal static class OpenApiHandler
     private static Dictionary<string, object?> SchemaRef(string slug) =>
         new() { ["$ref"] = $"#/components/schemas/{SchemaKey(slug)}" };
 
-    private static string SchemaKey(string slug) =>
-        string.Concat(slug.Split('-')
-            .Where(p => p.Length > 0)
-            .Select(p => char.ToUpperInvariant(p[0]) + p[1..]));
+    private static string SchemaKey(string slug)
+    {
+        var parts = slug.Split('-');
+        var sb = new StringBuilder();
+        foreach (var p in parts)
+        {
+            if (p.Length > 0)
+            {
+                sb.Append(char.ToUpperInvariant(p[0]));
+                sb.Append(p, 1, p.Length - 1);
+            }
+        }
+        return sb.ToString();
+    }
 
     private static Dictionary<string, object?> IdParameter() =>
         new()
@@ -478,6 +499,14 @@ internal static class OpenApiHandler
             return user != null;
 
         var required = perms.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-        return required.Any(r => userPermissions.Any(p => string.Equals(p, r, StringComparison.OrdinalIgnoreCase)));
+        foreach (var r in required)
+        {
+            foreach (var p in userPermissions)
+            {
+                if (string.Equals(p, r, StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+        }
+        return false;
     }
 }

--- a/BareMetalWeb.Host/PageRenderer.cs
+++ b/BareMetalWeb.Host/PageRenderer.cs
@@ -62,7 +62,12 @@ public static partial class PageRenderer
             Top = 1
         };
         var pages = await meta.Handlers.QueryAsync(queryDef, context.RequestAborted);
-        BaseDataObject? pageObj = pages.FirstOrDefault();
+        BaseDataObject? pageObj = null;
+        foreach (var p in pages)
+        {
+            pageObj = p;
+            break;
+        }
 
         if (pageObj == null)
         {
@@ -239,8 +244,15 @@ public static partial class PageRenderer
 
     private static string GetField(BaseDataObject obj, DataEntityMetadata meta, string fieldName)
     {
-        var field = meta.Fields.FirstOrDefault(f =>
-            string.Equals(f.Name, fieldName, StringComparison.OrdinalIgnoreCase));
+        BareMetalWeb.Core.DataFieldMetadata? field = null;
+        foreach (var f in meta.Fields)
+        {
+            if (string.Equals(f.Name, fieldName, StringComparison.OrdinalIgnoreCase))
+            {
+                field = f;
+                break;
+            }
+        }
         return field?.GetValueFn?.Invoke(obj)?.ToString() ?? string.Empty;
     }
 }

--- a/BareMetalWeb.Host/ProductRenderer.cs
+++ b/BareMetalWeb.Host/ProductRenderer.cs
@@ -215,8 +215,15 @@ public static class ProductRenderer
 
     private static string GetField(BaseDataObject obj, DataEntityMetadata meta, string fieldName)
     {
-        var field = meta.Fields.FirstOrDefault(f =>
-            string.Equals(f.Name, fieldName, StringComparison.OrdinalIgnoreCase));
+        BareMetalWeb.Core.DataFieldMetadata? field = null;
+        foreach (var f in meta.Fields)
+        {
+            if (string.Equals(f.Name, fieldName, StringComparison.OrdinalIgnoreCase))
+            {
+                field = f;
+                break;
+            }
+        }
         return field?.GetValueFn?.Invoke(obj)?.ToString() ?? string.Empty;
     }
 

--- a/BareMetalWeb.Host/Program.cs
+++ b/BareMetalWeb.Host/Program.cs
@@ -88,7 +88,12 @@ await app.UseBareMetalWeb(configureRoutes: (appInfo, routeHandlers, pageInfoFact
             return;
         }
         var queryDef = new BareMetalWeb.Data.QueryDefinition { Clauses = new() { new BareMetalWeb.Data.QueryClause { Field = "DeviceCode", Operator = BareMetalWeb.Data.QueryOperator.Equals, Value = deviceCode } }, Top = 1 };
-        var dc = (await DataStoreProvider.Current.QueryAsync<DeviceCodeAuth>(queryDef)).FirstOrDefault();
+        DeviceCodeAuth? dc = null;
+        foreach (var item in await DataStoreProvider.Current.QueryAsync<DeviceCodeAuth>(queryDef))
+        {
+            dc = item;
+            break;
+        }
         if (dc == null || dc.IsExpired(DateTime.UtcNow))
         {
             context.Response.ContentType = "application/json";
@@ -180,7 +185,15 @@ await app.UseBareMetalWeb(configureRoutes: (appInfo, routeHandlers, pageInfoFact
         }
         var queryDef = new BareMetalWeb.Data.QueryDefinition { Clauses = new() { new BareMetalWeb.Data.QueryClause { Field = "UserCode", Operator = BareMetalWeb.Data.QueryOperator.Equals, Value = code } }, Top = 10 };
         var candidates = await DataStoreProvider.Current.QueryAsync<DeviceCodeAuth>(queryDef);
-        var dc = candidates.FirstOrDefault(d => d.Status == "pending" && !d.IsExpired(DateTime.UtcNow));
+        DeviceCodeAuth? dc = null;
+        foreach (var d in candidates)
+        {
+            if (d.Status == "pending" && !d.IsExpired(DateTime.UtcNow))
+            {
+                dc = d;
+                break;
+            }
+        }
         if (dc == null)
         {
             context.Response.Redirect($"/device?msg=Error:+Invalid+or+expired+code&code={System.Net.WebUtility.UrlEncode(code)}");
@@ -195,60 +208,84 @@ await app.UseBareMetalWeb(configureRoutes: (appInfo, routeHandlers, pageInfoFact
     appInfo.RegisterRoute("GET /api/_meta", new RouteHandlerData(pageInfoFactory.RawPage("Authenticated", false), async context =>
     {
         var entities = DataScaffold.Entities;
-        var result = entities.Select(e => new Dictionary<string, object?>
+        var resultList = new List<Dictionary<string, object?>>();
+        foreach (var e in entities)
         {
-            ["name"] = e.Name,
-            ["slug"] = e.Slug,
-            ["permissions"] = e.Permissions,
-            ["showOnNav"] = e.ShowOnNav,
-            ["navGroup"] = e.NavGroup,
-            ["navOrder"] = e.NavOrder,
-            ["viewType"] = e.ViewType.ToString(),
-            ["parentField"] = e.ParentField?.Name,
-            ["commands"] = e.Commands.Select(c => new Dictionary<string, object?>
+            var commandsList = new List<Dictionary<string, object?>>();
+            foreach (var c in e.Commands)
             {
-                ["name"] = c.Name,
-                ["label"] = c.Label,
-                ["icon"] = c.Icon,
-                ["confirmMessage"] = c.ConfirmMessage,
-                ["destructive"] = c.Destructive,
-                ["order"] = c.Order
-            }).ToArray(),
-            ["fields"] = e.Fields.Select(f => new Dictionary<string, object?>
-            {
-                ["name"] = f.Name,
-                ["label"] = f.Label,
-                ["type"] = f.FieldType.ToString(),
-                ["order"] = f.Order,
-                ["required"] = f.Required,
-                ["list"] = f.List,
-                ["view"] = f.View,
-                ["edit"] = f.Edit,
-                ["create"] = f.Create,
-                ["readOnly"] = f.ReadOnly,
-                ["placeholder"] = f.Placeholder,
-                ["isComputed"] = f.Computed != null,
-                ["isCalculated"] = f.Calculated != null,
-                ["lookupTargetSlug"] = f.Lookup != null ? DataScaffold.GetEntityByType(f.Lookup.TargetType)?.Slug : null,
-                ["lookupValueField"] = f.Lookup?.ValueField,
-                ["lookupDisplayField"] = f.Lookup?.DisplayField,
-                ["lookupFilterField"] = f.Lookup?.QueryField,
-                ["lookupFilterValue"] = f.Lookup?.QueryValue,
-                ["enumValues"] = f.FieldType == FormFieldType.Enum
-                    ? DataScaffold.BuildEnumOptions(f.Property.PropertyType)
-                        .Select(kv => new { value = kv.Key, label = kv.Value })
-                        .ToArray()
-                    : null,
-                ["upload"] = f.Upload == null ? null : new Dictionary<string, object?>
+                commandsList.Add(new Dictionary<string, object?>
                 {
-                    ["maxFileSizeBytes"] = f.Upload.MaxFileSizeBytes,
-                    ["allowedMimeTypes"] = f.Upload.AllowedMimeTypes,
-                    ["maxImageWidth"] = f.Upload.MaxImageWidth,
-                    ["maxImageHeight"] = f.Upload.MaxImageHeight,
-                    ["generateThumbnail"] = f.Upload.GenerateThumbnail
+                    ["name"] = c.Name,
+                    ["label"] = c.Label,
+                    ["icon"] = c.Icon,
+                    ["confirmMessage"] = c.ConfirmMessage,
+                    ["destructive"] = c.Destructive,
+                    ["order"] = c.Order
+                });
+            }
+
+            var fieldsList = new List<Dictionary<string, object?>>();
+            foreach (var f in e.Fields)
+            {
+                object? enumValues = null;
+                if (f.FieldType == FormFieldType.Enum)
+                {
+                    var enumOptionsList = new List<object>();
+                    foreach (var kv in DataScaffold.BuildEnumOptions(f.Property.PropertyType))
+                    {
+                        enumOptionsList.Add(new { value = kv.Key, label = kv.Value });
+                    }
+                    enumValues = enumOptionsList.ToArray();
                 }
-            }).ToArray()
-        }).ToArray();
+
+                fieldsList.Add(new Dictionary<string, object?>
+                {
+                    ["name"] = f.Name,
+                    ["label"] = f.Label,
+                    ["type"] = f.FieldType.ToString(),
+                    ["order"] = f.Order,
+                    ["required"] = f.Required,
+                    ["list"] = f.List,
+                    ["view"] = f.View,
+                    ["edit"] = f.Edit,
+                    ["create"] = f.Create,
+                    ["readOnly"] = f.ReadOnly,
+                    ["placeholder"] = f.Placeholder,
+                    ["isComputed"] = f.Computed != null,
+                    ["isCalculated"] = f.Calculated != null,
+                    ["lookupTargetSlug"] = f.Lookup != null ? DataScaffold.GetEntityByType(f.Lookup.TargetType)?.Slug : null,
+                    ["lookupValueField"] = f.Lookup?.ValueField,
+                    ["lookupDisplayField"] = f.Lookup?.DisplayField,
+                    ["lookupFilterField"] = f.Lookup?.QueryField,
+                    ["lookupFilterValue"] = f.Lookup?.QueryValue,
+                    ["enumValues"] = enumValues,
+                    ["upload"] = f.Upload == null ? null : new Dictionary<string, object?>
+                    {
+                        ["maxFileSizeBytes"] = f.Upload.MaxFileSizeBytes,
+                        ["allowedMimeTypes"] = f.Upload.AllowedMimeTypes,
+                        ["maxImageWidth"] = f.Upload.MaxImageWidth,
+                        ["maxImageHeight"] = f.Upload.MaxImageHeight,
+                        ["generateThumbnail"] = f.Upload.GenerateThumbnail
+                    }
+                });
+            }
+
+            resultList.Add(new Dictionary<string, object?>
+            {
+                ["name"] = e.Name,
+                ["slug"] = e.Slug,
+                ["permissions"] = e.Permissions,
+                ["showOnNav"] = e.ShowOnNav,
+                ["navGroup"] = e.NavGroup,
+                ["navOrder"] = e.NavOrder,
+                ["viewType"] = e.ViewType.ToString(),
+                ["parentField"] = e.ParentField?.Name,
+                ["commands"] = commandsList.ToArray(),
+                ["fields"] = fieldsList.ToArray()
+            });
+        }
+        var result = resultList.ToArray();
         context.Response.ContentType = "application/json";
         await context.Response.WriteAsync(JsonSerializer.Serialize(result, new JsonSerializerOptions { WriteIndented = true }));
     }));
@@ -292,7 +329,12 @@ await app.UseBareMetalWeb(configureRoutes: (appInfo, routeHandlers, pageInfoFact
             walProvider.SaveRecord(record, schema);
         }
 
-        var todos = walProvider.QueryRecords(schema).ToList();
+        var todosEnumerable = walProvider.QueryRecords(schema);
+        var todos = new List<BareMetalWeb.Data.DataRecord>();
+        foreach (var todo in todosEnumerable)
+        {
+            todos.Add(todo);
+        }
         var sb = new System.Text.StringBuilder();
         sb.Append("<!DOCTYPE html><html><head><meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">");
         sb.Append("<title>Ideas</title><style>");
@@ -497,19 +539,33 @@ static class ProgramSetup
             }
         };
 
-        var users = (await DataStoreProvider.Current.QueryAsync<User>(query, cancellationToken).ConfigureAwait(false)).ToList();
+        var usersEnumerable = await DataStoreProvider.Current.QueryAsync<User>(query, cancellationToken).ConfigureAwait(false);
+        var users = new List<User>();
+        foreach (var u in usersEnumerable)
+        {
+            users.Add(u);
+        }
         foreach (var user in users)
         {
             if (user is null || !user.IsActive)
                 continue;
 
-            var perms = user.Permissions?.ToList() ?? new List<string>();
+            var perms = user.Permissions != null ? new List<string>(user.Permissions) : new List<string>();
             var changed = false;
             foreach (var required in requiredPermissions)
             {
                 if (string.IsNullOrWhiteSpace(required))
                     continue;
-                if (perms.Any(p => string.Equals(p, required, StringComparison.OrdinalIgnoreCase)))
+                bool alreadyHasPerm = false;
+                foreach (var p in perms)
+                {
+                    if (string.Equals(p, required, StringComparison.OrdinalIgnoreCase))
+                    {
+                        alreadyHasPerm = true;
+                        break;
+                    }
+                }
+                if (alreadyHasPerm)
                     continue;
                 perms.Add(required);
                 changed = true;
@@ -609,7 +665,12 @@ static class ProgramSetup
             appInfo.RegisterRoute("GET /proxy/status", new RouteHandlerData(pageInfoFactory.RawPage("admin", false), async context =>
             {
                 context.Response.ContentType = "application/json";
-                var status = proxyHandlers.Select(handler => handler.GetStatus()).ToArray();
+                var statusList = new List<ProxyRouteStatus>();
+                foreach (var handler in proxyHandlers)
+                {
+                    statusList.Add(handler.GetStatus());
+                }
+                var status = statusList.ToArray();
 
                 await using var stream = context.Response.Body;
                 using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = true });

--- a/BareMetalWeb.Host/ProxyRouteHandler.cs
+++ b/BareMetalWeb.Host/ProxyRouteHandler.cs
@@ -305,16 +305,38 @@ public sealed class ProxyRouteHandler
                 && string.Equals(_route.StickySessionMode, "Cookie", StringComparison.OrdinalIgnoreCase)
                 && string.Equals(header.Key, _route.StickySessionKeyName, StringComparison.OrdinalIgnoreCase))
                 continue;
-            if (_route.RemoveHeaders.Contains(header.Key, StringComparer.OrdinalIgnoreCase))
+            if (ListContainsIgnoreCase(_route.RemoveHeaders, header.Key))
                 continue;
 
             if (ContainsCrlf(header.Key))
                 continue;
 
             var rawValues = header.Value.ToArray();
-            var safeValues = rawValues.Any(ContainsCrlf)
-                ? rawValues.Where(v => !ContainsCrlf(v)).ToArray()
-                : rawValues;
+            bool hasCrlf = false;
+            for (int i = 0; i < rawValues.Length; i++)
+            {
+                if (ContainsCrlf(rawValues[i]))
+                {
+                    hasCrlf = true;
+                    break;
+                }
+            }
+
+            string?[] safeValues;
+            if (hasCrlf)
+            {
+                var filtered = new List<string?>();
+                for (int i = 0; i < rawValues.Length; i++)
+                {
+                    if (!ContainsCrlf(rawValues[i]))
+                        filtered.Add(rawValues[i]);
+                }
+                safeValues = filtered.ToArray();
+            }
+            else
+            {
+                safeValues = rawValues;
+            }
             if (safeValues.Length == 0)
                 continue;
 
@@ -391,9 +413,9 @@ public sealed class ProxyRouteHandler
             if (HopByHopHeaders.Contains(header.Key))
                 continue;
 
-            if (!context.Response.Headers.TryAdd(header.Key, new StringValues(header.Value.ToArray())))
+            if (!context.Response.Headers.TryAdd(header.Key, new StringValues(EnumerableToArray(header.Value))))
             {
-                context.Response.Headers[header.Key] = new StringValues(header.Value.ToArray());
+                context.Response.Headers[header.Key] = new StringValues(EnumerableToArray(header.Value));
             }
         }
 
@@ -402,9 +424,9 @@ public sealed class ProxyRouteHandler
             if (HopByHopHeaders.Contains(header.Key))
                 continue;
 
-            if (!context.Response.Headers.TryAdd(header.Key, new StringValues(header.Value.ToArray())))
+            if (!context.Response.Headers.TryAdd(header.Key, new StringValues(EnumerableToArray(header.Value))))
             {
-                context.Response.Headers[header.Key] = new StringValues(header.Value.ToArray());
+                context.Response.Headers[header.Key] = new StringValues(EnumerableToArray(header.Value));
             }
         }
 
@@ -532,9 +554,22 @@ public sealed class ProxyRouteHandler
             return null;
 
         var now = DateTimeOffset.UtcNow;
-        var available = _targets.Where(t => !t.IsOffline(now)).ToList();
+        var available = new List<ProxyTargetState>();
+        for (int i = 0; i < _targets.Count; i++)
+        {
+            if (!_targets[i].IsOffline(now))
+                available.Add(_targets[i]);
+        }
         if (exclude != null && exclude.Count > 0)
-            available = available.Where(t => !exclude.Contains(t)).ToList();
+        {
+            var filtered = new List<ProxyTargetState>();
+            for (int i = 0; i < available.Count; i++)
+            {
+                if (!exclude.Contains(available[i]))
+                    filtered.Add(available[i]);
+            }
+            available = filtered;
+        }
         if (available.Count == 0)
             return null;
 
@@ -556,12 +591,19 @@ public sealed class ProxyRouteHandler
     private bool HasAvailableTargets(HashSet<ProxyTargetState> attempted)
     {
         var now = DateTimeOffset.UtcNow;
-        return _targets.Any(t => !t.IsOffline(now) && !attempted.Contains(t));
+        for (int i = 0; i < _targets.Count; i++)
+        {
+            if (!_targets[i].IsOffline(now) && !attempted.Contains(_targets[i]))
+                return true;
+        }
+        return false;
     }
 
     private ProxyTargetState? SelectTargetByWeight(List<ProxyTargetState> available)
     {
-        var totalWeight = available.Sum(t => t.Weight);
+        int totalWeight = 0;
+        for (int i = 0; i < available.Count; i++)
+            totalWeight += available[i].Weight;
         if (totalWeight <= 0)
             return available[0];
 
@@ -579,7 +621,9 @@ public sealed class ProxyRouteHandler
 
     private ProxyTargetState? SelectTargetByHash(List<ProxyTargetState> available, string key)
     {
-        var totalWeight = available.Sum(t => t.Weight);
+        int totalWeight = 0;
+        for (int i = 0; i < available.Count; i++)
+            totalWeight += available[i].Weight;
         if (totalWeight <= 0)
             return available[0];
 
@@ -653,12 +697,15 @@ public sealed class ProxyRouteHandler
     public ProxyRouteStatus GetStatus()
     {
         var now = DateTimeOffset.UtcNow;
+        var snapshots = new ProxyTargetStatus[_targets.Count];
+        for (int i = 0; i < _targets.Count; i++)
+            snapshots[i] = _targets[i].Snapshot(now);
         return new ProxyRouteStatus
         {
             Route = _route.Route,
             MatchMode = _route.MatchMode,
             LoadBalance = _route.LoadBalance,
-            Targets = _targets.Select(t => t.Snapshot(now)).ToArray()
+            Targets = snapshots
         };
     }
 
@@ -700,5 +747,23 @@ public sealed class ProxyRouteHandler
             target.TakeOffline(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(_route.OfflineSeconds));
             _logger.LogError($"Proxy target {target.BaseUri} taken offline due to failure rate.", exception ?? new Exception("Proxy failure rate exceeded."));
         }
+    }
+
+    private static bool ListContainsIgnoreCase(List<string> list, string value)
+    {
+        for (int i = 0; i < list.Count; i++)
+        {
+            if (string.Equals(list[i], value, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
+    }
+
+    private static string[] EnumerableToArray(IEnumerable<string> values)
+    {
+        var list = new List<string>();
+        foreach (var v in values)
+            list.Add(v);
+        return list.ToArray();
     }
 }

--- a/BareMetalWeb.Host/ReportHtmlRenderer.cs
+++ b/BareMetalWeb.Host/ReportHtmlRenderer.cs
@@ -326,8 +326,15 @@ public static class ReportHtmlRenderer
         if (!BareMetalWeb.Core.DataScaffold.TryGetEntity(entitySlug, out var meta))
             return Array.Empty<string>();
 
-        var field = meta.Fields.FirstOrDefault(f =>
-            string.Equals(f.Name, fieldName, StringComparison.OrdinalIgnoreCase));
+        BareMetalWeb.Core.DataFieldMetadata? field = null;
+        foreach (var f in meta.Fields)
+        {
+            if (string.Equals(f.Name, fieldName, StringComparison.OrdinalIgnoreCase))
+            {
+                field = f;
+                break;
+            }
+        }
         if (field == null) return Array.Empty<string>();
 
         var getter = field.GetValueFn;
@@ -348,6 +355,8 @@ public static class ReportHtmlRenderer
             }
         }
 
-        return distinct.ToArray();
+        var distinctArray = new string[distinct.Count];
+        distinct.CopyTo(distinctArray);
+        return distinctArray;
     }
 }

--- a/BareMetalWeb.Host/RouteHandlers.cs
+++ b/BareMetalWeb.Host/RouteHandlers.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using System.IO;
 using System.IO.Compression;
 using System.Globalization;
@@ -864,7 +863,10 @@ public sealed class RouteHandlers : IRouteHandlers
             RegisterSuccess(BuildMfaAttemptKey("setup:secret", currentPendingSecret));
 
             context.SetStringValue("title", "Enable MFA");
-            var backupList = string.Join(string.Empty, backupCodes.Codes.Select(codeValue => $"<li><code>{WebUtility.HtmlEncode(codeValue)}</code></li>"));
+            var backupListBuilder = new StringBuilder();
+            foreach (var codeValue in backupCodes.Codes)
+                backupListBuilder.Append($"<li><code>{WebUtility.HtmlEncode(codeValue)}</code></li>");
+            var backupList = backupListBuilder.ToString();
             var backupHtml = string.IsNullOrWhiteSpace(backupList)
                 ? string.Empty
                 : $"<div class=\"mt-3\"><p><strong>Backup codes (save these now):</strong></p><ul>{backupList}</ul><p class=\"text-warning\">These codes are shown once.</p></div>";
@@ -1110,9 +1112,9 @@ public sealed class RouteHandlers : IRouteHandlers
     private async ValueTask EnsureDefaultReports(string createdBy)
     {
         var existing = await DataStoreProvider.Current.QueryAsync<ReportDefinition>(null).ConfigureAwait(false);
-        var existingNames = new HashSet<string>(
-            existing.Select(r => r.Name),
-            StringComparer.OrdinalIgnoreCase);
+        var existingNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var r in existing)
+            existingNames.Add(r.Name);
 
         var reports = new List<ReportDefinition>
         {
@@ -1611,17 +1613,24 @@ public sealed class RouteHandlers : IRouteHandlers
             ctx.SetStringValue("title", "Data");
             ctx.SetStringValue("html_message", "<p>Manage data entities.</p>");
 
-            var rows = DataScaffold.Entities
-                .OrderBy(e => e.NavOrder)
-                .ThenBy(e => e.Name)
-                .Select(entity => new[]
+            var sortedEntities = new List<DataEntityMetadata>(DataScaffold.Entities);
+            sortedEntities.Sort((a, b) =>
+            {
+                int cmp = a.NavOrder.CompareTo(b.NavOrder);
+                return cmp != 0 ? cmp : string.Compare(a.Name, b.Name, StringComparison.Ordinal);
+            });
+            var rowsList = new List<string[]>();
+            foreach (var entity in sortedEntities)
+            {
+                rowsList.Add(new[]
                 {
                     $"<a class=\"btn btn-sm btn-outline-info me-1\" href=\"/ssr/admin/data/{entity.Slug}\" title=\"Open\" aria-label=\"Open\"><i class=\"bi bi-search\" aria-hidden=\"true\"></i></a><a class=\"btn btn-sm btn-outline-success\" href=\"/ssr/admin/data/{entity.Slug}/import\" title=\"Import CSV\" aria-label=\"Import CSV\"><i class=\"bi bi-upload\" aria-hidden=\"true\"></i></a>",
                     WebUtility.HtmlEncode(entity.Name),
                     WebUtility.HtmlEncode(entity.Slug),
                     string.IsNullOrWhiteSpace(entity.Permissions) ? "Public" : WebUtility.HtmlEncode(entity.Permissions)
-                })
-                .ToArray();
+                });
+            }
+            var rows = rowsList.ToArray();
 
             ctx.AddTable(new[] { "Actions", "Entity", "Slug", "Permissions" }, rows);
         })(context);
@@ -1663,7 +1672,13 @@ public sealed class RouteHandlers : IRouteHandlers
                 return false;
             var userPermissions = new HashSet<string>(currentUser.Permissions ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
             var required = permissionsNeeded.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-            return required.Length == 0 || required.All(userPermissions.Contains);
+            if (required.Length == 0) return true;
+            foreach (var r in required)
+            {
+                if (!userPermissions.Contains(r))
+                    return false;
+            }
+            return true;
         }
 
         var queryDictionary = ToQueryDictionary(context.Request.Query);
@@ -1695,7 +1710,10 @@ public sealed class RouteHandlers : IRouteHandlers
         {
             var allQuery = DataScaffold.BuildQueryDefinition(queryDictionary, meta);
             allQuery.Top ??= 10000; // Cap to prevent unbounded memory usage
-            var allResults = (await DataScaffold.QueryAsync(meta, allQuery)).Cast<BaseDataObject>().ToList();
+            var allResultsRaw = await DataScaffold.QueryAsync(meta, allQuery);
+            var allResults = new List<BaseDataObject>();
+            foreach (var item in allResultsRaw)
+                allResults.Add((BaseDataObject)item);
             
             var basePath = $"/ssr/admin/data/{typeSlug}";
 
@@ -1850,7 +1868,13 @@ public sealed class RouteHandlers : IRouteHandlers
                 return false;
             var userPermissions = new HashSet<string>(currentUser.Permissions ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
             var required = permissionsNeeded.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-            return required.Length == 0 || required.All(userPermissions.Contains);
+            if (required.Length == 0) return true;
+            foreach (var r in required)
+            {
+                if (!userPermissions.Contains(r))
+                    return false;
+            }
+            return true;
         }
 
         var instance = await DataScaffold.LoadAsync(meta, uint.Parse(id));
@@ -1863,13 +1887,17 @@ public sealed class RouteHandlers : IRouteHandlers
             return;
         }
 
-        var rows = DataScaffold.BuildViewRowsHtml(meta, instance, HasPermissionForMeta)
-            .Select(row => new[]
+        var viewRowsHtml = DataScaffold.BuildViewRowsHtml(meta, instance, HasPermissionForMeta);
+        var rowsList2 = new List<string[]>();
+        foreach (var row in viewRowsHtml)
+        {
+            rowsList2.Add(new[]
             {
                 WebUtility.HtmlEncode(row.Label),
                 row.IsHtml ? row.Value : WebUtility.HtmlEncode(row.Value)
-            })
-            .ToArray();
+            });
+        }
+        var rows = rowsList2.ToArray();
 
         // Check if entity has nested components
         var nestedComponents = DataScaffold.GetNestedComponents(meta);
@@ -1904,7 +1932,9 @@ public sealed class RouteHandlers : IRouteHandlers
 
         var query = DataScaffold.BuildQueryDefinition(ToQueryDictionary(context.Request.Query), meta);
         var results = await DataScaffold.QueryAsync(meta, query);
-        var resultsList = results.Cast<object?>().ToList();
+        var resultsList = new List<object?>();
+        foreach (var item in results)
+            resultsList.Add((object?)item);
 
         var rows = BuildListPlainRowsWithId(meta, resultsList, out var headers);
         var csv = BuildCsv(headers, rows);
@@ -1930,7 +1960,9 @@ public sealed class RouteHandlers : IRouteHandlers
 
         var query = DataScaffold.BuildQueryDefinition(ToQueryDictionary(context.Request.Query), meta);
         var results = await DataScaffold.QueryAsync(meta, query);
-        var resultsList = results.Cast<object?>().ToList();
+        var resultsList = new List<object?>();
+        foreach (var item in results)
+            resultsList.Add((object?)item);
 
         var rows = BuildListPlainRowsWithId(meta, resultsList, out var headers);
         var title = $"{meta.Name} List";
@@ -1958,7 +1990,9 @@ public sealed class RouteHandlers : IRouteHandlers
         var options = ExportOptions.FromQuery(context.Request.Query);
         var query = DataScaffold.BuildQueryDefinition(ToQueryDictionary(context.Request.Query), meta);
         var results = await DataScaffold.QueryAsync(meta, query);
-        var resultsList = results.Cast<object?>().ToList();
+        var resultsList = new List<object?>();
+        foreach (var item in results)
+            resultsList.Add((object?)item);
 
         switch (options.Format)
         {
@@ -2023,13 +2057,18 @@ public sealed class RouteHandlers : IRouteHandlers
             case ExportFormat.SimpleCSV:
             default:
                 // Fall back to simple CSV (entity fields only, no nested)
-                var rows = DataScaffold.BuildViewRows(meta, instance)
-                    .Select(row => new[] { row.Label, row.Value })
-                    .ToArray();
+                var viewRows1 = DataScaffold.BuildViewRows(meta, instance);
+                var rowsList1 = new List<string[]>();
+                foreach (var row in viewRows1)
+                    rowsList1.Add(new[] { row.Label, row.Value });
+                var rows = rowsList1.ToArray();
                 if (instance is BaseDataObject dataObject)
                 {
                     var recordId = DataScaffold.GetIdValue(dataObject) ?? string.Empty;
-                    rows = new[] { new[] { "Id", recordId } }.Concat(rows).ToArray();
+                    var concatList = new List<string[]>();
+                    concatList.Add(new[] { "Id", recordId });
+                    concatList.AddRange(rows);
+                    rows = concatList.ToArray();
                 }
                 var headers = new[] { "Field", "Value" };
                 var csv = BuildCsv(headers, rows);
@@ -2064,13 +2103,18 @@ public sealed class RouteHandlers : IRouteHandlers
             return;
         }
 
-        var rows = DataScaffold.BuildViewRows(meta, instance)
-            .Select(row => new[] { row.Label, row.Value })
-            .ToArray();
+        var viewRowsRtf = DataScaffold.BuildViewRows(meta, instance);
+        var rowsListRtf = new List<string[]>();
+        foreach (var row in viewRowsRtf)
+            rowsListRtf.Add(new[] { row.Label, row.Value });
+        var rows = rowsListRtf.ToArray();
         if (instance is BaseDataObject dataObject)
         {
             var recordId = DataScaffold.GetIdValue(dataObject) ?? string.Empty;
-            rows = new[] { new[] { "Id", recordId } }.Concat(rows).ToArray();
+            var concatList = new List<string[]>();
+            concatList.Add(new[] { "Id", recordId });
+            concatList.AddRange(rows);
+            rows = concatList.ToArray();
         }
         var title = $"{meta.Name} Details";
         var rtf = BuildRtfDocument(title, rows);
@@ -2103,13 +2147,18 @@ public sealed class RouteHandlers : IRouteHandlers
             return;
         }
 
-        var rows = DataScaffold.BuildViewRows(meta, instance)
-            .Select(row => new[] { row.Label, row.Value })
-            .ToArray();
+        var viewRowsHtml2 = DataScaffold.BuildViewRows(meta, instance);
+        var rowsListHtml2 = new List<string[]>();
+        foreach (var row in viewRowsHtml2)
+            rowsListHtml2.Add(new[] { row.Label, row.Value });
+        var rows = rowsListHtml2.ToArray();
         if (instance is BaseDataObject dataObject)
         {
             var recordId = DataScaffold.GetIdValue(dataObject) ?? string.Empty;
-            rows = new[] { new[] { "Id", recordId } }.Concat(rows).ToArray();
+            var concatList = new List<string[]>();
+            concatList.Add(new[] { "Id", recordId });
+            concatList.AddRange(rows);
+            rows = concatList.ToArray();
         }
         var title = $"{meta.Name} Details";
         var html = BuildHtmlTableDocument(title, new[] { "Field", "Value" }, rows);
@@ -2228,7 +2277,16 @@ public sealed class RouteHandlers : IRouteHandlers
         for (int i = 1; i < rows.Count; i++)
         {
             var row = rows[i];
-            if (row.All(string.IsNullOrWhiteSpace))
+            bool allBlank = true;
+            foreach (var cell in row)
+            {
+                if (!string.IsNullOrWhiteSpace(cell))
+                {
+                    allBlank = false;
+                    break;
+                }
+            }
+            if (allBlank)
                 continue;
 
             var rowNumber = i + 1;
@@ -2294,7 +2352,16 @@ public sealed class RouteHandlers : IRouteHandlers
         var summary = $"<p>Import complete. Created: {created}, Updated: {updated}, Skipped: {skipped}.</p>";
         if (errors.Count > 0)
         {
-            var preview = string.Join("<br/>", errors.Take(10).Select(WebUtility.HtmlEncode));
+            var previewBuilder = new StringBuilder();
+            int previewCount = 0;
+            foreach (var err in errors)
+            {
+                if (previewCount >= 10) break;
+                if (previewCount > 0) previewBuilder.Append("<br/>");
+                previewBuilder.Append(WebUtility.HtmlEncode(err));
+                previewCount++;
+            }
+            var preview = previewBuilder.ToString();
             var more = errors.Count > 10 ? $"<p>And {errors.Count - 10} more errors.</p>" : string.Empty;
             summary += $"<div class=\"alert alert-warning\"><strong>Errors:</strong><br/>{preview}{more}</div>";
         }
@@ -2326,7 +2393,7 @@ public sealed class RouteHandlers : IRouteHandlers
         }
 
         var csrfToken = CsrfProtection.EnsureToken(context);
-        var fields = DataScaffold.BuildFormFields(meta, null, forCreate: true, cspNonce: context.GetCspNonce()).ToList();
+        var fields = new List<FormField>(DataScaffold.BuildFormFields(meta, null, forCreate: true, cspNonce: context.GetCspNonce()));
         AppendUserPasswordFieldsIfNeeded(meta, fields, isCreate: true);
         fields.Insert(0, new FormField(FormFieldType.Hidden, CsrfProtection.FormFieldName, string.Empty, Value: csrfToken));
 
@@ -2381,7 +2448,9 @@ public sealed class RouteHandlers : IRouteHandlers
         // Apply auto-generated IDs before binding form values
         DataScaffold.ApplyAutoGeneratedIds(meta, instance);
 
-        var values = form.ToDictionary(k => k.Key, v => (string?)v.Value.ToString(), StringComparer.OrdinalIgnoreCase);
+        var values = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        foreach (var kvp in form)
+            values[kvp.Key] = (string?)kvp.Value.ToString();
         var apiKeyInputs = ExtractSystemPrincipalKeys(values);
         var errors = DataScaffold.ApplyValuesFromForm(meta, instance, values, forCreate: true);
         await ApplyUploadFieldsFromFormAsync(context, meta, (BaseDataObject)instance, form, errors).ConfigureAwait(false);
@@ -2397,7 +2466,7 @@ public sealed class RouteHandlers : IRouteHandlers
         if (errors.Count > 0)
         {
             context.SetStringValue("title", $"Create {meta.Name}");
-            context.SetStringValue("html_message", $"<div class=\"alert alert-danger\">{string.Join("<br/>", errors.Select(WebUtility.HtmlEncode))}</div>");
+            context.SetStringValue("html_message", $"<div class=\"alert alert-danger\">{JoinEncoded("<br/>", errors)}</div>");
             var fields = BuildFormFieldsWithErrors(meta, instance, forCreate: true, validationResult, cspNonce: context.GetCspNonce());
             AppendUserPasswordFieldsIfNeeded(meta, fields, isCreate: true);
             fields.Insert(0, new FormField(FormFieldType.Hidden, CsrfProtection.FormFieldName, string.Empty, Value: CsrfProtection.EnsureToken(context)));
@@ -2411,7 +2480,7 @@ public sealed class RouteHandlers : IRouteHandlers
         if (instance is SystemPrincipal principal)
         {
             var createdKeys = ApplySystemPrincipalKeys(principal, apiKeyInputs, isCreate: true);
-            newApiKey = createdKeys.FirstOrDefault();
+            newApiKey = createdKeys.Count > 0 ? createdKeys[0] : null;
         }
 
         var userName = (await UserAuth.GetUserAsync(context, context.RequestAborted).ConfigureAwait(false))?.UserName ?? "system";
@@ -2487,7 +2556,7 @@ public sealed class RouteHandlers : IRouteHandlers
         }
 
         var csrfToken = CsrfProtection.EnsureToken(context);
-        var fields = DataScaffold.BuildFormFields(meta, instance, forCreate: false, cspNonce: context.GetCspNonce()).ToList();
+        var fields = new List<FormField>(DataScaffold.BuildFormFields(meta, instance, forCreate: false, cspNonce: context.GetCspNonce()));
         AppendUserPasswordFieldsIfNeeded(meta, fields, isCreate: false);
         fields.Insert(0, new FormField(FormFieldType.Hidden, CsrfProtection.FormFieldName, string.Empty, Value: csrfToken));
 
@@ -2561,7 +2630,9 @@ public sealed class RouteHandlers : IRouteHandlers
             return;
         }
 
-        var values = form.ToDictionary(k => k.Key, v => (string?)v.Value.ToString(), StringComparer.OrdinalIgnoreCase);
+        var values = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        foreach (var kvp in form)
+            values[kvp.Key] = (string?)kvp.Value.ToString();
         var apiKeyInputs = ExtractSystemPrincipalKeys(values);
         var errors = DataScaffold.ApplyValuesFromForm(meta, instance, values, forCreate: false);
         await ApplyUploadFieldsFromFormAsync(context, meta, (BaseDataObject)instance, form, errors).ConfigureAwait(false);
@@ -2575,7 +2646,7 @@ public sealed class RouteHandlers : IRouteHandlers
         if (errors.Count > 0)
         {
             context.SetStringValue("title", $"Edit {meta.Name}");
-            context.SetStringValue("html_message", $"<div class=\"alert alert-danger\">{string.Join("<br/>", errors.Select(WebUtility.HtmlEncode))}</div>");
+            context.SetStringValue("html_message", $"<div class=\"alert alert-danger\">{JoinEncoded("<br/>", errors)}</div>");
             var fields = BuildFormFieldsWithErrors(meta, instance, forCreate: false, validationResult, cspNonce: context.GetCspNonce());
             AppendUserPasswordFieldsIfNeeded(meta, fields, isCreate: false);
             fields.Insert(0, new FormField(FormFieldType.Hidden, CsrfProtection.FormFieldName, string.Empty, Value: CsrfProtection.EnsureToken(context)));
@@ -2941,12 +3012,20 @@ public sealed class RouteHandlers : IRouteHandlers
             context.Response.Headers.Append("Content-Disposition", $"attachment; filename=\"{typeSlug}-bulk-export.csv\"");
             
             using var writer = new StreamWriter(context.Response.Body);
-            await writer.WriteLineAsync(string.Join(",", headers.Select(EscapeCsvValue)));
+            var encodedHeaders = new List<string>();
+            foreach (var h in headers)
+                encodedHeaders.Add(EscapeCsvValue(h));
+            await writer.WriteLineAsync(string.Join(",", encodedHeaders));
             
             foreach (var row in rows)
             {
-                var cleanRow = row.Select(cell => StripHtmlTags(cell)).ToArray();
-                await writer.WriteLineAsync(string.Join(",", cleanRow.Select(EscapeCsvValue)));
+                var cleanRow = new string[row.Length];
+                for (int ci = 0; ci < row.Length; ci++)
+                    cleanRow[ci] = StripHtmlTags(row[ci]);
+                var encodedCells = new List<string>();
+                foreach (var cell in cleanRow)
+                    encodedCells.Add(EscapeCsvValue(cell));
+                await writer.WriteLineAsync(string.Join(",", encodedCells));
             }
         }
     }
@@ -3068,7 +3147,9 @@ public sealed class RouteHandlers : IRouteHandlers
     private static BaseDataObject CreateClone(DataEntityMetadata meta, BaseDataObject source)
     {
         var clone = meta.Handlers.Create();
-        foreach (var field in meta.Fields.OrderBy(f => f.Order))
+        var sortedFields = new List<DataFieldMetadata>(meta.Fields);
+        sortedFields.Sort((a, b) => a.Order.CompareTo(b.Order));
+        foreach (var field in sortedFields)
         {
             var property = field.Property;
             if (!property.CanWrite)
@@ -3163,14 +3244,19 @@ public sealed class RouteHandlers : IRouteHandlers
 
             if (format == "csv" || acceptCsv)
             {
-                var resultsList = results.Cast<object?>().ToList();
+                var resultsList = new List<object?>();
+                foreach (var item in results)
+                    resultsList.Add((object?)item);
                 var rows = BuildListPlainRowsWithId(meta, resultsList, out var headers);
                 var csv = BuildCsv(headers, rows);
                 await WriteTextResponseAsync(context, "text/csv", csv, $"{typeSlug}_list.csv");
                 return;
             }
 
-            var payload = results.Cast<object>().Select(item => BuildApiModel(meta, item)).ToArray();
+            var payloadList = new List<Dictionary<string, object?>>();
+            foreach (var item in results)
+                payloadList.Add(BuildApiModel(meta, (object)item));
+            var payload = payloadList.ToArray();
             // Clamp total: if fewer items than requested were returned, the real total cannot exceed skip + returned count.
             // This prevents inflated page counts when the location map has stale entries for unreadable records.
             // Applies whether or not Top was specified: without a top limit we also know the total is at most skip + payload.Length.
@@ -3184,14 +3270,19 @@ public sealed class RouteHandlers : IRouteHandlers
 
         if (format == "csv" || acceptCsv)
         {
-            var resultsList = allResults.Cast<object?>().ToList();
+            var resultsList = new List<object?>();
+            foreach (var item in allResults)
+                resultsList.Add((object?)item);
             var rows = BuildListPlainRowsWithId(meta, resultsList, out var headers);
             var csv = BuildCsv(headers, rows);
             await WriteTextResponseAsync(context, "text/csv", csv, $"{typeSlug}_list.csv");
             return;
         }
 
-        var allPayload = allResults.Cast<object>().Select(item => BuildApiModel(meta, item)).ToArray();
+        var allPayloadList = new List<Dictionary<string, object?>>();
+        foreach (var item in allResults)
+            allPayloadList.Add(BuildApiModel(meta, (object)item));
+        var allPayload = allPayloadList.ToArray();
         await WriteJsonResponseAsync(context, allPayload);
     }
 
@@ -3267,7 +3358,16 @@ public sealed class RouteHandlers : IRouteHandlers
         for (int i = 1; i < rows.Count; i++)
         {
             var row = rows[i];
-            if (row.All(string.IsNullOrWhiteSpace)) continue;
+            bool allBlankApi = true;
+            foreach (var cell in row)
+            {
+                if (!string.IsNullOrWhiteSpace(cell))
+                {
+                    allBlankApi = false;
+                    break;
+                }
+            }
+            if (allBlankApi) continue;
 
             var rowNumber = i + 1;
             var idValue = idIndex >= 0 && idIndex < row.Length ? row[idIndex]?.Trim() : string.Empty;
@@ -3391,7 +3491,9 @@ public sealed class RouteHandlers : IRouteHandlers
         if (context.Request.HasFormContentType)
         {
             var form = await context.Request.ReadFormAsync();
-            var values = form.ToDictionary(k => k.Key, v => (string?)v.Value.ToString(), StringComparer.OrdinalIgnoreCase);
+            var values = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+            foreach (var kvp in form)
+                values[kvp.Key] = (string?)kvp.Value.ToString();
             errors = DataScaffold.ApplyValuesFromForm(meta, instance, values, forCreate: true);
             await ApplyUploadFieldsFromFormAsync(context, meta, (BaseDataObject)instance, form, errors).ConfigureAwait(false);
         }
@@ -3479,7 +3581,9 @@ public sealed class RouteHandlers : IRouteHandlers
         if (context.Request.HasFormContentType)
         {
             var form = await context.Request.ReadFormAsync();
-            var values = form.ToDictionary(k => k.Key, v => (string?)v.Value.ToString(), StringComparer.OrdinalIgnoreCase);
+            var values = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+            foreach (var kvp in form)
+                values[kvp.Key] = (string?)kvp.Value.ToString();
             errors = DataScaffold.ApplyValuesFromForm(meta, instance, values, forCreate: false);
             errors = FilterMissingRequiredErrorsForPatchForm(meta, values, errors);
             await ApplyUploadFieldsFromFormAsync(context, meta, (BaseDataObject)instance, form, errors).ConfigureAwait(false);
@@ -3566,7 +3670,9 @@ public sealed class RouteHandlers : IRouteHandlers
         if (context.Request.HasFormContentType)
         {
             var form = await context.Request.ReadFormAsync();
-            var values = form.ToDictionary(k => k.Key, v => (string?)v.Value.ToString(), StringComparer.OrdinalIgnoreCase);
+            var values = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+            foreach (var kvp in form)
+                values[kvp.Key] = (string?)kvp.Value.ToString();
             errors = DataScaffold.ApplyValuesFromForm(meta, instance, values, forCreate: false);
             await ApplyUploadFieldsFromFormAsync(context, meta, (BaseDataObject)instance, form, errors).ConfigureAwait(false);
         }
@@ -3742,68 +3848,171 @@ public sealed class RouteHandlers : IRouteHandlers
             var year = ctx.Request.Query["year"].ToString();
             var month = ctx.Request.Query["month"].ToString();
 
-            var dates = Directory.GetDirectories(root)
-                .Select(Path.GetFileName)
-                .Where(name => !string.IsNullOrWhiteSpace(name))
-                .Select(name => name!)
-                .ToList();
+            var dates = new List<string>();
+            foreach (var dir in Directory.GetDirectories(root))
+            {
+                var dirName = Path.GetFileName(dir);
+                if (!string.IsNullOrWhiteSpace(dirName))
+                    dates.Add(dirName!);
+            }
 
-            if (!dates.Contains(date, StringComparer.OrdinalIgnoreCase))
-                date = string.Empty;
+            {
+                bool dateFound = false;
+                foreach (var d in dates)
+                {
+                    if (string.Equals(d, date, StringComparison.OrdinalIgnoreCase))
+                    {
+                        dateFound = true;
+                        break;
+                    }
+                }
+                if (!dateFound)
+                    date = string.Empty;
+            }
 
-            var hours = string.IsNullOrWhiteSpace(date)
-                ? new List<string>()
-                : Directory.GetDirectories(Path.Combine(root, date))
-                    .Select(Path.GetFileName)
-                    .Where(name => !string.IsNullOrWhiteSpace(name))
-                    .Select(name => name!)
-                    .ToList();
+            List<string> hours;
+            if (string.IsNullOrWhiteSpace(date))
+            {
+                hours = new List<string>();
+            }
+            else
+            {
+                hours = new List<string>();
+                foreach (var dir in Directory.GetDirectories(Path.Combine(root, date)))
+                {
+                    var dirName = Path.GetFileName(dir);
+                    if (!string.IsNullOrWhiteSpace(dirName))
+                        hours.Add(dirName!);
+                }
+            }
 
-            hours = hours
-                .OrderBy(h => ParseHourValue(h))
-                .ThenBy(h => h, StringComparer.OrdinalIgnoreCase)
-                .ToList();
+            hours.Sort((a, b) =>
+            {
+                int cmp = ParseHourValue(a).CompareTo(ParseHourValue(b));
+                return cmp != 0 ? cmp : string.Compare(a, b, StringComparison.OrdinalIgnoreCase);
+            });
 
-            if (!hours.Contains(hour, StringComparer.OrdinalIgnoreCase))
-                hour = string.Empty;
+            {
+                bool hourFound = false;
+                foreach (var h in hours)
+                {
+                    if (string.Equals(h, hour, StringComparison.OrdinalIgnoreCase))
+                    {
+                        hourFound = true;
+                        break;
+                    }
+                }
+                if (!hourFound)
+                    hour = string.Empty;
+            }
 
-            var fileEntries = string.IsNullOrWhiteSpace(date) || string.IsNullOrWhiteSpace(hour)
-                ? new List<LogFileEntry>()
-                : Directory.GetFiles(Path.Combine(root, date, hour), "*.log")
-                    .Select(Path.GetFileName)
-                    .Where(name => !string.IsNullOrWhiteSpace(name))
-                    .Select(name => BuildLogFileEntry(name!))
-                    .OrderBy(entry => entry.SortKey)
-                    .ThenBy(entry => entry.Name, StringComparer.OrdinalIgnoreCase)
-                    .ToList();
+            List<LogFileEntry> fileEntries;
+            if (string.IsNullOrWhiteSpace(date) || string.IsNullOrWhiteSpace(hour))
+            {
+                fileEntries = new List<LogFileEntry>();
+            }
+            else
+            {
+                fileEntries = new List<LogFileEntry>();
+                foreach (var filePath in Directory.GetFiles(Path.Combine(root, date, hour), "*.log"))
+                {
+                    var fileName = Path.GetFileName(filePath);
+                    if (!string.IsNullOrWhiteSpace(fileName))
+                        fileEntries.Add(BuildLogFileEntry(fileName!));
+                }
+                fileEntries.Sort((a, b) =>
+                {
+                    int cmp = a.SortKey.CompareTo(b.SortKey);
+                    return cmp != 0 ? cmp : string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase);
+                });
+            }
 
-            if (!fileEntries.Any(entry => string.Equals(entry.Name, file, StringComparison.OrdinalIgnoreCase)))
-                file = string.Empty;
+            {
+                bool fileFound = false;
+                foreach (var entry in fileEntries)
+                {
+                    if (string.Equals(entry.Name, file, StringComparison.OrdinalIgnoreCase))
+                    {
+                        fileFound = true;
+                        break;
+                    }
+                }
+                if (!fileFound)
+                    file = string.Empty;
+            }
 
             var yearEntries = BuildLogYears(root, dates);
             var selectedYearKey = string.IsNullOrWhiteSpace(year) ? ResolveYearKey(selectedDate: date) : year;
             var selectedMonthKey = string.IsNullOrWhiteSpace(month) ? ResolveMonthKey(selectedDate: date) : month;
 
-            if (!yearEntries.Any(entry => string.Equals(entry.Key, selectedYearKey, StringComparison.OrdinalIgnoreCase)))
-                selectedYearKey = string.Empty;
+            {
+                bool yearFound = false;
+                foreach (var entry in yearEntries)
+                {
+                    if (string.Equals(entry.Key, selectedYearKey, StringComparison.OrdinalIgnoreCase))
+                    {
+                        yearFound = true;
+                        break;
+                    }
+                }
+                if (!yearFound)
+                    selectedYearKey = string.Empty;
+            }
 
             if (string.IsNullOrWhiteSpace(selectedYearKey) && yearEntries.Count > 0)
             {
-                var latestYear = yearEntries.OrderByDescending(entry => entry.YearDate).First();
+                var latestYear = yearEntries[0];
+                for (int yi = 1; yi < yearEntries.Count; yi++)
+                {
+                    if (yearEntries[yi].YearDate > latestYear.YearDate)
+                        latestYear = yearEntries[yi];
+                }
                 selectedYearKey = latestYear.Key;
             }
 
-            var selectedYear = yearEntries.FirstOrDefault(entry => string.Equals(entry.Key, selectedYearKey, StringComparison.OrdinalIgnoreCase));
-            if (!(selectedYear.Months?.Any(entry => string.Equals(entry.Key, selectedMonthKey, StringComparison.OrdinalIgnoreCase)) ?? false))
-                selectedMonthKey = string.Empty;
+            LogYearEntry selectedYear = default;
+            foreach (var entry in yearEntries)
+            {
+                if (string.Equals(entry.Key, selectedYearKey, StringComparison.OrdinalIgnoreCase))
+                {
+                    selectedYear = entry;
+                    break;
+                }
+            }
+            {
+                bool monthFound = false;
+                if (selectedYear.Months != null)
+                {
+                    foreach (var entry in selectedYear.Months)
+                    {
+                        if (string.Equals(entry.Key, selectedMonthKey, StringComparison.OrdinalIgnoreCase))
+                        {
+                            monthFound = true;
+                            break;
+                        }
+                    }
+                }
+                if (!monthFound)
+                    selectedMonthKey = string.Empty;
+            }
 
             if (string.IsNullOrWhiteSpace(selectedMonthKey) && selectedYear.Months?.Count > 0)
             {
-                var latestMonth = selectedYear.Months!.OrderByDescending(entry => entry.MonthDate).First();
+                var latestMonth = selectedYear.Months![0];
+                for (int mi = 1; mi < selectedYear.Months.Count; mi++)
+                {
+                    if (selectedYear.Months[mi].MonthDate > latestMonth.MonthDate)
+                        latestMonth = selectedYear.Months[mi];
+                }
                 selectedMonthKey = latestMonth.Key;
             }
 
-            var monthEntries = yearEntries.SelectMany(entry => entry.Months).ToList();
+            var monthEntries = new List<LogMonthEntry>();
+            foreach (var entry in yearEntries)
+            {
+                if (entry.Months != null)
+                    monthEntries.AddRange(entry.Months);
+            }
             var actionsHtml = RenderLogActions(yearEntries, selectedYearKey, selectedMonthKey, date, hour);
 
             var html = new StringBuilder();
@@ -3818,7 +4027,15 @@ public sealed class RouteHandlers : IRouteHandlers
             {
                 var fullPath = Path.GetFullPath(Path.Combine(root, date ?? string.Empty, hour ?? string.Empty, file));
                 var normalizedRoot = Path.GetFullPath(root);
-                var selectedEntry = fileEntries.FirstOrDefault(entry => string.Equals(entry.Name, file, StringComparison.OrdinalIgnoreCase));
+                LogFileEntry selectedEntry = default;
+                foreach (var fe in fileEntries)
+                {
+                    if (string.Equals(fe.Name, file, StringComparison.OrdinalIgnoreCase))
+                    {
+                        selectedEntry = fe;
+                        break;
+                    }
+                }
 
                 var isUnderRoot = fullPath.StartsWith(normalizedRoot, StringComparison.OrdinalIgnoreCase)
                     && (fullPath.Length == normalizedRoot.Length
@@ -4021,8 +4238,8 @@ public sealed class RouteHandlers : IRouteHandlers
         if (errors.Count > 0)
         {
             context.SetStringValue("title", "Generate Sample Data");
-            context.SetStringValue("html_message", $"<div class=\"alert alert-danger\">{string.Join("<br/>", errors.Select(WebUtility.HtmlEncode))}</div>");
-            RenderSampleDataForm(context, $"<div class=\"alert alert-danger\">{string.Join("<br/>", errors.Select(WebUtility.HtmlEncode))}</div>", registry.All, 10, clearExisting);
+            context.SetStringValue("html_message", $"<div class=\"alert alert-danger\">{JoinEncoded("<br/>", errors)}</div>");
+            RenderSampleDataForm(context, $"<div class=\"alert alert-danger\">{JoinEncoded("<br/>", errors)}</div>", registry.All, 10, clearExisting);
             await _renderer.RenderPage(context);
             return;
         }
@@ -4046,10 +4263,12 @@ public sealed class RouteHandlers : IRouteHandlers
                     return;
                 }
 
-                var slugs = capturedCounts.Keys.ToList();
+                var slugs = new List<string>(capturedCounts.Keys);
                 int totalEntities = slugs.Count;
                 int entityIndex = 0;
-                int totalRecords = capturedCounts.Values.Sum();
+                int totalRecords = 0;
+                foreach (var v in capturedCounts.Values)
+                    totalRecords += v;
                 int savedRecords = 0;
 
                 foreach (var slug in slugs)
@@ -4103,9 +4322,13 @@ public sealed class RouteHandlers : IRouteHandlers
                     entityIndex++;
                 }
 
-                var summary = string.Join(", ", slugs
-                    .Where(s => capturedCounts[s] > 0)
-                    .Select(s => $"{capturedCounts[s]} {s}"));
+                var summaryParts = new List<string>();
+                foreach (var s in slugs)
+                {
+                    if (capturedCounts[s] > 0)
+                        summaryParts.Add($"{capturedCounts[s]} {s}");
+                }
+                var summary = string.Join(", ", summaryParts);
                 progress.Report(100, $"Done. Created {summary}.");
             });
 
@@ -4177,7 +4400,7 @@ public sealed class RouteHandlers : IRouteHandlers
             return;
         }
 
-        var providers = DataStoreProvider.Current.Providers.ToList();
+        var providers = new List<BareMetalWeb.Data.Interfaces.IDataProvider>(DataStoreProvider.Current.Providers);
         int totalProviders = providers.Count;
 
         var jobId = BackgroundJobService.Instance.StartJob(
@@ -4361,8 +4584,10 @@ public sealed class RouteHandlers : IRouteHandlers
                     return;
                 }
 
-                var slugs = capturedCounts.Keys.ToList();
-                int totalRecords = capturedCounts.Values.Sum();
+                var slugs = new List<string>(capturedCounts.Keys);
+                int totalRecords = 0;
+                foreach (var v in capturedCounts.Values)
+                    totalRecords += v;
                 int savedRecords = 0;
                 int entityIndex = 0;
                 int totalEntities = slugs.Count;
@@ -4418,9 +4643,13 @@ public sealed class RouteHandlers : IRouteHandlers
                     entityIndex++;
                 }
 
-                var summary = string.Join(", ", slugs
-                    .Where(s => capturedCounts[s] > 0)
-                    .Select(s => $"{capturedCounts[s]} {s}"));
+                var summaryParts2 = new List<string>();
+                foreach (var s in slugs)
+                {
+                    if (capturedCounts[s] > 0)
+                        summaryParts2.Add($"{capturedCounts[s]} {s}");
+                }
+                var summary = string.Join(", ", summaryParts2);
                 progress.Report(100, $"Done. Created {summary}.");
             });
 
@@ -4485,7 +4714,7 @@ public sealed class RouteHandlers : IRouteHandlers
             return;
         }
 
-        var providers = DataStoreProvider.Current.Providers.ToList();
+        var providers = new List<BareMetalWeb.Data.Interfaces.IDataProvider>(DataStoreProvider.Current.Providers);
         int totalProviders = providers.Count;
 
         var jobId = BackgroundJobService.Instance.StartJob(
@@ -4525,37 +4754,51 @@ public sealed class RouteHandlers : IRouteHandlers
     {
         var entries = QueryPlanHistory.GetSnapshot();
 
-        var payload = entries.Select(e => new Dictionary<string, object?>
+        var payload = new List<Dictionary<string, object?>>();
+        foreach (var e in entries)
         {
-            ["executedAt"]     = e.ExecutedAt.ToString("o"),
-            ["rootEntity"]     = e.RootEntity,
-            ["joinCount"]      = e.JoinCount,
-            ["resultRowCount"] = e.ResultRowCount,
-            ["elapsedMs"]      = Math.Round(e.ElapsedMs, 3),
-            ["canStreamAggregate"]   = e.Plan.CanStreamAggregate,
-            ["joinOrderOptimised"]   = e.Plan.JoinOrderOptimised,
-            ["steps"] = e.Plan.Steps.Select(s => new Dictionary<string, object?>
+            var stepsList = new List<Dictionary<string, object?>>();
+            foreach (var s in e.Plan.Steps)
             {
-                ["stepType"]     = s.StepType.ToString(),
-                ["entitySlug"]   = s.EntitySlug,
-                ["estimatedRows"] = s.EstimatedRows,
-                ["indexedFields"] = s.IndexedFields,
-                ["join"] = s.JoinInfo == null ? null : new Dictionary<string, object?>
+                stepsList.Add(new Dictionary<string, object?>
                 {
-                    ["fromEntity"]        = s.JoinInfo.FromEntity,
-                    ["fromField"]         = s.JoinInfo.FromField,
-                    ["toField"]           = s.JoinInfo.ToField,
-                    ["joinType"]          = s.JoinInfo.JoinType.ToString(),
-                    ["buildSideIndexed"]  = s.JoinInfo.BuildSideIndexed
-                }
-            }).ToList(),
-            ["missingIndexRecommendations"] = e.Plan.MissingIndexRecommendations.Select(r => new Dictionary<string, object?>
+                    ["stepType"]     = s.StepType.ToString(),
+                    ["entitySlug"]   = s.EntitySlug,
+                    ["estimatedRows"] = s.EstimatedRows,
+                    ["indexedFields"] = s.IndexedFields,
+                    ["join"] = s.JoinInfo == null ? null : new Dictionary<string, object?>
+                    {
+                        ["fromEntity"]        = s.JoinInfo.FromEntity,
+                        ["fromField"]         = s.JoinInfo.FromField,
+                        ["toField"]           = s.JoinInfo.ToField,
+                        ["joinType"]          = s.JoinInfo.JoinType.ToString(),
+                        ["buildSideIndexed"]  = s.JoinInfo.BuildSideIndexed
+                    }
+                });
+            }
+            var missingIndexList = new List<Dictionary<string, object?>>();
+            foreach (var r in e.Plan.MissingIndexRecommendations)
             {
-                ["entitySlug"] = r.EntitySlug,
-                ["fieldName"]  = r.FieldName,
-                ["reason"]     = r.Reason
-            }).ToList()
-        }).ToList();
+                missingIndexList.Add(new Dictionary<string, object?>
+                {
+                    ["entitySlug"] = r.EntitySlug,
+                    ["fieldName"]  = r.FieldName,
+                    ["reason"]     = r.Reason
+                });
+            }
+            payload.Add(new Dictionary<string, object?>
+            {
+                ["executedAt"]     = e.ExecutedAt.ToString("o"),
+                ["rootEntity"]     = e.RootEntity,
+                ["joinCount"]      = e.JoinCount,
+                ["resultRowCount"] = e.ResultRowCount,
+                ["elapsedMs"]      = Math.Round(e.ElapsedMs, 3),
+                ["canStreamAggregate"]   = e.Plan.CanStreamAggregate,
+                ["joinOrderOptimised"]   = e.Plan.JoinOrderOptimised,
+                ["steps"] = stepsList,
+                ["missingIndexRecommendations"] = missingIndexList
+            });
+        }
 
         await WriteJsonResponseAsync(context, payload);
     }
@@ -4579,16 +4822,31 @@ public sealed class RouteHandlers : IRouteHandlers
 
             // Determine which packages are already deployed (have at least one EntityDefinition with matching slug)
             var deployedSlugs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            var existingDefs = (await DataStoreProvider.Current.QueryAsync<EntityDefinition>(null, ctx.RequestAborted)
-                .ConfigureAwait(false)).ToList();
-            var existingSlugs = existingDefs
-                .Select(e => e.Slug ?? string.Empty)
-                .Where(s => s.Length > 0)
-                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            var existingDefsRaw = await DataStoreProvider.Current.QueryAsync<EntityDefinition>(null, ctx.RequestAborted)
+                .ConfigureAwait(false);
+            var existingDefs = new List<EntityDefinition>();
+            foreach (var def in existingDefsRaw)
+                existingDefs.Add(def);
+            var existingSlugs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var e in existingDefs)
+            {
+                var slug = e.Slug ?? string.Empty;
+                if (slug.Length > 0)
+                    existingSlugs.Add(slug);
+            }
 
             foreach (var pkg in packages)
             {
-                if (pkg.Entities.Any(e => existingSlugs.Contains(e.Slug ?? string.Empty)))
+                bool hasMatchingEntity = false;
+                foreach (var e in pkg.Entities)
+                {
+                    if (existingSlugs.Contains(e.Slug ?? string.Empty))
+                    {
+                        hasMatchingEntity = true;
+                        break;
+                    }
+                }
+                if (hasMatchingEntity)
                     deployedSlugs.Add(pkg.Slug);
             }
 
@@ -4695,8 +4953,10 @@ public sealed class RouteHandlers : IRouteHandlers
 
     private async ValueTask ApplyUploadFieldsFromFormAsync(HttpContext context, DataEntityMetadata meta, BaseDataObject instance, IFormCollection form, List<string> errors)
     {
-        foreach (var field in meta.Fields.Where(f => f.FieldType == FormFieldType.File || f.FieldType == FormFieldType.Image))
+        foreach (var field in meta.Fields)
         {
+            if (field.FieldType != FormFieldType.File && field.FieldType != FormFieldType.Image)
+                continue;
             var deleteKey = $"{field.Name}__delete";
             var deleteRequested = form.TryGetValue(deleteKey, out var deleteValue) && DataScaffold.IsTruthy(deleteValue.ToString());
             var uploadedFile = form.Files.GetFile(field.Name);
@@ -4726,10 +4986,22 @@ public sealed class RouteHandlers : IRouteHandlers
                     continue;
                 }
 
-                if (config.AllowedMimeTypes.Length > 0 && !config.AllowedMimeTypes.Contains(uploadedFile.ContentType, StringComparer.OrdinalIgnoreCase))
+                if (config.AllowedMimeTypes.Length > 0)
                 {
-                    errors.Add($"{field.Label} has an invalid file type.");
-                    continue;
+                    bool mimeAllowed = false;
+                    foreach (var mime in config.AllowedMimeTypes)
+                    {
+                        if (string.Equals(mime, uploadedFile.ContentType, StringComparison.OrdinalIgnoreCase))
+                        {
+                            mimeAllowed = true;
+                            break;
+                        }
+                    }
+                    if (!mimeAllowed)
+                    {
+                        errors.Add($"{field.Label} has an invalid file type.");
+                        continue;
+                    }
                 }
             }
 
@@ -4960,11 +5232,35 @@ public sealed class RouteHandlers : IRouteHandlers
         if (string.IsNullOrWhiteSpace(selectedYearKey) && string.IsNullOrWhiteSpace(selectedMonthKey) && string.IsNullOrWhiteSpace(selectedDate) && string.IsNullOrWhiteSpace(selectedHour))
             return string.Empty;
 
-        var year = years.FirstOrDefault(entry => string.Equals(entry.Key, selectedYearKey, StringComparison.OrdinalIgnoreCase));
+        LogYearEntry year = default;
+        foreach (var entry in years)
+        {
+            if (string.Equals(entry.Key, selectedYearKey, StringComparison.OrdinalIgnoreCase))
+            {
+                year = entry;
+                break;
+            }
+        }
         var months = year.Months ?? Array.Empty<LogMonthEntry>();
-        var month = months.FirstOrDefault(entry => string.Equals(entry.Key, selectedMonthKey, StringComparison.OrdinalIgnoreCase));
+        LogMonthEntry month = default;
+        foreach (var entry in months)
+        {
+            if (string.Equals(entry.Key, selectedMonthKey, StringComparison.OrdinalIgnoreCase))
+            {
+                month = entry;
+                break;
+            }
+        }
         var days = month.Days ?? Array.Empty<LogDayEntry>();
-        var day = days.FirstOrDefault(entry => string.Equals(entry.Folder, selectedDate, StringComparison.OrdinalIgnoreCase));
+        LogDayEntry day = default;
+        foreach (var entry in days)
+        {
+            if (string.Equals(entry.Folder, selectedDate, StringComparison.OrdinalIgnoreCase))
+            {
+                day = entry;
+                break;
+            }
+        }
 
         html.Append("<nav class=\"bm-log-actions mb-3\" aria-label=\"Log scope\">");
         html.Append("<div class=\"bm-log-actions-row\">Log scope</div>");
@@ -5096,14 +5392,16 @@ public sealed class RouteHandlers : IRouteHandlers
                 return false;
             }
 
-            var dayFolders = Directory.GetDirectories(root)
-                .Select(Path.GetFileName)
-                .Where(name => !string.IsNullOrWhiteSpace(name))
-                .Select(name => name!)
-                .Where(name => TryParseDayFolder(name, out var dateValue) && dateValue.Year == yearValue)
-                .Select(name => Path.Combine(root, name))
-                .Where(Directory.Exists)
-                .ToList();
+            var dayFolders = new List<string>();
+            foreach (var dir in Directory.GetDirectories(root))
+            {
+                var name = Path.GetFileName(dir);
+                if (string.IsNullOrWhiteSpace(name)) continue;
+                if (!TryParseDayFolder(name!, out var dv) || dv.Year != yearValue) continue;
+                var fullPath = Path.Combine(root, name!);
+                if (Directory.Exists(fullPath))
+                    dayFolders.Add(fullPath);
+            }
 
             if (dayFolders.Count == 0)
             {
@@ -5123,14 +5421,16 @@ public sealed class RouteHandlers : IRouteHandlers
                 return false;
             }
 
-            var dayFolders = Directory.GetDirectories(root)
-                .Select(Path.GetFileName)
-                .Where(name => !string.IsNullOrWhiteSpace(name))
-                .Select(name => name!)
-                .Where(name => TryParseDayFolder(name, out var dateValue) && dateValue.Year == monthDate.Year && dateValue.Month == monthDate.Month)
-                .Select(name => Path.Combine(root, name))
-                .Where(Directory.Exists)
-                .ToList();
+            var dayFolders = new List<string>();
+            foreach (var dir in Directory.GetDirectories(root))
+            {
+                var name = Path.GetFileName(dir);
+                if (string.IsNullOrWhiteSpace(name)) continue;
+                if (!TryParseDayFolder(name!, out var dv) || dv.Year != monthDate.Year || dv.Month != monthDate.Month) continue;
+                var fullPath = Path.Combine(root, name!);
+                if (Directory.Exists(fullPath))
+                    dayFolders.Add(fullPath);
+            }
 
             if (dayFolders.Count == 0)
             {
@@ -5213,7 +5513,13 @@ public sealed class RouteHandlers : IRouteHandlers
         if (!Directory.Exists(dayPath))
             return;
 
-        if (Directory.EnumerateFileSystemEntries(dayPath).Any())
+        bool hasEntries = false;
+        foreach (var _ in Directory.EnumerateFileSystemEntries(dayPath))
+        {
+            hasEntries = true;
+            break;
+        }
+        if (hasEntries)
             return;
 
         Directory.Delete(dayPath, recursive: false);
@@ -5241,38 +5547,66 @@ public sealed class RouteHandlers : IRouteHandlers
             }
         }
 
-        var years = dayEntries
-            .GroupBy(entry => entry.YearKey, StringComparer.OrdinalIgnoreCase)
-            .Select(group =>
+        // Group by year
+        var yearDict = new Dictionary<string, List<LogDayEntry>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var entry in dayEntries)
+        {
+            if (!yearDict.TryGetValue(entry.YearKey, out var yearGroup))
             {
-                var first = group.First();
-                var yearDate = first.Date == DateTime.MinValue
+                yearGroup = new List<LogDayEntry>();
+                yearDict[entry.YearKey] = yearGroup;
+            }
+            yearGroup.Add(entry);
+        }
+
+        var years = new List<LogYearEntry>();
+        foreach (var (yearKey, yearGroup) in yearDict)
+        {
+            var first = yearGroup[0];
+            var yearDate = first.Date == DateTime.MinValue
+                ? DateTime.MaxValue
+                : new DateTime(first.Date.Year, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+            // Group by month within year
+            var monthDict = new Dictionary<string, List<LogDayEntry>>(StringComparer.OrdinalIgnoreCase);
+            foreach (var entry in yearGroup)
+            {
+                if (!monthDict.TryGetValue(entry.MonthKey, out var monthGroup))
+                {
+                    monthGroup = new List<LogDayEntry>();
+                    monthDict[entry.MonthKey] = monthGroup;
+                }
+                monthGroup.Add(entry);
+            }
+
+            var monthsList = new List<LogMonthEntry>();
+            foreach (var (monthKey, monthGroup) in monthDict)
+            {
+                var monthFirst = monthGroup[0];
+                var monthDate = monthFirst.Date == DateTime.MinValue
                     ? DateTime.MaxValue
-                    : new DateTime(first.Date.Year, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+                    : new DateTime(monthFirst.Date.Year, monthFirst.Date.Month, 1, 0, 0, 0, DateTimeKind.Utc);
+                var days = new List<LogDayEntry>(monthGroup);
+                days.Sort((a, b) =>
+                {
+                    var da = a.Date == DateTime.MinValue ? DateTime.MaxValue : a.Date;
+                    var db = b.Date == DateTime.MinValue ? DateTime.MaxValue : b.Date;
+                    int cmp = da.CompareTo(db);
+                    return cmp != 0 ? cmp : string.Compare(a.Folder, b.Folder, StringComparison.OrdinalIgnoreCase);
+                });
+                long monthSize = 0;
+                foreach (var d in days)
+                    monthSize += d.SizeBytes;
+                monthsList.Add(new LogMonthEntry(monthKey, monthFirst.MonthLabel, monthDate, days, monthSize));
+            }
+            monthsList.Sort((a, b) => a.MonthDate.CompareTo(b.MonthDate));
 
-                var months = group
-                    .GroupBy(entry => entry.MonthKey, StringComparer.OrdinalIgnoreCase)
-                    .Select(monthGroup =>
-                    {
-                        var monthFirst = monthGroup.First();
-                        var monthDate = monthFirst.Date == DateTime.MinValue
-                            ? DateTime.MaxValue
-                            : new DateTime(monthFirst.Date.Year, monthFirst.Date.Month, 1, 0, 0, 0, DateTimeKind.Utc);
-                        var days = monthGroup
-                            .OrderBy(entry => entry.Date == DateTime.MinValue ? DateTime.MaxValue : entry.Date)
-                            .ThenBy(entry => entry.Folder, StringComparer.OrdinalIgnoreCase)
-                            .ToList();
-                        var monthSize = days.Sum(entry => entry.SizeBytes);
-                        return new LogMonthEntry(monthGroup.Key, monthFirst.MonthLabel, monthDate, days, monthSize);
-                    })
-                    .OrderBy(entry => entry.MonthDate)
-                    .ToList();
-
-                var yearSize = months.Sum(entry => entry.SizeBytes);
-                return new LogYearEntry(group.Key, first.YearLabel, yearDate, months, yearSize);
-            })
-            .OrderBy(entry => entry.YearDate)
-            .ToList();
+            long yearSize = 0;
+            foreach (var m in monthsList)
+                yearSize += m.SizeBytes;
+            years.Add(new LogYearEntry(yearKey, first.YearLabel, yearDate, monthsList, yearSize));
+        }
+        years.Sort((a, b) => a.YearDate.CompareTo(b.YearDate));
 
         return years;
     }
@@ -5434,16 +5768,30 @@ public sealed class RouteHandlers : IRouteHandlers
     private static string[][] BuildListPlainRows(DataEntityMetadata metadata, IEnumerable items)
     {
         var rows = DataScaffold.BuildListRows(metadata, items, string.Empty, includeActions: false);
-        return rows
-            .Select(row => row.Select(cell => StripHtml(WebUtility.HtmlDecode(cell ?? string.Empty))).ToArray())
-            .ToArray();
+        var result = new List<string[]>();
+        foreach (var row in rows)
+        {
+            var cleanRow = new string[row.Length];
+            for (int ci = 0; ci < row.Length; ci++)
+                cleanRow[ci] = StripHtml(WebUtility.HtmlDecode(row[ci] ?? string.Empty));
+            result.Add(cleanRow);
+        }
+        return result.ToArray();
     }
 
     private static string[][] BuildListPlainRowsWithId(DataEntityMetadata metadata, IReadOnlyList<object?> items, out string[] headers)
     {
-        var filteredItems = items.Where(item => item != null).ToList();
+        var filteredItems = new List<object?>();
+        foreach (var item in items)
+        {
+            if (item != null)
+                filteredItems.Add(item);
+        }
         var baseRows = BuildListPlainRows(metadata, filteredItems);
-        headers = new[] { "Id" }.Concat(DataScaffold.BuildListHeaders(metadata, includeActions: false)).ToArray();
+        var baseHeaders = DataScaffold.BuildListHeaders(metadata, includeActions: false);
+        var headerList = new List<string> { "Id" };
+        headerList.AddRange(baseHeaders);
+        headers = headerList.ToArray();
 
         var output = new string[baseRows.Length][];
         for (int i = 0; i < baseRows.Length; i++)
@@ -5451,7 +5799,10 @@ public sealed class RouteHandlers : IRouteHandlers
             var id = filteredItems[i] is BaseDataObject dataObject
                 ? DataScaffold.GetIdValue(dataObject) ?? string.Empty
                 : string.Empty;
-            output[i] = new[] { id }.Concat(baseRows[i]).ToArray();
+            var concatRow = new string[1 + baseRows[i].Length];
+            concatRow[0] = id;
+            Array.Copy(baseRows[i], 0, concatRow, 1, baseRows[i].Length);
+            output[i] = concatRow;
         }
 
         return output;
@@ -5517,6 +5868,50 @@ public sealed class RouteHandlers : IRouteHandlers
         return safe;
     }
 
+    private static string[][] ViewRowsToArray(IReadOnlyList<(string Label, string Value)> viewRows)
+    {
+        var result = new string[viewRows.Count][];
+        for (int i = 0; i < viewRows.Count; i++)
+            result[i] = new[] { viewRows[i].Label, viewRows[i].Value };
+        return result;
+    }
+
+    private static string[][] PrependIdRow(string recordId, string[][] rows)
+    {
+        var result = new string[rows.Length + 1][];
+        result[0] = new[] { "Id", recordId };
+        Array.Copy(rows, 0, result, 1, rows.Length);
+        return result;
+    }
+
+    private static string[] ConcatArrays(string[] a, string[] b)
+    {
+        var result = new string[a.Length + b.Length];
+        Array.Copy(a, 0, result, 0, a.Length);
+        Array.Copy(b, 0, result, a.Length, b.Length);
+        return result;
+    }
+
+    private static string[] BuildParentValueRow(string parentId, List<(string Label, string Value)> fields)
+    {
+        var result = new string[1 + fields.Count];
+        result[0] = parentId;
+        for (int i = 0; i < fields.Count; i++)
+            result[i + 1] = fields[i].Value;
+        return result;
+    }
+
+    private static string JoinEncoded(string separator, IReadOnlyList<string> items)
+    {
+        var sb = new StringBuilder();
+        for (int i = 0; i < items.Count; i++)
+        {
+            if (i > 0) sb.Append(separator);
+            sb.Append(WebUtility.HtmlEncode(items[i]));
+        }
+        return sb.ToString();
+    }
+
     // Export helper methods for nested/embedded components
 
     private async ValueTask ExportHierarchicalJson(HttpContext context, DataEntityMetadata meta, string typeSlug, IReadOnlyList<object?> items, ExportOptions options)
@@ -5564,16 +5959,22 @@ public sealed class RouteHandlers : IRouteHandlers
 
         // Build flat CSV with parent fields repeated for each child row
         var flatRows = new List<string[]>();
-        var parentHeaders = new[] { "Id" }.Concat(DataScaffold.BuildListHeaders(meta, includeActions: false)).ToList();
-        var allHeaders = new List<string>(parentHeaders);
+        var parentHeadersList = new List<string> { "Id" };
+        parentHeadersList.AddRange(DataScaffold.BuildListHeaders(meta, includeActions: false));
+        var allHeaders = new List<string>(parentHeadersList);
         
         // Add headers for first nested component (for simplicity, we'll flatten only the first one)
         var firstNested = nestedComponents[0];
-        var nestedData = DataScaffold.ExtractNestedData(meta, items.FirstOrDefault() ?? new object());
+        object firstItem = new object();
+        foreach (var it in items)
+        {
+            if (it != null) { firstItem = it; break; }
+        }
+        var nestedData = DataScaffold.ExtractNestedData(meta, firstItem);
         if (nestedData.Count > 0)
         {
-            var childHeaders = nestedData[0].Headers.Select(h => $"{firstNested.Field.Label}.{h}");
-            allHeaders.AddRange(childHeaders);
+            foreach (var h in nestedData[0].Headers)
+                allHeaders.Add($"{firstNested.Field.Label}.{h}");
         }
 
         foreach (var item in items)
@@ -5582,22 +5983,29 @@ public sealed class RouteHandlers : IRouteHandlers
                 continue;
 
             var id = item is BaseDataObject dataObject ? DataScaffold.GetIdValue(dataObject) ?? string.Empty : string.Empty;
-            var parentRow = new[] { id }.Concat(BuildListPlainRows(meta, new[] { item })[0]).ToArray();
+            var baseRow = BuildListPlainRows(meta, new[] { item })[0];
+            var parentRow = new string[1 + baseRow.Length];
+            parentRow[0] = id;
+            Array.Copy(baseRow, 0, parentRow, 1, baseRow.Length);
             
             var nested = DataScaffold.ExtractNestedData(meta, item);
             if (nested.Count > 0 && nested[0].Rows.Length > 0)
             {
-                // Repeat parent row for each child
                 foreach (var childRow in nested[0].Rows)
                 {
-                    flatRows.Add(parentRow.Concat(childRow).ToArray());
+                    var combined = new string[parentRow.Length + childRow.Length];
+                    Array.Copy(parentRow, 0, combined, 0, parentRow.Length);
+                    Array.Copy(childRow, 0, combined, parentRow.Length, childRow.Length);
+                    flatRows.Add(combined);
                 }
             }
             else
             {
-                // No children, just add parent row with empty child fields
                 var emptyChild = nestedData.Count > 0 ? new string[nestedData[0].Headers.Length] : Array.Empty<string>();
-                flatRows.Add(parentRow.Concat(emptyChild).ToArray());
+                var combined = new string[parentRow.Length + emptyChild.Length];
+                Array.Copy(parentRow, 0, combined, 0, parentRow.Length);
+                Array.Copy(emptyChild, 0, combined, parentRow.Length, emptyChild.Length);
+                flatRows.Add(combined);
             }
         }
 
@@ -5609,15 +6017,9 @@ public sealed class RouteHandlers : IRouteHandlers
     {
         if (!options.IncludeNested || options.MaxDepth < 1)
         {
-            // No nested data, fall back to simple CSV
-            var rows = DataScaffold.BuildViewRows(meta, instance)
-                .Select(row => new[] { row.Label, row.Value })
-                .ToArray();
+            var rows = ViewRowsToArray(DataScaffold.BuildViewRows(meta, instance));
             if (instance is BaseDataObject dataObject)
-            {
-                var recordId = DataScaffold.GetIdValue(dataObject) ?? string.Empty;
-                rows = new[] { new[] { "Id", recordId } }.Concat(rows).ToArray();
-            }
+                rows = PrependIdRow(DataScaffold.GetIdValue(dataObject) ?? string.Empty, rows);
             var headers = new[] { "Field", "Value" };
             var csv = BuildCsv(headers, rows);
             await WriteTextResponseAsync(context, "text/csv", csv, $"{typeSlug}_{WebUtility.UrlEncode(id)}_flat.csv");
@@ -5627,15 +6029,9 @@ public sealed class RouteHandlers : IRouteHandlers
         var nestedComponents = DataScaffold.GetNestedComponents(meta);
         if (nestedComponents.Count == 0)
         {
-            // No nested components
-            var rows = DataScaffold.BuildViewRows(meta, instance)
-                .Select(row => new[] { row.Label, row.Value })
-                .ToArray();
+            var rows = ViewRowsToArray(DataScaffold.BuildViewRows(meta, instance));
             if (instance is BaseDataObject dataObject)
-            {
-                var recordId = DataScaffold.GetIdValue(dataObject) ?? string.Empty;
-                rows = new[] { new[] { "Id", recordId } }.Concat(rows).ToArray();
-            }
+                rows = PrependIdRow(DataScaffold.GetIdValue(dataObject) ?? string.Empty, rows);
             var headers = new[] { "Field", "Value" };
             var csv = BuildCsv(headers, rows);
             await WriteTextResponseAsync(context, "text/csv", csv, $"{typeSlug}_{WebUtility.UrlEncode(id)}_flat.csv");
@@ -5645,36 +6041,35 @@ public sealed class RouteHandlers : IRouteHandlers
         // Build flat CSV with parent fields repeated for each child row
         var flatRows = new List<string[]>();
         var parentId = instance is BaseDataObject dobj ? DataScaffold.GetIdValue(dobj) ?? string.Empty : string.Empty;
-        var parentFields = DataScaffold.BuildViewRows(meta, instance).ToList();
+        var parentFieldsList = new List<(string Label, string Value)>(DataScaffold.BuildViewRows(meta, instance));
         var parentHeaders = new List<string> { "Id" };
-        parentHeaders.AddRange(parentFields.Select(f => f.Label));
+        foreach (var f in parentFieldsList)
+            parentHeaders.Add(f.Label);
 
         var allHeaders = new List<string>(parentHeaders);
         var nested = DataScaffold.ExtractNestedData(meta, instance);
         
         if (nested.Count > 0)
         {
-            var childHeaders = nested[0].Headers.Select(h => $"{nested[0].FieldName}.{h}");
-            allHeaders.AddRange(childHeaders);
+            foreach (var h in nested[0].Headers)
+                allHeaders.Add($"{nested[0].FieldName}.{h}");
 
-            var parentRow = new[] { parentId }.Concat(parentFields.Select(f => f.Value)).ToArray();
+            var parentRow = BuildParentValueRow(parentId, parentFieldsList);
             
             if (nested[0].Rows.Length > 0)
             {
                 foreach (var childRow in nested[0].Rows)
-                {
-                    flatRows.Add(parentRow.Concat(childRow).ToArray());
-                }
+                    flatRows.Add(ConcatArrays(parentRow, childRow));
             }
             else
             {
                 var emptyChild = new string[nested[0].Headers.Length];
-                flatRows.Add(parentRow.Concat(emptyChild).ToArray());
+                flatRows.Add(ConcatArrays(parentRow, emptyChild));
             }
         }
         else
         {
-            var parentRow = new[] { parentId }.Concat(parentFields.Select(f => f.Value)).ToArray();
+            var parentRow = BuildParentValueRow(parentId, parentFieldsList);
             flatRows.Add(parentRow);
         }
 
@@ -5713,7 +6108,15 @@ public sealed class RouteHandlers : IRouteHandlers
 
                         var parentId = item is BaseDataObject dobj ? DataScaffold.GetIdValue(dobj) ?? string.Empty : string.Empty;
                         var nested = DataScaffold.ExtractNestedData(meta, item);
-                        var matchingNested = nested.FirstOrDefault(n => string.Equals(n.FieldName, field.Name, StringComparison.OrdinalIgnoreCase));
+                        (string FieldName, string[] Headers, string[][] Rows) matchingNested = default;
+                        foreach (var n in nested)
+                        {
+                            if (string.Equals(n.FieldName, field.Name, StringComparison.OrdinalIgnoreCase))
+                            {
+                                matchingNested = n;
+                                break;
+                            }
+                        }
                         
                         if (headers == null && matchingNested.Headers != null && matchingNested.Headers.Length > 0)
                         {
@@ -5725,7 +6128,10 @@ public sealed class RouteHandlers : IRouteHandlers
                         {
                             foreach (var row in matchingNested.Rows)
                             {
-                                childRows.Add(new[] { parentId }.Concat(row).ToArray());
+                                var concatRow = new string[1 + row.Length];
+                                concatRow[0] = parentId;
+                                Array.Copy(row, 0, concatRow, 1, row.Length);
+                                childRows.Add(concatRow);
                             }
                         }
                     }
@@ -5754,14 +6160,9 @@ public sealed class RouteHandlers : IRouteHandlers
         using (var archive = new ZipArchive(memoryStream, ZipArchiveMode.Create, leaveOpen: true))
         {
             // Add parent CSV
-            var parentRows = DataScaffold.BuildViewRows(meta, instance)
-                .Select(row => new[] { row.Label, row.Value })
-                .ToArray();
+            var parentRows = ViewRowsToArray(DataScaffold.BuildViewRows(meta, instance));
             if (instance is BaseDataObject dataObject)
-            {
-                var recordId = DataScaffold.GetIdValue(dataObject) ?? string.Empty;
-                parentRows = new[] { new[] { "Id", recordId } }.Concat(parentRows).ToArray();
-            }
+                parentRows = PrependIdRow(DataScaffold.GetIdValue(dataObject) ?? string.Empty, parentRows);
             var parentHeaders = new[] { "Field", "Value" };
             var parentCsv = BuildCsv(parentHeaders, parentRows);
             var parentEntry = archive.CreateEntry($"{typeSlug}.csv");
@@ -5979,7 +6380,13 @@ public sealed class RouteHandlers : IRouteHandlers
 
         var userPermissions = new HashSet<string>(user.Permissions ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
         var required = permissionsNeeded.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-        return required.Length == 0 || required.All(userPermissions.Contains);
+        if (required.Length == 0) return true;
+        foreach (var r in required)
+        {
+            if (!userPermissions.Contains(r))
+                return false;
+        }
+        return true;
     }
 
     private static List<string[]> ParseCsvRows(string content)
@@ -6048,8 +6455,19 @@ public sealed class RouteHandlers : IRouteHandlers
         }
 
         current.Add(field.ToString());
-        if (current.Any(value => !string.IsNullOrWhiteSpace(value)))
-            rows.Add(current.ToArray());
+        {
+            bool hasNonBlank = false;
+            foreach (var value in current)
+            {
+                if (!string.IsNullOrWhiteSpace(value))
+                {
+                    hasNonBlank = true;
+                    break;
+                }
+            }
+            if (hasNonBlank)
+                rows.Add(current.ToArray());
+        }
 
         return rows;
     }
@@ -6061,8 +6479,10 @@ public sealed class RouteHandlers : IRouteHandlers
         passwordIndex = -1;
 
         var fieldMap = new Dictionary<string, DataFieldMetadata>(StringComparer.OrdinalIgnoreCase);
-        foreach (var field in meta.Fields.Where(f => (f.Create || f.Edit) && !f.ReadOnly))
+        foreach (var field in meta.Fields)
         {
+            if (!((field.Create || field.Edit) && !field.ReadOnly))
+                continue;
             if (!fieldMap.ContainsKey(field.Name))
                 fieldMap[field.Name] = field;
             if (!string.IsNullOrWhiteSpace(field.Label) && !fieldMap.ContainsKey(field.Label))
@@ -6336,8 +6756,14 @@ public sealed class RouteHandlers : IRouteHandlers
             var props = JsonPropertyCache.GetOrAdd(valueType, static t =>
             {
                 #pragma warning disable IL2070, IL2075
-                return t.GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance)
-                        .Where(p => p.CanRead && p.GetIndexParameters().Length == 0).ToArray();
+                var allProps = t.GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
+                var filtered = new List<System.Reflection.PropertyInfo>();
+                foreach (var p in allProps)
+                {
+                    if (p.CanRead && p.GetIndexParameters().Length == 0)
+                        filtered.Add(p);
+                }
+                return filtered.ToArray();
                 #pragma warning restore IL2070, IL2075
             });
             foreach (var prop in props)
@@ -6409,7 +6835,13 @@ public sealed class RouteHandlers : IRouteHandlers
                     },
                     Top = 1
                 };
-                var existing = (await DataStoreProvider.Current.QueryAsync<AppSetting>(query, cancellationToken).ConfigureAwait(false)).FirstOrDefault();
+                var existingResults = await DataStoreProvider.Current.QueryAsync<AppSetting>(query, cancellationToken).ConfigureAwait(false);
+                AppSetting? existing = null;
+                foreach (var e in existingResults)
+                {
+                    existing = e;
+                    break;
+                }
                 if (existing != null && !string.Equals(existing.Key.ToString(), excludeId, StringComparison.OrdinalIgnoreCase))
                     errors.Add("A setting with this Setting ID already exists.");
             }
@@ -6443,7 +6875,9 @@ public sealed class RouteHandlers : IRouteHandlers
             return errors;
 
         const string requiredSuffix = " is required.";
-        var fieldByLabel = meta.Fields.ToDictionary(f => f.Label, f => f, StringComparer.OrdinalIgnoreCase);
+        var fieldByLabel = new Dictionary<string, DataFieldMetadata>(StringComparer.OrdinalIgnoreCase);
+        foreach (var f in meta.Fields)
+            fieldByLabel[f.Label] = f;
         var filtered = new List<string>(errors.Count);
         foreach (var error in errors)
         {
@@ -6522,7 +6956,13 @@ public sealed class RouteHandlers : IRouteHandlers
         };
 
         var users = await DataStoreProvider.Current.QueryAsync<User>(query, cancellationToken).ConfigureAwait(false);
-        return users.Any();
+        bool hasUsers = false;
+        foreach (var _ in users)
+        {
+            hasUsers = true;
+            break;
+        }
+        return hasUsers;
     }
 
     private static async ValueTask<User?> GetLockedRootUserAsync(CancellationToken cancellationToken = default)
@@ -6537,7 +6977,16 @@ public sealed class RouteHandlers : IRouteHandlers
         };
 
         var users = await DataStoreProvider.Current.QueryAsync<User>(query, cancellationToken).ConfigureAwait(false);
-        return users.FirstOrDefault(u => u.IsLockedOut);
+        User? lockedUser = null;
+        foreach (var u in users)
+        {
+            if (u.IsLockedOut)
+            {
+                lockedUser = u;
+                break;
+            }
+        }
+        return lockedUser;
     }
 
     private static string BuildViewSwitcher(string typeSlug, ViewType currentView, DataEntityMetadata meta)
@@ -6585,15 +7034,22 @@ public sealed class RouteHandlers : IRouteHandlers
         var html = new StringBuilder();
 
         // Find the first two DateOnly/DateTime fields: first is start date, second (if any) is end date
-        var dateFields = meta.Fields
-            .Where(f => f.FieldType == FormFieldType.DateOnly || f.FieldType == FormFieldType.DateTime)
-            .Take(2)
-            .ToList();
+        var dateFields = new List<DataFieldMetadata>();
+        foreach (var f in meta.Fields)
+        {
+            if (f.FieldType == FormFieldType.DateOnly || f.FieldType == FormFieldType.DateTime)
+            {
+                dateFields.Add(f);
+                if (dateFields.Count >= 2) break;
+            }
+        }
 
         if (dateFields.Count == 0)
             return "<p class=\"text-warning\">Timeline view requires a DateOnly or DateTime field.</p>";
 
-        var itemsList = allItems.ToList();
+        var itemsList = new List<BaseDataObject>();
+        foreach (var item in allItems)
+            itemsList.Add(item);
         if (itemsList.Count == 0)
             return "<p class=\"text-muted\">No items found.</p>";
 
@@ -6641,8 +7097,13 @@ public sealed class RouteHandlers : IRouteHandlers
         ganttItems.Sort((a, b) => a.Start.CompareTo(b.Start));
 
         // Expand date range to full month boundaries
-        var minDate = ganttItems.Min(x => x.Start);
-        var maxDate = ganttItems.Max(x => x.End);
+        var minDate = ganttItems[0].Start;
+        var maxDate = ganttItems[0].End;
+        for (int gi = 1; gi < ganttItems.Count; gi++)
+        {
+            if (ganttItems[gi].Start < minDate) minDate = ganttItems[gi].Start;
+            if (ganttItems[gi].End > maxDate) maxDate = ganttItems[gi].End;
+        }
         var chartStart = new DateOnly(minDate.Year, minDate.Month, 1);
         var chartEndExclusive = maxDate.Month == 12
             ? new DateOnly(maxDate.Year + 1, 1, 1)
@@ -6743,10 +7204,17 @@ public sealed class RouteHandlers : IRouteHandlers
     private static string GetDisplayValue(DataEntityMetadata meta, BaseDataObject item)
     {
         // Try common name fields first (same heuristic as DataScaffold.GetDisplayValue)
-        var nameField = meta.Fields.FirstOrDefault(f =>
-            string.Equals(f.Name, "Name", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(f.Name, "Title", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(f.Name, "DisplayName", StringComparison.OrdinalIgnoreCase));
+        DataFieldMetadata? nameField = null;
+        foreach (var f in meta.Fields)
+        {
+            if (string.Equals(f.Name, "Name", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(f.Name, "Title", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(f.Name, "DisplayName", StringComparison.OrdinalIgnoreCase))
+            {
+                nameField = f;
+                break;
+            }
+        }
         if (nameField != null)
         {
             var value = nameField.Property.GetValue(item)?.ToString();
@@ -6755,7 +7223,15 @@ public sealed class RouteHandlers : IRouteHandlers
         }
 
         // Fall back to first List string field
-        var displayField = meta.Fields.FirstOrDefault(f => f.List && f.FieldType == FormFieldType.String);
+        DataFieldMetadata? displayField = null;
+        foreach (var f in meta.Fields)
+        {
+            if (f.List && f.FieldType == FormFieldType.String)
+            {
+                displayField = f;
+                break;
+            }
+        }
         if (displayField != null)
         {
             var value = displayField.Property.GetValue(item)?.ToString();
@@ -6981,7 +7457,8 @@ public sealed class RouteHandlers : IRouteHandlers
             columnTitles.Add("");
         if (includeActions)
             columnTitles.Add("Actions");
-        columnTitles.AddRange(metadata.ListFields.Select(f => f.Label));
+        foreach (var f in metadata.ListFields)
+            columnTitles.Add(f.Label);
         
         foreach (var row in rows)
         {
@@ -7027,7 +7504,7 @@ public sealed class RouteHandlers : IRouteHandlers
     private static List<FormField> BuildFormFieldsWithErrors(
         DataEntityMetadata meta, object instance, bool forCreate, ValidationResult validationResult, string? cspNonce = null)
     {
-        var fields = DataScaffold.BuildFormFields(meta, instance, forCreate, cspNonce: cspNonce).ToList();
+        var fields = new List<FormField>(DataScaffold.BuildFormFields(meta, instance, forCreate, cspNonce: cspNonce));
         if (!validationResult.IsValid)
         {
             for (int i = 0; i < fields.Count; i++)
@@ -7069,7 +7546,15 @@ public sealed class RouteHandlers : IRouteHandlers
             return;
         }
 
-        var cmd = meta.Commands.FirstOrDefault(c => string.Equals(c.Name, commandName, StringComparison.OrdinalIgnoreCase));
+        RemoteCommandMetadata? cmd = null;
+        foreach (var c in meta.Commands)
+        {
+            if (string.Equals(c.Name, commandName, StringComparison.OrdinalIgnoreCase))
+            {
+                cmd = c;
+                break;
+            }
+        }
         if (cmd == null)
         {
             context.Response.StatusCode = StatusCodes.Status404NotFound;
@@ -7099,7 +7584,19 @@ public sealed class RouteHandlers : IRouteHandlers
         if (!string.IsNullOrEmpty(cmd.Permission))
         {
             var user = await UserAuth.GetUserAsync(context, context.RequestAborted).ConfigureAwait(false);
-            if (user == null || !user.Permissions.Contains(cmd.Permission, StringComparer.OrdinalIgnoreCase))
+            bool hasPermission = false;
+            if (user != null)
+            {
+                foreach (var perm in user.Permissions)
+                {
+                    if (string.Equals(perm, cmd.Permission, StringComparison.OrdinalIgnoreCase))
+                    {
+                        hasPermission = true;
+                        break;
+                    }
+                }
+            }
+            if (user == null || !hasPermission)
             {
                 context.Response.StatusCode = StatusCodes.Status403Forbidden;
                 await WriteJsonResponseAsync(context, new { success = false, message = "Insufficient permissions." });
@@ -7264,7 +7761,9 @@ public sealed class RouteHandlers : IRouteHandlers
             html.Append("<th class=\"text-end\">Table Total</th>");
             html.Append("</tr></thead><tbody>");
 
-            foreach (var (name, slug, schemaBytes, idMapBytes, indexBytes) in rows.OrderBy(r => r.Name, StringComparer.OrdinalIgnoreCase))
+            var sortedRows = new List<(string Name, string Slug, long SchemaBytes, long IdMapBytes, long IndexBytes)>(rows);
+            sortedRows.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase));
+            foreach (var (name, slug, schemaBytes, idMapBytes, indexBytes) in sortedRows)
             {
                 long tableTotal = schemaBytes + idMapBytes + indexBytes;
                 html.Append("<tr>");
@@ -7381,9 +7880,12 @@ public sealed class RouteHandlers : IRouteHandlers
     {
         var jobs = BackgroundJobService.Instance.GetAllJobs();
 
-        var items = jobs
-            .OrderByDescending(s => s.StartedAt)
-            .Select(snapshot => (object)new
+        var jobsList = new List<JobStatusSnapshot>(jobs);
+        jobsList.Sort((a, b) => b.StartedAt.CompareTo(a.StartedAt));
+        var itemsList = new List<object>();
+        foreach (var snapshot in jobsList)
+        {
+            itemsList.Add(new
             {
                 jobId           = snapshot.JobId,
                 operationName   = snapshot.OperationName,
@@ -7401,8 +7903,9 @@ public sealed class RouteHandlers : IRouteHandlers
                 completedAt     = snapshot.CompletedAt?.ToString("O"),
                 error           = snapshot.Error,
                 resultUrl       = snapshot.ResultUrl
-            })
-            .ToArray();
+            });
+        }
+        var items = itemsList.ToArray();
 
         context.Response.StatusCode = StatusCodes.Status200OK;
         context.Response.ContentType = "application/json";

--- a/BareMetalWeb.Host/RouteRegistrationExtensions.cs
+++ b/BareMetalWeb.Host/RouteRegistrationExtensions.cs
@@ -3,7 +3,7 @@ using System.Reflection;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
-using System.Linq;
+
 using BareMetalWeb.Core;
 using BareMetalWeb.Core.Host;
 using BareMetalWeb.Core.Interfaces;
@@ -368,7 +368,9 @@ public static class RouteRegistrationExtensions
                 var initialData  = new Dictionary<string, object?>();
                 var layoutFields = new List<string>();
 
-                foreach (var f in meta.Fields.OrderBy(x => x.Order))
+                var sortedFieldsForSchema = new List<DataFieldMetadata>(meta.Fields);
+                sortedFieldsForSchema.Sort((a, b) => a.Order.CompareTo(b.Order));
+                foreach (var f in sortedFieldsForSchema)
                 {
                     var isId = f.Name.Equals("Id", StringComparison.OrdinalIgnoreCase);
                     // Override type to "select" for fields with lookup config so the
@@ -621,8 +623,15 @@ public static class RouteRegistrationExtensions
                                     parentDoc = await targetMeta.Handlers.LoadAsync(parentKey, context.RequestAborted).ConfigureAwait(false);
                                     if (parentDoc != null)
                                     {
-                                        var displayField = targetMeta.Fields.FirstOrDefault(f =>
-                                            string.Equals(f.Name, rf.RelatedDocument.DisplayField, StringComparison.OrdinalIgnoreCase));
+                                        DataFieldMetadata? displayField = null;
+                                        foreach (var fCandidate in targetMeta.Fields)
+                                        {
+                                            if (string.Equals(fCandidate.Name, rf.RelatedDocument.DisplayField, StringComparison.OrdinalIgnoreCase))
+                                            {
+                                                displayField = fCandidate;
+                                                break;
+                                            }
+                                        }
                                         parentLabel = displayField?.GetValueFn(parentDoc)?.ToString();
                                     }
                                 }
@@ -663,10 +672,18 @@ public static class RouteRegistrationExtensions
                         };
 
                         var children = await childMeta.Handlers.QueryAsync(query, context.RequestAborted).ConfigureAwait(false);
-                        var labelField = childMeta.Fields
-                            .Where(f => f.List)
-                            .OrderBy(f => f.Order)
-                            .FirstOrDefault();
+                        DataFieldMetadata? labelField = null;
+                        {
+                            int bestOrder = int.MaxValue;
+                            foreach (var fCandidate in childMeta.Fields)
+                            {
+                                if (fCandidate.List && fCandidate.Order < bestOrder)
+                                {
+                                    bestOrder = fCandidate.Order;
+                                    labelField = fCandidate;
+                                }
+                            }
+                        }
 
                         foreach (var child in children)
                         {
@@ -808,9 +825,11 @@ public static class RouteRegistrationExtensions
                 var user = await UserAuth.GetRequestUserAsync(context, context.RequestAborted).ConfigureAwait(false);
                 var userPermissions = user?.Permissions ?? Array.Empty<string>();
 
-                var entities = DataScaffold.Entities
-                    .Where(e => IsEntityAccessible(e, user, userPermissions))
-                    .Select(e => (object)new Dictionary<string, object?>
+                var entitiesList = new List<object>();
+                foreach (var e in DataScaffold.Entities)
+                {
+                    if (!IsEntityAccessible(e, user, userPermissions)) continue;
+                    entitiesList.Add(new Dictionary<string, object?>
                     {
                         ["slug"]         = e.Slug,
                         ["name"]         = e.Name,
@@ -819,8 +838,9 @@ public static class RouteRegistrationExtensions
                         ["navOrder"]     = e.NavOrder,
                         ["viewType"]     = e.ViewType.ToString(),
                         ["rightAligned"] = string.Equals(e.NavGroup, "Admin", StringComparison.OrdinalIgnoreCase)
-                    })
-                    .ToArray();
+                    });
+                }
+                var entities = entitiesList.ToArray();
 
                 context.Response.ContentType = "application/json";
                 context.Response.Headers["Cache-Control"] = "private, max-age=300";
@@ -897,20 +917,10 @@ public static class RouteRegistrationExtensions
                     return;
                 }
 
-                var result = new Dictionary<string, object?>
+                var runtimeFieldsList = new List<object>();
+                foreach (var f in runtimeModel.Fields)
                 {
-                    ["entityId"] = runtimeModel.EntityId,
-                    ["name"] = runtimeModel.Name,
-                    ["slug"] = runtimeModel.Slug,
-                    ["permissions"] = runtimeModel.Permissions,
-                    ["showOnNav"] = runtimeModel.ShowOnNav,
-                    ["navGroup"] = runtimeModel.NavGroup,
-                    ["navOrder"] = runtimeModel.NavOrder,
-                    ["idStrategy"] = runtimeModel.IdStrategy.ToString(),
-                    ["version"] = runtimeModel.Version,
-                    ["schemaHash"] = runtimeModel.SchemaHash,
-                    ["formLayout"] = runtimeModel.FormLayout,
-                    ["fields"] = runtimeModel.Fields.Select(f => (object)new Dictionary<string, object?>
+                    runtimeFieldsList.Add(new Dictionary<string, object?>
                     {
                         ["fieldId"] = f.FieldId,
                         ["ordinal"] = f.Ordinal,
@@ -942,14 +952,22 @@ public static class RouteRegistrationExtensions
                                   ["pattern"] = f.Pattern
                               }
                             : null
-                    }).ToArray(),
-                    ["indexes"] = runtimeModel.Indexes.Select(i => (object)new Dictionary<string, object?>
+                    });
+                }
+                var runtimeIndexesList = new List<object>();
+                foreach (var i in runtimeModel.Indexes)
+                {
+                    runtimeIndexesList.Add(new Dictionary<string, object?>
                     {
                         ["indexId"] = i.IndexId,
                         ["fields"] = i.FieldNames,
                         ["type"] = i.Type
-                    }).ToArray(),
-                    ["actions"] = runtimeModel.Actions.Select(a => (object)new Dictionary<string, object?>
+                    });
+                }
+                var runtimeActionsList = new List<object>();
+                foreach (var a in runtimeModel.Actions)
+                {
+                    runtimeActionsList.Add(new Dictionary<string, object?>
                     {
                         ["actionId"] = a.ActionId,
                         ["name"] = a.Name,
@@ -957,7 +975,25 @@ public static class RouteRegistrationExtensions
                         ["icon"] = a.Icon,
                         ["permission"] = a.Permission,
                         ["enabledWhen"] = a.EnabledWhen
-                    }).ToArray()
+                    });
+                }
+
+                var result = new Dictionary<string, object?>
+                {
+                    ["entityId"] = runtimeModel.EntityId,
+                    ["name"] = runtimeModel.Name,
+                    ["slug"] = runtimeModel.Slug,
+                    ["permissions"] = runtimeModel.Permissions,
+                    ["showOnNav"] = runtimeModel.ShowOnNav,
+                    ["navGroup"] = runtimeModel.NavGroup,
+                    ["navOrder"] = runtimeModel.NavOrder,
+                    ["idStrategy"] = runtimeModel.IdStrategy.ToString(),
+                    ["version"] = runtimeModel.Version,
+                    ["schemaHash"] = runtimeModel.SchemaHash,
+                    ["formLayout"] = runtimeModel.FormLayout,
+                    ["fields"] = runtimeFieldsList.ToArray(),
+                    ["indexes"] = runtimeIndexesList.ToArray(),
+                    ["actions"] = runtimeActionsList.ToArray()
                 };
 
                 context.Response.ContentType = "application/json";
@@ -1037,11 +1073,17 @@ public static class RouteRegistrationExtensions
             pageInfoFactory.RawPage("admin", false),
             async context =>
             {
-                var types = DataScaffold.Entities
-                    .Where(m => m.Type != typeof(DataRecord)
-                                && m.Type.GetCustomAttribute<DataEntityAttribute>() != null)
-                    .OrderBy(m => m.Name)
-                    .Select(m => (object)new Dictionary<string, object?>
+                var filteredTypes = new List<DataEntityMetadata>();
+                foreach (var m in DataScaffold.Entities)
+                {
+                    if (m.Type != typeof(DataRecord) && m.Type.GetCustomAttribute<DataEntityAttribute>() != null)
+                        filteredTypes.Add(m);
+                }
+                filteredTypes.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.Ordinal));
+                var typesList = new List<object>();
+                foreach (var m in filteredTypes)
+                {
+                    typesList.Add(new Dictionary<string, object?>
                     {
                         ["name"] = m.Name,
                         ["slug"] = m.Slug,
@@ -1050,8 +1092,9 @@ public static class RouteRegistrationExtensions
                         ["showOnNav"] = m.ShowOnNav,
                         ["navGroup"] = m.NavGroup,
                         ["fieldCount"] = m.Fields.Count
-                    })
-                    .ToArray();
+                    });
+                }
+                var types = typesList.ToArray();
 
                 context.Response.ContentType = "application/json";
                 await context.Response.WriteAsync(JsonSerializer.Serialize(types, jsonOptions));
@@ -1128,7 +1171,20 @@ public static class RouteRegistrationExtensions
 
         // Legacy flat check
         var required = perms.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-        if (required.Any(r => userPermissions.Any(p => string.Equals(p, r, StringComparison.OrdinalIgnoreCase))))
+        bool hasMatchingPermission = false;
+        foreach (var r in required)
+        {
+            foreach (var p in userPermissions)
+            {
+                if (string.Equals(p, r, StringComparison.OrdinalIgnoreCase))
+                {
+                    hasMatchingPermission = true;
+                    break;
+                }
+            }
+            if (hasMatchingPermission) break;
+        }
+        if (hasMatchingPermission)
             return true;
 
         // RBAC check via resolved permission set
@@ -1158,7 +1214,10 @@ public static class RouteRegistrationExtensions
 
     private static Dictionary<string, object?> BuildEntitySchema(DataEntityMetadata meta)
     {
-        var fields = meta.Fields.OrderBy(f => f.Order).Select(f =>
+        var sortedFieldsForBuild = new List<DataFieldMetadata>(meta.Fields);
+        sortedFieldsForBuild.Sort((a, b) => a.Order.CompareTo(b.Order));
+        var fieldsList = new List<object>();
+        foreach (var f in sortedFieldsForBuild)
         {
             var fd = new Dictionary<string, object?>
             {
@@ -1286,11 +1345,18 @@ public static class RouteRegistrationExtensions
 
             // Sub-field schema for List<T> child collections (CustomHtml type)
             fd["subFields"] = DataScaffold.BuildSubFieldSchemas(f);
-            fd["enumValues"] = f.FieldType == FormFieldType.Enum
-                ? DataScaffold.BuildEnumOptions(f.Property.PropertyType)
-                    .Select(kv => new { value = kv.Key, label = kv.Value })
-                    .ToArray()
-                : null;
+            if (f.FieldType == FormFieldType.Enum)
+            {
+                var enumOptions = DataScaffold.BuildEnumOptions(f.Property.PropertyType);
+                var enumList = new List<object>();
+                foreach (var kv in enumOptions)
+                    enumList.Add(new { value = kv.Key, label = kv.Value });
+                fd["enumValues"] = enumList.ToArray();
+            }
+            else
+            {
+                fd["enumValues"] = null;
+            }
 
             if (f.RelatedDocument != null)
             {
@@ -1310,19 +1376,56 @@ public static class RouteRegistrationExtensions
                 fd["relatedDocument"] = null;
             }
 
-            return (object)fd;
-        }).ToArray();
+            fieldsList.Add(fd);
+        }
+        var fields = fieldsList.ToArray();
 
-        var commands = meta.Commands.OrderBy(c => c.Order).Select(c => (object)new Dictionary<string, object?>
+        var sortedCommands = new List<RemoteCommandMetadata>(meta.Commands);
+        sortedCommands.Sort((a, b) => a.Order.CompareTo(b.Order));
+        var commandsList = new List<object>();
+        foreach (var c in sortedCommands)
         {
-            ["name"] = c.Name,
-            ["label"] = c.Label,
-            ["icon"] = c.Icon,
-            ["confirmMessage"] = c.ConfirmMessage,
-            ["destructive"] = c.Destructive,
-            ["permission"] = c.Permission,
-            ["order"] = c.Order
-        }).ToArray();
+            commandsList.Add(new Dictionary<string, object?>
+            {
+                ["name"] = c.Name,
+                ["label"] = c.Label,
+                ["icon"] = c.Icon,
+                ["confirmMessage"] = c.ConfirmMessage,
+                ["destructive"] = c.Destructive,
+                ["permission"] = c.Permission,
+                ["order"] = c.Order
+            });
+        }
+        var commands = commandsList.ToArray();
+
+        bool canShowWorkflow = false;
+        foreach (var f in meta.Fields)
+        {
+            if (f.FieldType == BareMetalWeb.Rendering.Models.FormFieldType.Enum)
+            {
+                canShowWorkflow = true;
+                break;
+            }
+        }
+
+        object[]? documentRelationFieldsArray = null;
+        if (meta.DocumentRelationFields != null && meta.DocumentRelationFields.Count > 0)
+        {
+            var drfList = new List<object>();
+            foreach (var f in meta.DocumentRelationFields)
+            {
+                var targetMeta = DataScaffold.GetEntityByType(f.RelatedDocument!.TargetType);
+                drfList.Add(new Dictionary<string, object?>
+                {
+                    ["name"] = f.Name,
+                    ["label"] = f.Label,
+                    ["targetSlug"] = targetMeta?.Slug,
+                    ["targetName"] = targetMeta?.Name,
+                    ["displayField"] = f.RelatedDocument.DisplayField
+                });
+            }
+            documentRelationFieldsArray = drfList.ToArray();
+        }
 
         return new Dictionary<string, object?>
         {
@@ -1337,7 +1440,7 @@ public static class RouteRegistrationExtensions
             ["canShowTimeline"] = DataScaffold.CanShowTimelineView(meta),
             ["canShowSankey"] = DataScaffold.CanShowSankeyView(meta),
             ["canShowCalendar"] = DataScaffold.CanShowCalendarView(meta),
-            ["canShowWorkflow"] = meta.Fields.Any(f => f.FieldType == BareMetalWeb.Rendering.Models.FormFieldType.Enum),
+            ["canShowWorkflow"] = canShowWorkflow,
             ["idGeneration"] = meta.IdGeneration.ToString(),
             ["defaultSortField"] = meta.DefaultSortField,
             ["defaultSortDirection"] = meta.DefaultSortDirection.ToString(),
@@ -1346,20 +1449,7 @@ public static class RouteRegistrationExtensions
                 ["name"] = meta.ParentField.Name,
                 ["label"] = meta.ParentField.Label
             } : null,
-            ["documentRelationFields"] = meta.DocumentRelationFields != null && meta.DocumentRelationFields.Count > 0
-                ? meta.DocumentRelationFields.Select(f =>
-                {
-                    var targetMeta = DataScaffold.GetEntityByType(f.RelatedDocument!.TargetType);
-                    return (object)new Dictionary<string, object?>
-                    {
-                        ["name"] = f.Name,
-                        ["label"] = f.Label,
-                        ["targetSlug"] = targetMeta?.Slug,
-                        ["targetName"] = targetMeta?.Name,
-                        ["displayField"] = f.RelatedDocument.DisplayField
-                    };
-                }).ToArray()
-                : null,
+            ["documentRelationFields"] = documentRelationFieldsArray,
             ["fields"] = fields,
             ["commands"] = commands
         };
@@ -1386,7 +1476,8 @@ public static class RouteRegistrationExtensions
                 var userPermissions = new HashSet<string>(user.Permissions ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
                 if (!userPermissions.Contains("admin")) { context.Response.StatusCode = 403; await context.Response.WriteAsync("Access denied."); return; }
 
-                var reports = DataStoreProvider.Current.Query<ReportDefinition>(null).OrderBy(r => r.Name).ToList();
+                var reports = new List<ReportDefinition>(DataStoreProvider.Current.Query<ReportDefinition>(null));
+                reports.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.Ordinal));
                 var csrfToken = CsrfProtection.EnsureToken(context);
                 var safeToken = WebUtility.HtmlEncode(csrfToken);
                 var nonce = context.GetCspNonce();
@@ -1458,13 +1549,16 @@ public static class RouteRegistrationExtensions
                 }
 
                 var parameters = def.Parameters;
-                var runtimeParams = parameters.Count > 0
-                    ? parameters
-                        .Select(p => new KeyValuePair<string, string>(
-                            p.Name,
-                            context.Request.Query.TryGetValue(p.Name, out var qv) ? qv.ToString() : p.DefaultValue))
-                        .ToDictionary(kv => kv.Key, kv => kv.Value, StringComparer.OrdinalIgnoreCase)
-                    : null;
+                Dictionary<string, string>? runtimeParams = null;
+                if (parameters.Count > 0)
+                {
+                    runtimeParams = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                    foreach (var p in parameters)
+                    {
+                        var val = context.Request.Query.TryGetValue(p.Name, out var qv) ? qv.ToString() : p.DefaultValue;
+                        runtimeParams[p.Name] = val;
+                    }
+                }
 
                 var executor = new ReportExecutor(DataStoreProvider.Current);
                 ReportResult result;
@@ -1526,13 +1620,16 @@ public static class RouteRegistrationExtensions
                 }
 
                 var parameters = def.Parameters;
-                var runtimeParams = parameters.Count > 0
-                    ? parameters
-                        .Select(p => new KeyValuePair<string, string>(
-                            p.Name,
-                            context.Request.Query.TryGetValue(p.Name, out var qv) ? qv.ToString() : p.DefaultValue))
-                        .ToDictionary(kv => kv.Key, kv => kv.Value, StringComparer.OrdinalIgnoreCase)
-                    : null;
+                Dictionary<string, string>? runtimeParams = null;
+                if (parameters.Count > 0)
+                {
+                    runtimeParams = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                    foreach (var p in parameters)
+                    {
+                        var val = context.Request.Query.TryGetValue(p.Name, out var qv) ? qv.ToString() : p.DefaultValue;
+                        runtimeParams[p.Name] = val;
+                    }
+                }
 
                 var executor = new ReportExecutor(DataStoreProvider.Current);
                 ReportResult result;
@@ -1555,11 +1652,33 @@ public static class RouteRegistrationExtensions
                     context.Response.ContentType = "text/csv";
                     context.Response.Headers.ContentDisposition = $"attachment; filename=\"{Uri.EscapeDataString(def.Name)}.csv\"";
                     var csvSb = new StringBuilder();
-                    csvSb.AppendLine(string.Join(",", result.ColumnLabels.Select(CsvCell)));
+                    {
+                        var headerCells = new string[result.ColumnLabels.Length];
+                        for (int ci = 0; ci < result.ColumnLabels.Length; ci++)
+                            headerCells[ci] = CsvCell(result.ColumnLabels[ci]);
+                        csvSb.AppendLine(string.Join(",", headerCells));
+                    }
                     foreach (var row in result.Rows)
-                        csvSb.AppendLine(string.Join(",", row.Select(c => CsvCell(c ?? string.Empty))));
+                    {
+                        var rowCells = new string[row.Length];
+                        for (int ci = 0; ci < row.Length; ci++)
+                            rowCells[ci] = CsvCell(row[ci] ?? string.Empty);
+                        csvSb.AppendLine(string.Join(",", rowCells));
+                    }
                     await context.Response.WriteAsync(csvSb.ToString());
                     return;
+                }
+
+                var rowsList = new List<Dictionary<string, string?>>();
+                foreach (var r in result.Rows)
+                {
+                    var dict = new Dictionary<string, string?>();
+                    for (int i = 0; i < r.Length; i++)
+                    {
+                        var key = i < result.ColumnLabels.Length ? result.ColumnLabels[i] : $"col{i}";
+                        dict[key] = r[i];
+                    }
+                    rowsList.Add(dict);
                 }
 
                 // Default: JSON
@@ -1570,10 +1689,7 @@ public static class RouteRegistrationExtensions
                     totalRows = result.TotalRows,
                     isTruncated = result.IsTruncated,
                     columns = result.ColumnLabels,
-                    rows = result.Rows.Select(r => r.Select((v, i) => new KeyValuePair<string, string?>(
-                        i < result.ColumnLabels.Length ? result.ColumnLabels[i] : $"col{i}", v))
-                        .ToDictionary(kv => kv.Key, kv => kv.Value))
-                        .ToArray()
+                    rows = rowsList.ToArray()
                 };
                 context.Response.ContentType = "application/json";
                 await context.Response.WriteAsync(JsonSerializer.Serialize(json, JsonCompact));
@@ -1674,8 +1790,18 @@ public static class RouteRegistrationExtensions
                 // Only when there are no data-affecting query params in the URL
                 var q = context.Request.Query;
                 var hasCustomParams = q.ContainsKey("skip") || q.ContainsKey("top") || q.ContainsKey("q") ||
-                                      q.ContainsKey("sort") || q.ContainsKey("dir") ||
-                                      q.Keys.Any(k => k.StartsWith("f_", StringComparison.OrdinalIgnoreCase));
+                                      q.ContainsKey("sort") || q.ContainsKey("dir");
+                if (!hasCustomParams)
+                {
+                    foreach (var k in q.Keys)
+                    {
+                        if (k.StartsWith("f_", StringComparison.OrdinalIgnoreCase))
+                        {
+                            hasCustomParams = true;
+                            break;
+                        }
+                    }
+                }
                 if (!hasCustomParams)
                     initialDataScript = await TryBuildInitialDataScriptAsync(
                         context, entitySlug, safeNonce, user, context.RequestAborted).ConfigureAwait(false);
@@ -1724,9 +1850,11 @@ public static class RouteRegistrationExtensions
     {
         try
         {
-            var entities = DataScaffold.Entities
-                .Where(e => IsEntityAccessible(e, user, userPermissions))
-                .Select(e => (object)new Dictionary<string, object?>
+            var entitiesMetaList = new List<object>();
+            foreach (var e in DataScaffold.Entities)
+            {
+                if (!IsEntityAccessible(e, user, userPermissions)) continue;
+                entitiesMetaList.Add(new Dictionary<string, object?>
                 {
                     ["slug"]         = e.Slug,
                     ["name"]         = e.Name,
@@ -1735,8 +1863,9 @@ public static class RouteRegistrationExtensions
                     ["navOrder"]     = e.NavOrder,
                     ["viewType"]     = e.ViewType.ToString(),
                     ["rightAligned"] = string.Equals(e.NavGroup, "Admin", StringComparison.OrdinalIgnoreCase)
-                })
-                .ToArray();
+                });
+            }
+            var entities = entitiesMetaList.ToArray();
 
             // Check if user has any elevated permissions
             bool hasElevated = false;
@@ -1814,8 +1943,20 @@ public static class RouteRegistrationExtensions
                 {
                     var userPerms = new HashSet<string>(user.Permissions ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
                     var required = permissionsNeeded.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-                    if (required.Length > 0 && !required.All(userPerms.Contains))
-                        return null;
+                    if (required.Length > 0)
+                    {
+                        bool allMatch = true;
+                        foreach (var r in required)
+                        {
+                            if (!userPerms.Contains(r))
+                            {
+                                allMatch = false;
+                                break;
+                            }
+                        }
+                        if (!allMatch)
+                            return null;
+                    }
                 }
             }
 
@@ -1838,7 +1979,10 @@ public static class RouteRegistrationExtensions
 
             var results = await dataTask;
             var total   = await countTask;
-            var payload = results.Cast<object>().Select(item => RouteHandlers.BuildApiModel(meta, item)).ToArray();
+            var payloadList = new List<Dictionary<string, object?>>();
+            foreach (object item in results)
+                payloadList.Add(RouteHandlers.BuildApiModel(meta, item));
+            var payload = payloadList.ToArray();
             // Clamp total (same as DataApiListHandler)
             if (payload.Length < top)
                 total = Math.Min(total, payload.Length);
@@ -1885,7 +2029,12 @@ public static class RouteRegistrationExtensions
         if (payload.Length == 0) return null;
 
         // Only consider lookup fields that are shown in the list view
-        var lookupFields = meta.Fields.Where(f => f.Lookup != null && f.List).ToList();
+        var lookupFields = new List<DataFieldMetadata>();
+        foreach (var f in meta.Fields)
+        {
+            if (f.Lookup != null && f.List)
+                lookupFields.Add(f);
+        }
         if (lookupFields.Count == 0) return null;
 
         var prefetch = new Dictionary<string, Dictionary<string, object?>>(StringComparer.OrdinalIgnoreCase);
@@ -1898,11 +2047,14 @@ public static class RouteRegistrationExtensions
             if (targetMeta == null) continue;
 
             // Collect unique non-null IDs for this field across all payload rows
-            var uniqueIds = payload
-                .Select(item => item.TryGetValue(field.Name, out var val) ? val as string : null)
-                .Where(id => !string.IsNullOrWhiteSpace(id))
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToList();
+            var seenIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var uniqueIds = new List<string>();
+            foreach (var item in payload)
+            {
+                var idVal = item.TryGetValue(field.Name, out var val) ? val as string : null;
+                if (!string.IsNullOrWhiteSpace(idVal) && seenIds.Add(idVal))
+                    uniqueIds.Add(idVal);
+            }
 
             if (uniqueIds.Count == 0) continue;
 
@@ -1961,7 +2113,12 @@ public static class RouteRegistrationExtensions
 
     internal static void AppendVNextRightNavItems(StringBuilder sb, List<IMenuOption> options)
     {
-        var rightAligned = options.Where(o => o.RightAligned && o.ShowOnNavBar).ToList();
+        var rightAligned = new List<IMenuOption>();
+        foreach (var o in options)
+        {
+            if (o.RightAligned && o.ShowOnNavBar)
+                rightAligned.Add(o);
+        }
         var renderedGroups = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var option in rightAligned)
@@ -1979,9 +2136,12 @@ public static class RouteRegistrationExtensions
                 continue;
 
             renderedGroups.Add(option.Group);
-            var groupItems = rightAligned
-                .Where(o => string.Equals(o.Group, option.Group, StringComparison.OrdinalIgnoreCase))
-                .ToList();
+            var groupItems = new List<IMenuOption>();
+            foreach (var o in rightAligned)
+            {
+                if (string.Equals(o.Group, option.Group, StringComparison.OrdinalIgnoreCase))
+                    groupItems.Add(o);
+            }
 
             sb.Append($"<li class=\"nav-item dropdown\"><a class=\"nav-link dropdown-toggle\" href=\"#\" role=\"button\" data-bs-toggle=\"dropdown\" aria-expanded=\"false\">{WebUtility.HtmlEncode(option.Group)}</a>");
             sb.Append("<ul class=\"dropdown-menu dropdown-menu-end\">");
@@ -1995,7 +2155,12 @@ public static class RouteRegistrationExtensions
 
     internal static void AppendVNextLeftNavItems(StringBuilder sb, List<IMenuOption> options)
     {
-        var leftAligned = options.Where(o => !o.RightAligned && o.ShowOnNavBar).ToList();
+        var leftAligned = new List<IMenuOption>();
+        foreach (var o in options)
+        {
+            if (!o.RightAligned && o.ShowOnNavBar)
+                leftAligned.Add(o);
+        }
         var renderedGroups = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var option in leftAligned)
@@ -2013,9 +2178,12 @@ public static class RouteRegistrationExtensions
                 continue;
 
             renderedGroups.Add(option.Group);
-            var groupItems = leftAligned
-                .Where(o => string.Equals(o.Group, option.Group, StringComparison.OrdinalIgnoreCase))
-                .ToList();
+            var groupItems = new List<IMenuOption>();
+            foreach (var o in leftAligned)
+            {
+                if (string.Equals(o.Group, option.Group, StringComparison.OrdinalIgnoreCase))
+                    groupItems.Add(o);
+            }
 
             sb.Append($"<li class=\"nav-item dropdown\"><a class=\"nav-link dropdown-toggle\" href=\"#\" role=\"button\" data-bs-toggle=\"dropdown\" aria-expanded=\"false\">{WebUtility.HtmlEncode(option.Group)}</a>");
             sb.Append("<ul class=\"dropdown-menu\">");

--- a/BareMetalWeb.Host/ScheduledActionService.cs
+++ b/BareMetalWeb.Host/ScheduledActionService.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Linq;
+
 using System.Threading;
 using System.Threading.Tasks;
 using BareMetalWeb.Core.Interfaces;
@@ -54,7 +54,10 @@ public sealed class ScheduledActionService
     private async Task ProcessSchedulesAsync(DateTime nowUtc, CancellationToken ct)
     {
         var store = DataStoreProvider.Current;
-        var schedules = (await store.QueryAsync<BareMetalWeb.Runtime.ScheduledActionDefinition>(null, ct)).ToList();
+        var schedulesResult = await store.QueryAsync<BareMetalWeb.Runtime.ScheduledActionDefinition>(null, ct);
+        var schedules = new List<BareMetalWeb.Runtime.ScheduledActionDefinition>();
+        foreach (var s in schedulesResult)
+            schedules.Add(s);
 
         foreach (var sched in schedules)
         {
@@ -67,8 +70,15 @@ public sealed class ScheduledActionService
                 continue;
 
             // Find the action
-            var actionCmd = meta.Commands.FirstOrDefault(c =>
-                string.Equals(c.Name, sched.ActionName, StringComparison.OrdinalIgnoreCase));
+            RemoteCommandMetadata? actionCmd = null;
+            foreach (var c in meta.Commands)
+            {
+                if (string.Equals(c.Name, sched.ActionName, StringComparison.OrdinalIgnoreCase))
+                {
+                    actionCmd = c;
+                    break;
+                }
+            }
             if (actionCmd == null) continue;
 
             try
@@ -78,7 +88,10 @@ public sealed class ScheduledActionService
                     ? null
                     : new QueryDefinition();
 
-                var items = (await meta.Handlers.QueryAsync(query, ct)).ToList();
+                var queryResults = await meta.Handlers.QueryAsync(query, ct);
+                var items = new List<BaseDataObject>();
+                foreach (var item in queryResults)
+                    items.Add(item);
                 int count = 0;
 
                 foreach (var item in items)
@@ -152,7 +165,12 @@ public sealed class ScheduledActionService
                 Clauses = { new QueryClause { Field = "EntityId", Operator = QueryOperator.Equals, Value = entityId } }
             }, CancellationToken.None).GetAwaiter().GetResult();
 
-        var def = defs.FirstOrDefault();
+        BareMetalWeb.Runtime.EntityDefinition? def = null;
+        foreach (var d in defs)
+        {
+            def = d;
+            break;
+        }
         return def?.Slug ?? def?.Name?.Replace(' ', '-').ToLowerInvariant();
     }
 }

--- a/BareMetalWeb.Host/StaticFileService.cs
+++ b/BareMetalWeb.Host/StaticFileService.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.IO.Compression;
-using System.Linq;
+
 using System.Net;
 using System.Text;
 using System.Threading;
@@ -371,7 +371,16 @@ public static class StaticFileService
 
             if (TryParseEtags(ifNoneMatch, out var tags))
             {
-                if (tags.Any(tag => WeakEtagEquals(tag, etag)))
+                var anyMatch = false;
+                foreach (var tag in tags)
+                {
+                    if (WeakEtagEquals(tag, etag))
+                    {
+                        anyMatch = true;
+                        break;
+                    }
+                }
+                if (anyMatch)
                     return true;
             }
             else if (string.Equals(ifNoneMatch, etag, StringComparison.Ordinal))
@@ -409,7 +418,16 @@ public static class StaticFileService
 
             if (TryParseEtags(ifMatch, out var tags))
             {
-                if (!tags.Any(tag => StrongEtagEquals(tag, etag)))
+                var anyMatch = false;
+                foreach (var tag in tags)
+                {
+                    if (StrongEtagEquals(tag, etag))
+                    {
+                        anyMatch = true;
+                        break;
+                    }
+                }
+                if (!anyMatch)
                     return false;
             }
             else if (!string.Equals(ifMatch, etag, StringComparison.Ordinal))
@@ -540,20 +558,32 @@ public static class StaticFileService
             builder.Append("<li><a href=\"../\">../</a></li>");
         }
 
-        var entries = Directory.EnumerateFileSystemEntries(targetPath)
-            .Select(path => new { Path = path, Name = Path.GetFileName(path) ?? string.Empty, IsDir = Directory.Exists(path) })
-            .Where(entry => !string.IsNullOrWhiteSpace(entry.Name));
-
-        entries = entries.Where(entry => !IsDotName(entry.Name));
-        entries = entries.Where(entry => entry.IsDir || !entry.Name.EndsWith(".key", StringComparison.OrdinalIgnoreCase));
+        var entriesList = new List<(string Path, string Name, bool IsDir)>();
+        foreach (var path in Directory.EnumerateFileSystemEntries(targetPath))
+        {
+            var name = Path.GetFileName(path) ?? string.Empty;
+            if (string.IsNullOrWhiteSpace(name))
+                continue;
+            var isDir = Directory.Exists(path);
+            if (IsDotName(name))
+                continue;
+            if (!isDir && name.EndsWith(".key", StringComparison.OrdinalIgnoreCase))
+                continue;
+            entriesList.Add((path, name, isDir));
+        }
 
         if (options.DirectoryListingSortDirectoriesFirst)
         {
-            entries = entries.OrderByDescending(entry => entry.IsDir).ThenBy(entry => entry.Name, StringComparer.OrdinalIgnoreCase);
+            entriesList.Sort((a, b) =>
+            {
+                int dirCmp = b.IsDir.CompareTo(a.IsDir);
+                if (dirCmp != 0) return dirCmp;
+                return StringComparer.OrdinalIgnoreCase.Compare(a.Name, b.Name);
+            });
         }
 
         int count = 0;
-        foreach (var entry in entries)
+        foreach (var entry in entriesList)
         {
             if (options.DirectoryListingMaxEntries > 0 && count >= options.DirectoryListingMaxEntries)
                 break;
@@ -784,7 +814,12 @@ public static class StaticFileService
             return false;
 
         var value = contentType.Split(';', 2)[0].Trim();
-        return options.CompressibleContentTypePrefixes.Any(prefix => value.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
+        foreach (var prefix in options.CompressibleContentTypePrefixes)
+        {
+            if (value.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
     }
 
     private static void GetEncodingQualities(string header, out double brQ, out double gzipQ, out double identityQ, out double starQ)

--- a/BareMetalWeb.Host/TenantApiHandlers.cs
+++ b/BareMetalWeb.Host/TenantApiHandlers.cs
@@ -42,17 +42,21 @@ public static class TenantApiHandlers
             return;
         }
 
-        var tenants = _registry!.AllTenants.Select(t => new
+        var tenants = new List<object>();
+        foreach (var t in _registry!.AllTenants)
         {
-            t.TenantId,
-            t.DataRoot,
-            t.LogFolder,
-            t.DisplayName,
-            t.LogoUrl,
-            t.PrimaryColor,
-            t.MaxRecords,
-            t.MaxStorageBytes,
-        });
+            tenants.Add(new
+            {
+                t.TenantId,
+                t.DataRoot,
+                t.LogFolder,
+                t.DisplayName,
+                t.LogoUrl,
+                t.PrimaryColor,
+                t.MaxRecords,
+                t.MaxStorageBytes,
+            });
+        }
 
         context.Response.ContentType = "application/json";
         await JsonSerializer.SerializeAsync(context.Response.Body, tenants, JsonOpts);

--- a/BareMetalWeb.Host/TenantRegistry.cs
+++ b/BareMetalWeb.Host/TenantRegistry.cs
@@ -182,7 +182,16 @@ public sealed class TenantRegistry
     }
 
     /// <summary>Gets a stable snapshot of all registered tenant contexts.</summary>
-    public IReadOnlyCollection<TenantContext> AllTenants => _byId.Values.ToArray();
+    public IReadOnlyCollection<TenantContext> AllTenants
+    {
+        get
+        {
+            var list = new List<TenantContext>(_byId.Count);
+            foreach (var kvp in _byId)
+                list.Add(kvp.Value);
+            return list.ToArray();
+        }
+    }
 
     /// <summary>Gets the system/default tenant context.</summary>
     public TenantContext? SystemTenant => _systemTenant;

--- a/BareMetalWeb.Host/UserAuth.cs
+++ b/BareMetalWeb.Host/UserAuth.cs
@@ -3,8 +3,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using BareMetalWeb.Data;
 using Microsoft.AspNetCore.Http;
-using System.Linq;
-
 namespace BareMetalWeb.Host;
 
 public static class UserAuth

--- a/BareMetalWeb.Host/VectorApiHandlers.cs
+++ b/BareMetalWeb.Host/VectorApiHandlers.cs
@@ -59,13 +59,16 @@ public static class VectorApiHandlers
 
         var results = _manager.Search(entity, field, vector, top);
 
+        var projectedResults = new List<object>(results.Count);
+        foreach (var r in results)
+            projectedResults.Add(new { id = r.Id, distance = r.Distance });
         context.Response.ContentType = "application/json";
         await JsonSerializer.SerializeAsync(context.Response.Body, new
         {
             entity,
             field,
             count = results.Count,
-            results = results.Select(r => new { id = r.Id, distance = r.Distance }),
+            results = projectedResults,
         }, JsonOpts);
     }
 
@@ -120,15 +123,20 @@ public static class VectorApiHandlers
     {
         if (_manager == null) { context.Response.StatusCode = 503; return; }
 
-        var defs = _manager.GetDefinitions().Select(d => new
+        var rawDefs = _manager.GetDefinitions();
+        var defs = new List<object>();
+        foreach (var d in rawDefs)
         {
-            entity = d.EntityType,
-            field = d.Field,
-            dimension = d.Def.Dimension,
-            metric = d.Def.Metric.ToString(),
-            maxDegree = d.Def.MaxDegree,
-            count = _manager.Count(d.EntityType, d.Field),
-        });
+            defs.Add(new
+            {
+                entity = d.EntityType,
+                field = d.Field,
+                dimension = d.Def.Dimension,
+                metric = d.Def.Metric.ToString(),
+                maxDegree = d.Def.MaxDegree,
+                count = _manager.Count(d.EntityType, d.Field),
+            });
+        }
 
         context.Response.ContentType = "application/json";
         await JsonSerializer.SerializeAsync(context.Response.Body, defs, JsonOpts);

--- a/BareMetalWeb.Rendering/FormOptions.cs
+++ b/BareMetalWeb.Rendering/FormOptions.cs
@@ -21,7 +21,8 @@ public static class FormOptions
                 // Ignore invalid cultures
             }
         }
-        var list = set.OrderBy(code => code).ToList();
+        var list = new List<string>(set);
+        list.Sort(StringComparer.Ordinal);
         return list;
     });
 
@@ -41,9 +42,9 @@ public static class FormOptions
                 // Ignore invalid cultures
             }
         }
-        return set.OrderBy(kvp => kvp.Value)
-            .Select(kvp => new KeyValuePair<string, string>(kvp.Key, kvp.Value))
-            .ToList();
+        var list = new List<KeyValuePair<string, string>>(set);
+        list.Sort((a, b) => string.Compare(a.Value, b.Value, StringComparison.Ordinal));
+        return list;
     });
 
     public static IReadOnlyList<string> GetCurrencyOptions() => CurrencyCodes.Value;

--- a/BareMetalWeb.Rendering/HtmlRenderer.cs
+++ b/BareMetalWeb.Rendering/HtmlRenderer.cs
@@ -1,6 +1,6 @@
 using System.Buffers;
 using System.Collections.Generic;
-using System.Linq;
+
 using System.IO.Pipelines;
 using System.Net;
 using System.Text;
@@ -270,7 +270,7 @@ public class HtmlRenderer : IHtmlRenderer
 
         if (parts.Length == 5)
         {
-            parts = parts.Skip(1).ToArray();
+            var newParts = new string[parts.Length - 1]; Array.Copy(parts, 1, newParts, 0, parts.Length - 1); parts = newParts;
         }
 
         if (parts.Length != 4)
@@ -628,7 +628,7 @@ public class HtmlRenderer : IHtmlRenderer
     {
         if (!app.ShowHostDiagnostics)
             return false;
-        var qsVal = context.Request.Query["showhst"].FirstOrDefault() ?? string.Empty;
+        string? qsVal = string.Empty; var showhstValues = context.Request.Query["showhst"]; if (showhstValues.Count > 0) qsVal = showhstValues[0] ?? string.Empty; else qsVal = string.Empty;
         return string.Equals(qsVal, "true", StringComparison.OrdinalIgnoreCase);
     }
 

--- a/BareMetalWeb.Rendering/QrCodeGenerator.cs
+++ b/BareMetalWeb.Rendering/QrCodeGenerator.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
+
 using System.Text;
 
 namespace BareMetalWeb.Rendering;
@@ -482,9 +482,16 @@ public static class QrCodeGenerator
                 ecBlocks.Add(ecBlock);
             }
 
-            int maxDataLen = dataBlocks.Max(b => b.Length);
-            int maxEcLen = ecBlocks.Max(b => b.Length);
-            var result = new List<byte>(data.Length + ecBlocks.Sum(b => b.Length));
+            int maxDataLen = 0;
+            for (int j = 0; j < dataBlocks.Count; j++)
+                if (dataBlocks[j].Length > maxDataLen) maxDataLen = dataBlocks[j].Length;
+            int maxEcLen = 0;
+            for (int j = 0; j < ecBlocks.Count; j++)
+                if (ecBlocks[j].Length > maxEcLen) maxEcLen = ecBlocks[j].Length;
+            int ecBytesTotal = 0;
+            for (int j = 0; j < ecBlocks.Count; j++)
+                ecBytesTotal += ecBlocks[j].Length;
+            var result = new List<byte>(data.Length + ecBytesTotal);
 
             for (int i = 0; i < maxDataLen; i++)
             {
@@ -594,7 +601,13 @@ public static class QrCodeGenerator
     private static class RsBlockTable
     {
         public static int GetDataCodewords(int version, EccLevel ecc)
-            => GetBlocks(version, ecc).Sum(b => b.DataCodewords);
+        {
+            var blocks = GetBlocks(version, ecc);
+            int total = 0;
+            for (int i = 0; i < blocks.Length; i++)
+                total += blocks[i].DataCodewords;
+            return total;
+        }
 
         public static BlockInfo[] GetBlocks(int version, EccLevel ecc)
         {

--- a/BareMetalWeb.Rendering/StaticHTMLFragmentManager.cs
+++ b/BareMetalWeb.Rendering/StaticHTMLFragmentManager.cs
@@ -2,7 +2,7 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
+
 using System.Text;
 using BareMetalWeb.Interfaces;
 

--- a/BareMetalWeb.Rendering/StaticHTMLFragments.cs
+++ b/BareMetalWeb.Rendering/StaticHTMLFragments.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Buffers;
 using System.Text;
-using System.Linq;
+
 using System.Collections.Generic;
 using System.Net;
 using BareMetalWeb.Core.Interfaces;
@@ -358,7 +358,9 @@ public sealed class HtmlFragmentRenderer : IHtmlFragmentRenderer
     {
         var buffer = new ArrayBufferWriter<byte>();
 
-        var visibleOptions = options.Where(o => o.RightAligned == rightAligned).ToList();
+        var visibleOptions = new List<IMenuOption>();
+        foreach (var o in options)
+            if (o.RightAligned == rightAligned) visibleOptions.Add(o);
         var renderedGroups = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var option in visibleOptions)
@@ -377,9 +379,10 @@ public sealed class HtmlFragmentRenderer : IHtmlFragmentRenderer
                 continue;
 
             renderedGroups.Add(option.Group);
-            var groupItems = visibleOptions
-                .Where(o => string.Equals(o.Group, option.Group, StringComparison.OrdinalIgnoreCase))
-                .ToList();
+            var groupItems = new List<IMenuOption>();
+            foreach (var o in visibleOptions)
+                if (string.Equals(o.Group, option.Group, StringComparison.OrdinalIgnoreCase))
+                    groupItems.Add(o);
 
             var groupLabel = WebUtility.HtmlEncode(option.Group);
             var menuAlignmentClass = rightAligned ? "dropdown-menu dropdown-menu-end" : "dropdown-menu";
@@ -443,7 +446,15 @@ public sealed class HtmlFragmentRenderer : IHtmlFragmentRenderer
     {
         var buffer = new ArrayBufferWriter<byte>();
 
-        var needsMultipart = definition.Fields.Any(f => f.FieldType == FormFieldType.Image || f.FieldType == FormFieldType.File);
+        bool needsMultipart = false;
+        foreach (var f in definition.Fields)
+        {
+            if (f.FieldType == FormFieldType.Image || f.FieldType == FormFieldType.File)
+            {
+                needsMultipart = true;
+                break;
+            }
+        }
         _fragmentStore.ZeroAllocationReplaceCopyAndWrite(
             _fragmentStore.ReturnTemplateFragment("FormStart"),
             buffer,

--- a/BareMetalWeb.Runtime/ActionExpander.cs
+++ b/BareMetalWeb.Runtime/ActionExpander.cs
@@ -49,9 +49,13 @@ public static class ActionExpander
         ProcessCommands(action.Commands, workingContext, primaryKey, aggregateType, aggregateId,
             mutations, assertions, depth);
 
+        var builtMutations = new List<AggregateMutation>(mutations.Count);
+        foreach (var b in mutations.Values)
+            builtMutations.Add(b.Build());
+
         return new TransactionEnvelope(
             transactionId: Guid.NewGuid().ToString("N"),
-            aggregateMutations: mutations.Values.Select(b => b.Build()).ToList(),
+            aggregateMutations: builtMutations,
             assertions: assertions);
     }
 
@@ -67,7 +71,9 @@ public static class ActionExpander
         List<AssertionResult> assertions,
         int depth)
     {
-        foreach (var command in commands.OrderBy(c => c.Order))
+        var sortedCommands = new List<ActionCommand>(commands);
+        sortedCommands.Sort((a, b) => a.Order.CompareTo(b.Order));
+        foreach (var command in sortedCommands)
         {
             switch (command)
             {
@@ -154,7 +160,8 @@ public static class ActionExpander
             return;
 
         // Snapshot: take a copy of the list so snapshot-mode doesn't see loop mutations
-        var snapshot = items.ToList();
+        var snapshot = new List<IDictionary<string, object?>>();
+        foreach (var item in items) snapshot.Add(item);
 
         foreach (var item in snapshot)
         {
@@ -191,8 +198,15 @@ public static class ActionExpander
         if (!RuntimeEntityRegistry.Current.TryGet(cmd.TargetEntityType, out var targetModel))
             return;
 
-        var targetAction = targetModel.Actions
-            .FirstOrDefault(a => string.Equals(a.Name, cmd.TargetActionId, StringComparison.OrdinalIgnoreCase));
+        RuntimeActionModel? targetAction = null;
+        foreach (var a in targetModel.Actions)
+        {
+            if (string.Equals(a.Name, cmd.TargetActionId, StringComparison.OrdinalIgnoreCase))
+            {
+                targetAction = a;
+                break;
+            }
+        }
 
         if (targetAction == null)
             return;

--- a/BareMetalWeb.Runtime/AggregateLockManager.cs
+++ b/BareMetalWeb.Runtime/AggregateLockManager.cs
@@ -89,10 +89,11 @@ public sealed class AggregateLockManager
         TimeSpan expiry)
     {
         // §6.2 — sort deterministically to prevent deadlocks
-        var sorted = aggregateIds
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .OrderBy(x => x, StringComparer.Ordinal)
-            .ToList();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var sorted = new List<string>();
+        foreach (var id in aggregateIds)
+            if (seen.Add(id)) sorted.Add(id);
+        sorted.Sort(StringComparer.Ordinal);
 
         var acquired = new List<string>(sorted.Count);
         foreach (var id in sorted)
@@ -127,7 +128,12 @@ public sealed class AggregateLockManager
         {
             var now = DateTime.UtcNow;
             lock (_syncRoot)
-                return _locks.Values.Count(e => e.ExpiryUtc > now);
+            {
+                int count = 0;
+                foreach (var e in _locks.Values)
+                    if (e.ExpiryUtc > now) count++;
+                return count;
+            }
         }
     }
 }

--- a/BareMetalWeb.Runtime/AggregationDefinition.cs
+++ b/BareMetalWeb.Runtime/AggregationDefinition.cs
@@ -33,20 +33,21 @@ public class AggregationDefinition : RenderableDataObject
 
     public IReadOnlyList<string> GetGroupByList()
         => GroupByFields
-            .Split('|', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            .ToArray();
+            .Split('|', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
     public IReadOnlyList<(string Function, string Field)> GetMeasureList()
-        => Measures
-            .Split('|', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            .Select(m =>
-            {
-                var parts = m.Split(':', 2);
-                return parts.Length == 2
-                    ? (parts[0].ToLowerInvariant(), parts[1])
-                    : ("count", m);
-            })
-            .ToArray();
+    {
+        var parts = Measures.Split('|', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        var result = new (string Function, string Field)[parts.Length];
+        for (int i = 0; i < parts.Length; i++)
+        {
+            var p = parts[i].Split(':', 2);
+            result[i] = p.Length == 2
+                ? (p[0].ToLowerInvariant(), p[1])
+                : ("count", parts[i]);
+        }
+        return result;
+    }
 
     public override string ToString() => Name;
 }

--- a/BareMetalWeb.Runtime/CommandService.cs
+++ b/BareMetalWeb.Runtime/CommandService.cs
@@ -108,8 +108,15 @@ public sealed class CommandService : ICommandService
         if (!RuntimeEntityRegistry.Current.TryGet(intent.EntitySlug, out var runtimeModel))
             return CommandResult.Fail($"No runtime entity found for slug '{intent.EntitySlug}'.");
 
-        var action = runtimeModel.Actions
-            .FirstOrDefault(a => string.Equals(a.Name, actionName, StringComparison.OrdinalIgnoreCase));
+        RuntimeActionModel? action = null;
+        foreach (var a in runtimeModel.Actions)
+        {
+            if (string.Equals(a.Name, actionName, StringComparison.OrdinalIgnoreCase))
+            {
+                action = a;
+                break;
+            }
+        }
 
         if (action == null)
             return CommandResult.Fail($"Action '{intent.Operation}' not found on entity '{intent.EntitySlug}'.");
@@ -180,9 +187,9 @@ public sealed class CommandService : ICommandService
         }
 
         // §6.2 — collect touched aggregates and acquire locks in sorted order
-        var touchedIds = envelope.AggregateMutations
-            .Select(m => $"{m.AggregateType}:{m.AggregateId}")
-            .ToList();
+        var touchedIds = new List<string>(envelope.AggregateMutations.Count);
+        foreach (var m in envelope.AggregateMutations)
+            touchedIds.Add($"{m.AggregateType}:{m.AggregateId}");
 
         var transactionId = envelope.TransactionId;
         var lockTimeout = TimeSpan.FromSeconds(5);
@@ -202,9 +209,15 @@ public sealed class CommandService : ICommandService
         try
         {
             // Apply mutations for the primary aggregate to the loaded object
-            var primaryMutation = envelope.AggregateMutations
-                .FirstOrDefault(m => string.Equals(m.AggregateType, intent.EntitySlug,
-                    StringComparison.OrdinalIgnoreCase));
+            AggregateMutation? primaryMutation = null;
+            foreach (var m in envelope.AggregateMutations)
+            {
+                if (string.Equals(m.AggregateType, intent.EntitySlug, StringComparison.OrdinalIgnoreCase))
+                {
+                    primaryMutation = m;
+                    break;
+                }
+            }
 
             if (primaryMutation != null)
             {

--- a/BareMetalWeb.Runtime/IndexDefinition.cs
+++ b/BareMetalWeb.Runtime/IndexDefinition.cs
@@ -31,6 +31,5 @@ public class IndexDefinition : RenderableDataObject
 
     public IReadOnlyList<string> GetFieldList()
         => FieldNames
-            .Split('|', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            .ToArray();
+            .Split('|', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 }

--- a/BareMetalWeb.Runtime/MetadataExtractor.cs
+++ b/BareMetalWeb.Runtime/MetadataExtractor.cs
@@ -80,10 +80,8 @@ public static class MetadataExtractor
         var indexes = new List<IndexDefinition>();
         var nullabilityCtx = new NullabilityInfoContext();
 
-        var properties = type
-            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
-            .OrderBy(p => p.MetadataToken)
-            .ToArray();
+        var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+        Array.Sort(properties, (a, b) => a.MetadataToken.CompareTo(b.MetadataToken));
 
         int ordinal = 1;
         for (int i = 0; i < properties.Length; i++)

--- a/BareMetalWeb.Runtime/MetadataSeeder.cs
+++ b/BareMetalWeb.Runtime/MetadataSeeder.cs
@@ -42,15 +42,18 @@ public static class MetadataSeeder
         var seeded = new List<string>();
 
         // Load existing EntityDefinitions so we can skip already-seeded entities.
-        var existingDefs = (await store.QueryAsync<EntityDefinition>(null, cancellationToken)
-            .ConfigureAwait(false)).ToList();
+        var existingDefs = new List<EntityDefinition>(await store.QueryAsync<EntityDefinition>(null, cancellationToken)
+            .ConfigureAwait(false));
 
         // Index by the slug that will be used (either explicit Slug, or derived from Name).
-        var existingBySlug = existingDefs.ToDictionary(
-            e => !string.IsNullOrWhiteSpace(e.Slug)
+        var existingBySlug = new Dictionary<string, EntityDefinition>(StringComparer.OrdinalIgnoreCase);
+        foreach (var e in existingDefs)
+        {
+            var s = !string.IsNullOrWhiteSpace(e.Slug)
                 ? e.Slug!
-                : DataScaffold.ToSlug(e.Name),
-            StringComparer.OrdinalIgnoreCase);
+                : DataScaffold.ToSlug(e.Name);
+            existingBySlug[s] = e;
+        }
 
         foreach (var meta in DataScaffold.Entities)
         {
@@ -119,14 +122,12 @@ public static class MetadataSeeder
             Clauses = { new QueryClause { Field = "EntityId", Operator = QueryOperator.Equals, Value = entityDefId } }
         };
 
-        var fields = (await store.QueryAsync<FieldDefinition>(entityIdQuery, ct).ConfigureAwait(false))
-            .ToList();
+        var fields = new List<FieldDefinition>(await store.QueryAsync<FieldDefinition>(entityIdQuery, ct).ConfigureAwait(false));
 
         foreach (var f in fields)
             await store.DeleteAsync<FieldDefinition>(f.Key, ct).ConfigureAwait(false);
 
-        var idxs = (await store.QueryAsync<IndexDefinition>(entityIdQuery, ct).ConfigureAwait(false))
-            .ToList();
+        var idxs = new List<IndexDefinition>(await store.QueryAsync<IndexDefinition>(entityIdQuery, ct).ConfigureAwait(false));
 
         foreach (var idx in idxs)
             await store.DeleteAsync<IndexDefinition>(idx.Key, ct).ConfigureAwait(false);

--- a/BareMetalWeb.Runtime/QueryService.cs
+++ b/BareMetalWeb.Runtime/QueryService.cs
@@ -21,7 +21,10 @@ public sealed class QueryService : IQueryService
             return Array.Empty<Dictionary<string, object?>>();
 
         var items = await meta.Handlers.QueryAsync(query, cancellationToken).ConfigureAwait(false);
-        return items.Select(obj => SerializeObject(obj, meta));
+        var result = new List<Dictionary<string, object?>>();
+        foreach (var obj in items)
+            result.Add(SerializeObject(obj, meta));
+        return result;
     }
 
     /// <inheritdoc/>

--- a/BareMetalWeb.Runtime/RuntimeEntityCompiler.cs
+++ b/BareMetalWeb.Runtime/RuntimeEntityCompiler.cs
@@ -43,11 +43,17 @@ public sealed class RuntimeEntityCompiler : IRuntimeEntityCompiler
 
         // Sort fields: first by existing Ordinal (non-zero), then alphabetically.
         // Fields with Ordinal == 0 get assigned the next available ordinal.
-        var sortedFields = fields
-            .Where(f => !string.IsNullOrWhiteSpace(f.Name))
-            .OrderBy(f => f.Ordinal > 0 ? f.Ordinal : int.MaxValue)
-            .ThenBy(f => f.Name, StringComparer.OrdinalIgnoreCase)
-            .ToList();
+        var sortedFields = new List<FieldDefinition>();
+        foreach (var f in fields)
+            if (!string.IsNullOrWhiteSpace(f.Name)) sortedFields.Add(f);
+        sortedFields.Sort((a, b) =>
+        {
+            int ordA = a.Ordinal > 0 ? a.Ordinal : int.MaxValue;
+            int ordB = b.Ordinal > 0 ? b.Ordinal : int.MaxValue;
+            int cmp = ordA.CompareTo(ordB);
+            if (cmp != 0) return cmp;
+            return string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase);
+        });
 
         // Assign deterministic ordinals
         int nextOrdinal = 1;
@@ -59,7 +65,7 @@ public sealed class RuntimeEntityCompiler : IRuntimeEntityCompiler
         }
 
         // Re-sort by assigned ordinal
-        sortedFields = sortedFields.OrderBy(f => f.Ordinal).ToList();
+        sortedFields.Sort((a, b) => a.Ordinal.CompareTo(b.Ordinal));
 
         var compiledFields = new List<RuntimeFieldModel>(sortedFields.Count);
         foreach (var f in sortedFields)
@@ -118,44 +124,47 @@ public sealed class RuntimeEntityCompiler : IRuntimeEntityCompiler
 
         // ── Index compilation ──────────────────────────────────────────────────
 
-        var compiledIndexes = indexes
-            .Select(idx => new RuntimeIndexModel(
+        var compiledIndexes = new List<RuntimeIndexModel>(indexes.Count);
+        foreach (var idx in indexes)
+        {
+            compiledIndexes.Add(new RuntimeIndexModel(
                 IndexId: idx.Key.ToString(),
                 EntityId: idx.EntityId,
                 FieldNames: idx.GetFieldList(),
-                Type: string.IsNullOrWhiteSpace(idx.Type) ? "secondary" : idx.Type))
-            .ToList();
+                Type: string.IsNullOrWhiteSpace(idx.Type) ? "secondary" : idx.Type));
+        }
 
         // ── Action compilation ─────────────────────────────────────────────────
 
-        var compiledActions = actions
-            .Where(a => !string.IsNullOrWhiteSpace(a.Name))
-            .Select(a =>
+        var compiledActions = new List<RuntimeActionModel>();
+        foreach (var a in actions)
+        {
+            if (string.IsNullOrWhiteSpace(a.Name)) continue;
+            var actionKey = a.Key.ToString();
+            var topLevel = new List<ActionCommandDefinition>();
+            foreach (var c in actionCommands)
             {
-                var actionKey = a.Key.ToString();
-                // Load top-level commands for this action (ParentCommandId == null)
-                var topLevel = actionCommands
-                    .Where(c => string.Equals(c.ActionId, actionKey, StringComparison.OrdinalIgnoreCase)
-                             && string.IsNullOrWhiteSpace(c.ParentCommandId))
-                    .OrderBy(c => c.Order)
-                    .ToList();
+                if (string.Equals(c.ActionId, actionKey, StringComparison.OrdinalIgnoreCase)
+                    && string.IsNullOrWhiteSpace(c.ParentCommandId))
+                    topLevel.Add(c);
+            }
+            topLevel.Sort((x, y) => x.Order.CompareTo(y.Order));
 
-                var compiled = CompileCommands(topLevel, actionCommands, warnList);
+            var compiled = CompileCommands(topLevel, actionCommands, warnList);
 
-                return new RuntimeActionModel(
-                    ActionId: actionKey,
-                    EntityId: a.EntityId,
-                    Name: a.Name,
-                    Label: a.Label ?? a.Name,
-                    Icon: a.Icon,
-                    Permission: a.Permission,
-                    EnabledWhen: a.EnabledWhen,
-                    Operations: ParsePipeList(a.Operations),
-                    Commands: compiled,
-                    Version: a.Version
-                );
-            })
-            .ToList();
+            compiledActions.Add(new RuntimeActionModel(
+                ActionId: actionKey,
+                EntityId: a.EntityId,
+                Name: a.Name,
+                Label: a.Label ?? a.Name,
+                Icon: a.Icon,
+                Permission: a.Permission,
+                EnabledWhen: a.EnabledWhen,
+                Operations: ParsePipeList(a.Operations),
+                Commands: compiled,
+                Version: a.Version
+            ));
+        }
 
         // ── Schema hash ────────────────────────────────────────────────────────
 
@@ -336,8 +345,7 @@ public sealed class RuntimeEntityCompiler : IRuntimeEntityCompiler
             return Array.Empty<string>();
 
         return value
-            .Split('|', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            .ToArray();
+            .Split('|', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
     }
 
     /// <summary>
@@ -457,10 +465,11 @@ public sealed class RuntimeEntityCompiler : IRuntimeEntityCompiler
                 }
 
                 // Load sub-commands
-                var subDefs = allCommands
-                    .Where(c => string.Equals(c.ParentCommandId, defKey, StringComparison.OrdinalIgnoreCase))
-                    .OrderBy(c => c.Order)
-                    .ToList();
+                var subDefs = new List<ActionCommandDefinition>();
+                foreach (var c in allCommands)
+                    if (string.Equals(c.ParentCommandId, defKey, StringComparison.OrdinalIgnoreCase))
+                        subDefs.Add(c);
+                subDefs.Sort((x, y) => x.Order.CompareTo(y.Order));
 
                 var subCommands = CompileCommands(subDefs, allCommands, warnings);
 

--- a/BareMetalWeb.Runtime/RuntimeEntityModel.cs
+++ b/BareMetalWeb.Runtime/RuntimeEntityModel.cs
@@ -167,17 +167,22 @@ public sealed class RuntimeEntityModel
         }
 
         // Build action descriptors from RuntimeActionModel
-        var commands = Actions.Select((a, i) => new RemoteCommandMetadata(
-            Method: null!,
-            Name: a.Name,
-            Label: a.Label,
-            Icon: a.Icon,
-            ConfirmMessage: null,
-            Destructive: false,
-            Permission: a.Permission,
-            OverrideEntityPermissions: false,
-            Order: i
-        )).ToList();
+        var commands = new List<RemoteCommandMetadata>(Actions.Count);
+        for (int i = 0; i < Actions.Count; i++)
+        {
+            var a = Actions[i];
+            commands.Add(new RemoteCommandMetadata(
+                Method: null!,
+                Name: a.Name,
+                Label: a.Label,
+                Icon: a.Icon,
+                ConfirmMessage: null,
+                Destructive: false,
+                Permission: a.Permission,
+                OverrideEntityPermissions: false,
+                Order: i
+            ));
+        }
 
         var handlers = new DataEntityHandlers(
             Create: () => schema.CreateRecord(),
@@ -195,7 +200,9 @@ public sealed class RuntimeEntityModel
             QueryAsync: async (query, ct) =>
             {
                 var items = await walProvider.QueryRecordsAsync(schema, query, ct).ConfigureAwait(false);
-                return items.Cast<BaseDataObject>();
+                var result = new List<BaseDataObject>();
+                foreach (var item in items) result.Add((BaseDataObject)item);
+                return result;
             },
             CountAsync: (query, ct) => walProvider.CountRecordsAsync(schema, query, ct)
         );
@@ -212,7 +219,11 @@ public sealed class RuntimeEntityModel
             }
         }
 
-        return new DataEntityMetadata(
+            var docRelFields = new List<DataFieldMetadata>();
+            foreach (var f in fields)
+                if (f.RelatedDocument != null) docRelFields.Add(f);
+
+            return new DataEntityMetadata(
             Type: typeof(DataRecord),
             Name: Name,
             Slug: Slug,
@@ -226,7 +237,7 @@ public sealed class RuntimeEntityModel
             Fields: fields,
             Handlers: handlers,
             Commands: commands,
-            DocumentRelationFields: fields.Where(f => f.RelatedDocument != null).ToList()
+            DocumentRelationFields: docRelFields
         );
     }
 }

--- a/BareMetalWeb.Runtime/RuntimeEntityRegistry.cs
+++ b/BareMetalWeb.Runtime/RuntimeEntityRegistry.cs
@@ -48,7 +48,13 @@ public sealed class RuntimeEntityRegistry
             if (cached != null) return cached;
             lock (_sync)
             {
-                _sortedAll ??= _bySlug.Values.OrderBy(e => e.NavOrder).ThenBy(e => e.Name).ToArray();
+                var list = new List<RuntimeEntityModel>(_bySlug.Values);
+                list.Sort((a, b) =>
+                {
+                    int cmp = a.NavOrder.CompareTo(b.NavOrder);
+                    return cmp != 0 ? cmp : string.Compare(a.Name, b.Name, StringComparison.Ordinal);
+                });
+                _sortedAll ??= list.ToArray();
                 return _sortedAll;
             }
         }
@@ -158,7 +164,7 @@ public sealed class RuntimeEntityRegistry
         var registry = new RuntimeEntityRegistry();
 
         // Load all schema records in parallel
-        var entityDefs = (await store.QueryAsync<EntityDefinition>().ConfigureAwait(false)).ToList();
+        var entityDefs = new List<EntityDefinition>(await store.QueryAsync<EntityDefinition>().ConfigureAwait(false));
         if (entityDefs.Count == 0)
         {
             registry.Freeze();
@@ -166,10 +172,10 @@ public sealed class RuntimeEntityRegistry
             return registry;
         }
 
-        var allFields = (await store.QueryAsync<FieldDefinition>().ConfigureAwait(false)).ToList();
-        var allIndexes = (await store.QueryAsync<IndexDefinition>().ConfigureAwait(false)).ToList();
-        var allActions = (await store.QueryAsync<ActionDefinition>().ConfigureAwait(false)).ToList();
-        var allActionCommands = (await store.QueryAsync<ActionCommandDefinition>().ConfigureAwait(false)).ToList();
+        var allFields = new List<FieldDefinition>(await store.QueryAsync<FieldDefinition>().ConfigureAwait(false));
+        var allIndexes = new List<IndexDefinition>(await store.QueryAsync<IndexDefinition>().ConfigureAwait(false));
+        var allActions = new List<ActionDefinition>(await store.QueryAsync<ActionDefinition>().ConfigureAwait(false));
+        var allActionCommands = new List<ActionCommandDefinition>(await store.QueryAsync<ActionCommandDefinition>().ConfigureAwait(false));
 
         foreach (var entityDef in entityDefs)
         {
@@ -177,15 +183,18 @@ public sealed class RuntimeEntityRegistry
             if (string.IsNullOrWhiteSpace(entityDef.EntityId))
                 entityDef.EntityId = entityDef.Key.ToString();
 
-            var entityFields = allFields
-                .Where(f => string.Equals(f.EntityId, entityDef.EntityId, StringComparison.OrdinalIgnoreCase))
-                .ToList();
-            var entityIndexes = allIndexes
-                .Where(i => string.Equals(i.EntityId, entityDef.EntityId, StringComparison.OrdinalIgnoreCase))
-                .ToList();
-            var entityActions = allActions
-                .Where(a => string.Equals(a.EntityId, entityDef.EntityId, StringComparison.OrdinalIgnoreCase))
-                .ToList();
+            var entityFields = new List<FieldDefinition>();
+            foreach (var f in allFields)
+                if (string.Equals(f.EntityId, entityDef.EntityId, StringComparison.OrdinalIgnoreCase))
+                    entityFields.Add(f);
+            var entityIndexes = new List<IndexDefinition>();
+            foreach (var i in allIndexes)
+                if (string.Equals(i.EntityId, entityDef.EntityId, StringComparison.OrdinalIgnoreCase))
+                    entityIndexes.Add(i);
+            var entityActions = new List<ActionDefinition>();
+            foreach (var a in allActions)
+                if (string.Equals(a.EntityId, entityDef.EntityId, StringComparison.OrdinalIgnoreCase))
+                    entityActions.Add(a);
 
             // Ensure FieldId populated
             foreach (var f in entityFields)
@@ -193,12 +202,12 @@ public sealed class RuntimeEntityRegistry
                     f.FieldId = f.Key.ToString();
 
             // Gather all ActionCommandDefinitions whose ActionId belongs to this entity
-            var entityActionKeys = new HashSet<string>(
-                entityActions.Select(a => a.Key.ToString()),
-                StringComparer.OrdinalIgnoreCase);
-            var entityActionCommands = allActionCommands
-                .Where(c => entityActionKeys.Contains(c.ActionId))
-                .ToList();
+            var entityActionKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var a in entityActions)
+                entityActionKeys.Add(a.Key.ToString());
+            var entityActionCommands = new List<ActionCommandDefinition>();
+            foreach (var c in allActionCommands)
+                if (entityActionKeys.Contains(c.ActionId)) entityActionCommands.Add(c);
 
             var model = compiler.Compile(entityDef, entityFields, entityIndexes, entityActions,
                 entityActionCommands, out var warnings);

--- a/BareMetalWeb.Runtime/SampleGalleryService.cs
+++ b/BareMetalWeb.Runtime/SampleGalleryService.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -32,9 +31,14 @@ public static class SampleGalleryService
         var assembly = typeof(SampleGalleryService).Assembly;
         var packages = new List<SamplePackage>();
 
-        foreach (var resourceName in assembly.GetManifestResourceNames()
-            .Where(n => n.Contains(".Samples.") && n.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
-            .OrderBy(n => n))
+        var allResourceNames = assembly.GetManifestResourceNames();
+        var matchingResources = new List<string>();
+        foreach (var n in allResourceNames)
+            if (n.Contains(".Samples.") && n.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+                matchingResources.Add(n);
+        matchingResources.Sort(StringComparer.Ordinal);
+
+        foreach (var resourceName in matchingResources)
         {
             using var stream = assembly.GetManifestResourceStream(resourceName);
             if (stream == null) continue;
@@ -56,10 +60,15 @@ public static class SampleGalleryService
         ArgumentNullException.ThrowIfNull(slug);
 
         var assembly = typeof(SampleGalleryService).Assembly;
-        var resourceName = assembly.GetManifestResourceNames()
-            .FirstOrDefault(n =>
-                n.Contains(".Samples.") &&
-                n.EndsWith($".{slug}.json", StringComparison.OrdinalIgnoreCase));
+        string? resourceName = null;
+        foreach (var n in assembly.GetManifestResourceNames())
+        {
+            if (n.Contains(".Samples.") && n.EndsWith($".{slug}.json", StringComparison.OrdinalIgnoreCase))
+            {
+                resourceName = n;
+                break;
+            }
+        }
 
         if (resourceName == null) return null;
 
@@ -98,12 +107,15 @@ public static class SampleGalleryService
         var deployed = new List<string>();
 
         // Load existing EntityDefinitions so we can skip or overwrite
-        var existingDefs = (await store.QueryAsync<EntityDefinition>(null, cancellationToken)
-            .ConfigureAwait(false)).ToList();
+        var existingDefs = new List<EntityDefinition>(await store.QueryAsync<EntityDefinition>(null, cancellationToken)
+            .ConfigureAwait(false));
 
-        var existingBySlug = existingDefs.ToDictionary(
-            e => !string.IsNullOrWhiteSpace(e.Slug) ? e.Slug! : DataScaffold.ToSlug(e.Name),
-            StringComparer.OrdinalIgnoreCase);
+        var existingBySlug = new Dictionary<string, EntityDefinition>(StringComparer.OrdinalIgnoreCase);
+        foreach (var e in existingDefs)
+        {
+            var s = !string.IsNullOrWhiteSpace(e.Slug) ? e.Slug! : DataScaffold.ToSlug(e.Name);
+            existingBySlug[s] = e;
+        }
 
         foreach (var srcEntity in package.Entities)
         {
@@ -154,8 +166,9 @@ public static class SampleGalleryService
             await store.SaveAsync(newEntity, cancellationToken).ConfigureAwait(false);
 
             // Import fields that belong to this entity (matched by old entity Id from the JSON)
-            foreach (var srcField in package.Fields.Where(f => f.EntityId == oldEntityId))
+            foreach (var srcField in package.Fields)
             {
+                if (srcField.EntityId != oldEntityId) continue;
                 var newField = new FieldDefinition
                 {
                     FieldId = Guid.NewGuid().ToString("D"),
@@ -189,8 +202,9 @@ public static class SampleGalleryService
             }
 
             // Import indexes that belong to this entity
-            foreach (var srcIndex in package.Indexes.Where(ix => ix.EntityId == oldEntityId))
+            foreach (var srcIndex in package.Indexes)
             {
+                if (srcIndex.EntityId != oldEntityId) continue;
                 var newIndex = new IndexDefinition
                 {
                     EntityId = newEntity.EntityId,
@@ -202,8 +216,9 @@ public static class SampleGalleryService
             }
 
             // Import actions that belong to this entity
-            foreach (var srcAction in package.Actions.Where(a => a.EntityId == oldEntityId))
+            foreach (var srcAction in package.Actions)
             {
+                if (srcAction.EntityId != oldEntityId) continue;
                 var newAction = new ActionDefinition
                 {
                     EntityId = newEntity.EntityId,
@@ -218,8 +233,9 @@ public static class SampleGalleryService
                 await store.SaveAsync(newAction, cancellationToken).ConfigureAwait(false);
 
                 // Import action commands that belong to this action (matched by Name)
-                foreach (var srcCmd in package.ActionCommands.Where(c => c.ActionId == srcAction.Name))
+                foreach (var srcCmd in package.ActionCommands)
                 {
+                    if (srcCmd.ActionId != srcAction.Name) continue;
                     var newCmd = new ActionCommandDefinition
                     {
                         ActionId = newAction.Key.ToString(),
@@ -237,9 +253,9 @@ public static class SampleGalleryService
             }
 
             // Import reports that reference this entity slug
-            foreach (var srcReport in package.Reports.Where(r =>
-                string.Equals(r.RootEntity, srcEntity.Slug, StringComparison.OrdinalIgnoreCase)))
+            foreach (var srcReport in package.Reports)
             {
+                if (!string.Equals(srcReport.RootEntity, srcEntity.Slug, StringComparison.OrdinalIgnoreCase)) continue;
                 var newReport = new ReportDefinition
                 {
                     Name = srcReport.Name,
@@ -255,8 +271,9 @@ public static class SampleGalleryService
             }
 
             // Import aggregation definitions for this entity
-            foreach (var srcAgg in package.Aggregations.Where(a => a.EntityId == oldEntityId))
+            foreach (var srcAgg in package.Aggregations)
             {
+                if (srcAgg.EntityId != oldEntityId) continue;
                 var newAgg = new AggregationDefinition
                 {
                     EntityId = newEntity.EntityId,
@@ -268,8 +285,9 @@ public static class SampleGalleryService
             }
 
             // Import scheduled action definitions for this entity
-            foreach (var srcSched in package.ScheduledActions.Where(s => s.EntityId == oldEntityId))
+            foreach (var srcSched in package.ScheduledActions)
             {
+                if (srcSched.EntityId != oldEntityId) continue;
                 var newSched = new ScheduledActionDefinition
                 {
                     EntityId = newEntity.EntityId,
@@ -282,12 +300,16 @@ public static class SampleGalleryService
                 await store.SaveAsync(newSched, cancellationToken).ConfigureAwait(false);
             }
 
-            var fieldCount = package.Fields.Count(f => f.EntityId == oldEntityId);
-            var indexCount = package.Indexes.Count(ix => ix.EntityId == oldEntityId);
-            var actionCount = package.Actions.Count(a => a.EntityId == oldEntityId);
-            var reportCount = package.Reports.Count(r =>
-                string.Equals(r.RootEntity, srcEntity.Slug, StringComparison.OrdinalIgnoreCase));
-            var aggCount = package.Aggregations.Count(a => a.EntityId == oldEntityId);
+            int fieldCount = 0;
+            foreach (var f in package.Fields) if (f.EntityId == oldEntityId) fieldCount++;
+            int indexCount = 0;
+            foreach (var ix in package.Indexes) if (ix.EntityId == oldEntityId) indexCount++;
+            int actionCount = 0;
+            foreach (var a in package.Actions) if (a.EntityId == oldEntityId) actionCount++;
+            int reportCount = 0;
+            foreach (var r in package.Reports) if (string.Equals(r.RootEntity, srcEntity.Slug, StringComparison.OrdinalIgnoreCase)) reportCount++;
+            int aggCount = 0;
+            foreach (var a in package.Aggregations) if (a.EntityId == oldEntityId) aggCount++;
             logger?.Invoke($"Deployed '{srcEntity.Name}': {fieldCount} field(s), {indexCount} index(es), {actionCount} action(s), {reportCount} report(s), {aggCount} aggregation(s).");
             deployed.Add(srcEntity.Name);
         }
@@ -356,11 +378,11 @@ public static class SampleGalleryService
             Clauses = { new QueryClause { Field = "EntityId", Operator = QueryOperator.Equals, Value = entityDefId } }
         };
 
-        var fields = (await store.QueryAsync<FieldDefinition>(entityIdQuery, ct).ConfigureAwait(false)).ToList();
+        var fields = new List<FieldDefinition>(await store.QueryAsync<FieldDefinition>(entityIdQuery, ct).ConfigureAwait(false));
         foreach (var f in fields)
             await store.DeleteAsync<FieldDefinition>(f.Key, ct).ConfigureAwait(false);
 
-        var idxs = (await store.QueryAsync<IndexDefinition>(entityIdQuery, ct).ConfigureAwait(false)).ToList();
+        var idxs = new List<IndexDefinition>(await store.QueryAsync<IndexDefinition>(entityIdQuery, ct).ConfigureAwait(false));
         foreach (var idx in idxs)
             await store.DeleteAsync<IndexDefinition>(idx.Key, ct).ConfigureAwait(false);
 
@@ -369,14 +391,14 @@ public static class SampleGalleryService
         {
             Clauses = { new QueryClause { Field = "EntityId", Operator = QueryOperator.Equals, Value = entityDefId } }
         };
-        var actions = (await store.QueryAsync<ActionDefinition>(actionQuery, ct).ConfigureAwait(false)).ToList();
+        var actions = new List<ActionDefinition>(await store.QueryAsync<ActionDefinition>(actionQuery, ct).ConfigureAwait(false));
         foreach (var action in actions)
         {
             var cmdQuery = new QueryDefinition
             {
                 Clauses = { new QueryClause { Field = "ActionId", Operator = QueryOperator.Equals, Value = action.Key } }
             };
-            var cmds = (await store.QueryAsync<ActionCommandDefinition>(cmdQuery, ct).ConfigureAwait(false)).ToList();
+            var cmds = new List<ActionCommandDefinition>(await store.QueryAsync<ActionCommandDefinition>(cmdQuery, ct).ConfigureAwait(false));
             foreach (var cmd in cmds)
                 await store.DeleteAsync<ActionCommandDefinition>(cmd.Key, ct).ConfigureAwait(false);
             await store.DeleteAsync<ActionDefinition>(action.Key, ct).ConfigureAwait(false);
@@ -387,17 +409,17 @@ public static class SampleGalleryService
         {
             Clauses = { new QueryClause { Field = "RootEntity", Operator = QueryOperator.Equals, Value = entitySlug } }
         };
-        var reports = (await store.QueryAsync<ReportDefinition>(reportQuery, ct).ConfigureAwait(false)).ToList();
+        var reports = new List<ReportDefinition>(await store.QueryAsync<ReportDefinition>(reportQuery, ct).ConfigureAwait(false));
         foreach (var report in reports)
             await store.DeleteAsync<ReportDefinition>(report.Key, ct).ConfigureAwait(false);
 
         // Delete aggregation definitions
-        var aggs = (await store.QueryAsync<AggregationDefinition>(entityIdQuery, ct).ConfigureAwait(false)).ToList();
+        var aggs = new List<AggregationDefinition>(await store.QueryAsync<AggregationDefinition>(entityIdQuery, ct).ConfigureAwait(false));
         foreach (var agg in aggs)
             await store.DeleteAsync<AggregationDefinition>(agg.Key, ct).ConfigureAwait(false);
 
         // Delete scheduled actions
-        var scheds = (await store.QueryAsync<ScheduledActionDefinition>(entityIdQuery, ct).ConfigureAwait(false)).ToList();
+        var scheds = new List<ScheduledActionDefinition>(await store.QueryAsync<ScheduledActionDefinition>(entityIdQuery, ct).ConfigureAwait(false));
         foreach (var sched in scheds)
             await store.DeleteAsync<ScheduledActionDefinition>(sched.Key, ct).ConfigureAwait(false);
     }

--- a/BareMetalWeb.Runtime/TransactionEnvelope.cs
+++ b/BareMetalWeb.Runtime/TransactionEnvelope.cs
@@ -105,11 +105,26 @@ public sealed class TransactionEnvelope
     /// Returns <c>true</c> when no <see cref="AssertSeverity.Error"/> assertion fired.
     /// A <c>false</c> result means the commit must be aborted.
     /// </summary>
-    public bool IsValid => !Assertions.Any(a => a.Fired && a.Severity == AssertSeverity.Error);
+    public bool IsValid
+    {
+        get
+        {
+            foreach (var a in Assertions)
+                if (a.Fired && a.Severity == AssertSeverity.Error) return false;
+            return true;
+        }
+    }
 
     /// <summary>
     /// Returns the first error assertion that fired, or <c>null</c> when the envelope is valid.
     /// </summary>
-    public AssertionResult? FirstError =>
-        Assertions.FirstOrDefault(a => a.Fired && a.Severity == AssertSeverity.Error);
+    public AssertionResult? FirstError
+    {
+        get
+        {
+            foreach (var a in Assertions)
+                if (a.Fired && a.Severity == AssertSeverity.Error) return a;
+            return null;
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Removes every LINQ extension method call from all 79 production files and replaces with imperative loops. Test files are untouched for readability.

### Scope

| Project | Files Changed | Approx LINQ Calls Replaced |
|---------|--------------|---------------------------|
| BareMetalWeb.Host | 29 files | ~650+ |
| BareMetalWeb.Data | 30 files | ~400+ |
| BareMetalWeb.Rendering | 5 files | ~50+ |
| BareMetalWeb.Runtime | 12 files | ~100+ |
| BareMetalWeb.Core | 3 files | ~30+ |
| BareMetalWeb.AI/CLI/DataBrowser | 5 files | ~70+ |

### What was replaced

- `.Where()` → `foreach` + `if`/`continue`
- `.Select().ToList()` → `foreach` + `List.Add()`
- `.OrderBy()`/`.OrderByDescending()` → `List.Sort()` / `Array.Sort()`
- `.FirstOrDefault()` → `foreach` + `break`
- `.Any()`/`.All()` → `foreach` + bool flag
- `.GroupBy()` → `Dictionary<K, List<V>>` manual build
- `.Distinct()` → `HashSet<T>`
- `.Skip()`/`.Take()` → index tracking
- `.ToDictionary()` → manual `foreach`
- `.Sum()`/`.Min()`/`.Max()`/`.Average()` → manual accumulators
- `.Concat()` → `AddRange` / manual loops
- `.Cast<>()`/`.OfType<>()` → manual type checks

### What was NOT changed

- Test files (kept LINQ for readability)
- `System.Linq.Expressions` usage (expression trees, not query LINQ)
- `ImplicitUsings` in .csproj (auto-generates `global using System.Linq;` — harmless since no LINQ methods are called)
- Native collection methods (`List.Contains()`, `List.ToArray()`, `HashSet.Contains()`, `string.Contains()`, etc.)