### PR TITLE
fix: add missing BloomFilterPath and SchemaHashPath properties

### DIFF
--- a/BareMetalWeb.Data/DataLayerCapabilities.cs
+++ b/BareMetalWeb.Data/DataLayerCapabilities.cs
@@ -60,6 +60,18 @@ public static class DataLayerCapabilities
     }
 
     /// <summary>
+    /// The path used by <c>SearchIndexManager</c> for bloom filter hashing.
+    /// </summary>
+    public static string BloomFilterPath =>
+        "OrdinalIgnoreCase hash (zero-allocation, software)";
+
+    /// <summary>
+    /// The path used for schema hash computation.
+    /// </summary>
+    public static string SchemaHashPath =>
+        "SHA256 (managed, software)";
+
+    /// <summary>
     /// Returns a multi-line human-readable description of all active
     /// data-layer hardware acceleration paths.
     /// </summary>


### PR DESCRIPTION
Fixes the CI build failure (V1.472).

`DataLayerCapabilities.cs` referenced `BloomFilterPath` and `SchemaHashPath` properties that were never defined (introduced by another Copilot agent). Added the missing properties:

- **BloomFilterPath**: describes bloom filter hashing path (OrdinalIgnoreCase hash, zero-allocation, software)
- **SchemaHashPath**: describes schema hash computation path (SHA256, managed, software)

Build verified locally — full solution compiles cleanly.