### PR TITLE
feat: BmwContext, BmwRequest, and route jump table (fixes #922)

### DIFF
--- a/BareMetalWeb.Core/BmwContext.cs
+++ b/BareMetalWeb.Core/BmwContext.cs
@@ -1,0 +1,101 @@
+using System.IO.Pipelines;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using BareMetalWeb.Core.Host;
+using BareMetalWeb.Rendering;
+
+namespace BareMetalWeb.Core;
+
+/// <summary>
+/// Lightweight request context that wraps only the Kestrel features BMW needs.
+/// Created once per request in the pipeline entry point; avoids repeated
+/// IFeatureCollection lookups and HttpContext.Items dictionary access in handlers.
+/// </summary>
+/// <remarks>
+/// During migration, <see cref="HttpContext"/> remains available so existing
+/// handlers continue to work unchanged. New handlers should prefer the
+/// strongly-typed fields on this struct.
+/// </remarks>
+public sealed class BmwContext
+{
+    // ── Request data (populated once in CreateFrom) ─────────────────────
+    public BmwRequest Request;
+
+    // ── Pipelines ───────────────────────────────────────────────────────
+    public PipeReader RequestBody { get; }
+    public PipeWriter ResponseBody { get; }
+
+    // ── Features resolved once ──────────────────────────────────────────
+    public IHttpResponseFeature ResponseFeature { get; }
+    public IHttpConnectionFeature? ConnectionFeature { get; }
+
+    // ── BMW runtime state ───────────────────────────────────────────────
+    public IBareWebHost App { get; }
+    public PageInfo? PageInfo { get; set; }
+
+    /// <summary>Route parameters extracted by the jump-table or pattern router.</summary>
+    public Dictionary<string, string>? RouteParameters { get; set; }
+
+    // ── Migration bridge ────────────────────────────────────────────────
+    /// <summary>
+    /// The underlying ASP.NET HttpContext. Available during migration so
+    /// existing handlers can still access the full API surface. New code
+    /// should use the strongly-typed fields instead.
+    /// </summary>
+    public HttpContext HttpContext { get; }
+
+    /// <summary>Source IP extracted once from the connection feature.</summary>
+    public string SourceIp { get; }
+
+    /// <summary>Cancellation token from the underlying connection.</summary>
+    public CancellationToken RequestAborted => HttpContext.RequestAborted;
+
+    private BmwContext(
+        HttpContext httpContext,
+        BmwRequest request,
+        PipeReader requestBody,
+        PipeWriter responseBody,
+        IHttpResponseFeature responseFeature,
+        IHttpConnectionFeature? connectionFeature,
+        IBareWebHost app,
+        string sourceIp)
+    {
+        HttpContext = httpContext;
+        Request = request;
+        RequestBody = requestBody;
+        ResponseBody = responseBody;
+        ResponseFeature = responseFeature;
+        ConnectionFeature = connectionFeature;
+        App = app;
+        SourceIp = sourceIp;
+    }
+
+    /// <summary>
+    /// Creates a <see cref="BmwContext"/> from an <see cref="HttpContext"/>,
+    /// resolving all required features exactly once.
+    /// </summary>
+    public static BmwContext CreateFrom(HttpContext httpContext, IBareWebHost app)
+    {
+        var features = httpContext.Features;
+        var responseFeature = features.Get<IHttpResponseFeature>()!;
+        var connectionFeature = features.Get<IHttpConnectionFeature>();
+        var responseBodyFeature = features.Get<IHttpResponseBodyFeature>();
+
+        var request = new BmwRequest(
+            httpContext.Request.Method,
+            httpContext.Request.Path.Value ?? "/",
+            httpContext.Request.QueryString.Value ?? string.Empty);
+
+        var sourceIp = connectionFeature?.RemoteIpAddress?.ToString() ?? "unknown";
+
+        return new BmwContext(
+            httpContext,
+            request,
+            httpContext.Request.BodyReader,
+            responseBodyFeature?.Writer ?? httpContext.Response.BodyWriter,
+            responseFeature,
+            connectionFeature,
+            app,
+            sourceIp);
+    }
+}

--- a/BareMetalWeb.Core/BmwRequest.cs
+++ b/BareMetalWeb.Core/BmwRequest.cs
@@ -1,0 +1,33 @@
+namespace BareMetalWeb.Core;
+
+/// <summary>
+/// Parsed request data extracted once from the Kestrel request feature.
+/// Stored as strings (not spans) so the struct can live on the heap inside
+/// <see cref="BmwContext"/>. The values reference the same interned/pooled
+/// strings that Kestrel already provides — no extra allocations.
+/// </summary>
+public readonly struct BmwRequest
+{
+    /// <summary>HTTP method in uppercase (GET, POST, PUT, DELETE, etc.).</summary>
+    public readonly string Method;
+
+    /// <summary>Request path (e.g. "/api/users/42"). Normalised by Kestrel.</summary>
+    public readonly string Path;
+
+    /// <summary>Raw query string including the leading '?' (e.g. "?page=1&amp;size=10"), or empty.</summary>
+    public readonly string QueryString;
+
+    /// <summary>
+    /// Pre-computed route key in the form "METHOD /path" used for jump-table lookup.
+    /// Computed once at context creation time.
+    /// </summary>
+    public readonly string RouteKey;
+
+    public BmwRequest(string method, string path, string queryString)
+    {
+        Method = method;
+        Path = path;
+        QueryString = queryString;
+        RouteKey = string.Concat(method, " ", path);
+    }
+}

--- a/BareMetalWeb.Host/BareMetalWebServer.cs
+++ b/BareMetalWeb.Host/BareMetalWebServer.cs
@@ -86,6 +86,8 @@ public class BareMetalWebServer : IBareWebHost
     private readonly Dictionary<string, CompiledRoute> _compiledRoutes = new(StringComparer.Ordinal);
     private List<(string Key, RouteHandlerData Data, CompiledRoute Compiled)>? _sortedRoutes;
     private int _sortedRoutesVersion = -1;
+    private readonly RouteJumpTable _jumpTable = new();
+    private int _jumpTableVersion = -1;
     public BareMetalWebServer(
         string appName,
         string companyDescription,
@@ -321,8 +323,20 @@ public class BareMetalWebServer : IBareWebHost
         }
         return _sortedRoutes;
     }
+
+    /// <summary>Ensures the jump table is rebuilt when routes change.</summary>
+    private void EnsureJumpTable()
+    {
+        if (_jumpTableVersion != _routesVersion)
+        {
+            _jumpTable.Build(routes, _compiledRoutes, BufferedLogger);
+            _jumpTableVersion = _routesVersion;
+        }
+    }
     public Task WireUpRequestHandlingAndLoggerAsyncLifetime()
     {
+        // Build the jump table for O(1) exact-match route dispatch
+        EnsureJumpTable();
         // Single terminal request handler. We deliberately do not use routing, MVC, or minimal APIs. All requests are handled explicitly by RequestHandler.
         app.Use(async (HttpContext context, RequestDelegate _) => await RequestHandler(context));
         // Start everything (logging, request handling etc)
@@ -341,11 +355,13 @@ public class BareMetalWebServer : IBareWebHost
     public async Task RequestHandler(HttpContext context)
     {
         var stopwatch = Stopwatch.StartNew();
-        // Kestrel normalises HTTP methods to uppercase; avoid the extra allocation from ToUpperInvariant().
-        string method = context.Request.Method;
-        string requestPath = context.Request.Path.Value ?? "/";
-        string path = method + " " + requestPath;
-        string sourceIp = context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+
+        // ── Create BmwContext: resolve features once per request ─────────
+        var bmwCtx = BmwContext.CreateFrom(context, this);
+        string method = bmwCtx.Request.Method;
+        string requestPath = bmwCtx.Request.Path;
+        string routeKey = bmwCtx.Request.RouteKey;
+        string sourceIp = bmwCtx.SourceIp;
         context.SetApp(this);
 
         // ── Multitenancy: resolve tenant from Host header ─────────────────────
@@ -362,7 +378,7 @@ public class BareMetalWebServer : IBareWebHost
             var httpsUrl = BuildHttpsRedirectUrl(context, TrustForwardedHeaders, HttpsRedirectHost, HttpsRedirectPort);
             context.Response.StatusCode = StatusCodes.Status301MovedPermanently;
             context.Response.Headers.Location = httpsUrl;
-            BufferedLogger.LogInfo($"{path}|301|{sourceIp}|redirect={httpsUrl}|mode={HttpsRedirectMode}|httpsAvailable={HttpsEndpointAvailable}|trustForwarded={TrustForwardedHeaders}|host={context.Request.Host}");
+            BufferedLogger.LogInfo($"{routeKey}|301|{sourceIp}|redirect={httpsUrl}|mode={HttpsRedirectMode}|httpsAvailable={HttpsEndpointAvailable}|trustForwarded={TrustForwardedHeaders}|host={context.Request.Host}");
             return;
         }
         ApplySecurityHeaders(context, isHttps);
@@ -388,7 +404,7 @@ public class BareMetalWebServer : IBareWebHost
                 ? $"Too many Requests. Retry after {retryAfterSeconds.Value}s."
                 : "Too many Requests.";
             await context.Response.WriteAsync(retryText);
-            BufferedLogger.LogInfo($"{path}|429|{sourceIp}|{throttleReason}");
+            BufferedLogger.LogInfo($"{routeKey}|429|{sourceIp}|{throttleReason}");
             stopwatch.Stop();
             Metrics.RecordThrottled(stopwatch.Elapsed);
             return;
@@ -399,25 +415,25 @@ public class BareMetalWebServer : IBareWebHost
             {
                 context.Response.StatusCode = StatusCodes.Status302Found;
                 context.Response.Headers.Location = "/setup";
-                BufferedLogger.LogInfo($"{path}|302|{sourceIp}|setup=required");
+                BufferedLogger.LogInfo($"{routeKey}|302|{sourceIp}|setup=required");
                 return;
             }
 
             if (await JsBundleService.TryServeAsync(context))
             {
-                BufferedLogger.LogInfo($"{path}|{context.Response.StatusCode}|{sourceIp}|bundle");
+                BufferedLogger.LogInfo($"{routeKey}|{context.Response.StatusCode}|{sourceIp}|bundle");
                 return;
             }
 
             if (await CssBundleService.TryServeAsync(context))
             {
-                BufferedLogger.LogInfo($"{path}|{context.Response.StatusCode}|{sourceIp}|css-bundle");
+                BufferedLogger.LogInfo($"{routeKey}|{context.Response.StatusCode}|{sourceIp}|css-bundle");
                 return;
             }
 
             if (await StaticFileService.TryServeAsync(context, StaticFiles))
             {
-                BufferedLogger.LogInfo($"{path}|{context.Response.StatusCode}|{sourceIp}|static");
+                BufferedLogger.LogInfo($"{routeKey}|{context.Response.StatusCode}|{sourceIp}|static");
                 return;
             }
 
@@ -425,10 +441,10 @@ public class BareMetalWebServer : IBareWebHost
             // not for static assets (bundles, files) served above.
             await BuildAppInfoMenuOptionsAsync(context, context.RequestAborted).ConfigureAwait(false);
 
-            // (simplistic routing and parameter service) - Exact match first
-            if (routes.TryGetValue(path, out RouteHandlerData page))
+            // ── Jump table: O(1) exact-match dispatch ───────────────────────
+            EnsureJumpTable();
+            if (_jumpTable.TryLookup(routeKey, out RouteHandlerData page))
             {
-                // exact match found - no params needed.
                 if (page.PageInfo != null)
                 {
                     context.SetPageInfo(page.PageInfo);
@@ -436,14 +452,15 @@ public class BareMetalWebServer : IBareWebHost
                 if (!await IsAuthorizedAsync(page.PageInfo, context, context.RequestAborted).ConfigureAwait(false))
                 {
                     await RenderForbidden(context);
-                    await LogAccessDeniedAsync(path, sourceIp, context, page.PageInfo, context.RequestAborted).ConfigureAwait(false);
+                    await LogAccessDeniedAsync(routeKey, sourceIp, context, page.PageInfo, context.RequestAborted).ConfigureAwait(false);
                     return;
                 }
                 await page.Handler(context);
-                BufferedLogger.LogInfo($"{path}|200|{sourceIp}");
+                BufferedLogger.LogInfo($"{routeKey}|200|{sourceIp}");
                 return;
             }
-            if (routes.TryGetValue($"ALL {requestPath}", out RouteHandlerData allPage))
+            // Jump table also handles "ALL" verb routes
+            if (_jumpTable.TryLookup(string.Concat("ALL ", requestPath), out RouteHandlerData allPage))
             {
                 if (allPage.PageInfo != null)
                 {
@@ -452,11 +469,11 @@ public class BareMetalWebServer : IBareWebHost
                 if (!await IsAuthorizedAsync(allPage.PageInfo, context, context.RequestAborted).ConfigureAwait(false))
                 {
                     await RenderForbidden(context);
-                    await LogAccessDeniedAsync(path, sourceIp, context, allPage.PageInfo, context.RequestAborted).ConfigureAwait(false);
+                    await LogAccessDeniedAsync(routeKey, sourceIp, context, allPage.PageInfo, context.RequestAborted).ConfigureAwait(false);
                     return;
                 }
                 await allPage.Handler(context);
-                BufferedLogger.LogInfo($"{path}|ALL {requestPath}|200|{sourceIp}");
+                BufferedLogger.LogInfo($"{routeKey}|ALL {requestPath}|200|{sourceIp}");
                 return;
             }
             // Pattern match fallback — iterate most-specific routes first so that literal
@@ -481,7 +498,7 @@ public class BareMetalWebServer : IBareWebHost
                     if (!await IsAuthorizedAsync(injectedPage.PageInfo, context, context.RequestAborted).ConfigureAwait(false))
                     {
                         await RenderForbidden(context);
-                        await LogAccessDeniedAsync(path, sourceIp, context, injectedPage.PageInfo, context.RequestAborted).ConfigureAwait(false);
+                        await LogAccessDeniedAsync(routeKey, sourceIp, context, injectedPage.PageInfo, context.RequestAborted).ConfigureAwait(false);
                         return;
                     }
                     await injectedPage.Handler(context);
@@ -489,7 +506,7 @@ public class BareMetalWebServer : IBareWebHost
                     int paramIdx = 0;
                     foreach (var p in parameters)
                         paramParts[paramIdx++] = $"{p.Key}={p.Value}";
-                    BufferedLogger.LogInfo($"{path}|{method}|{compiled.Verb}|{string.Join(", ", paramParts)}|200|{sourceIp}");
+                    BufferedLogger.LogInfo($"{routeKey}|{method}|{compiled.Verb}|{string.Join(", ", paramParts)}|200|{sourceIp}");
                     return;
                 }
             }
@@ -513,7 +530,7 @@ public class BareMetalWebServer : IBareWebHost
                     if (!await IsAuthorizedAsync(injectedPage.PageInfo, context, context.RequestAborted).ConfigureAwait(false))
                     {
                         await RenderForbidden(context);
-                        await LogAccessDeniedAsync(path, sourceIp, context, injectedPage.PageInfo, context.RequestAborted).ConfigureAwait(false);
+                        await LogAccessDeniedAsync(routeKey, sourceIp, context, injectedPage.PageInfo, context.RequestAborted).ConfigureAwait(false);
                         return;
                     }
                     await injectedPage.Handler(context);
@@ -521,7 +538,7 @@ public class BareMetalWebServer : IBareWebHost
                     int paramIdx2 = 0;
                     foreach (var p in parameters)
                         paramParts2[paramIdx2++] = $"{p.Key}={p.Value}";
-                    BufferedLogger.LogInfo($"{path}|{method}|{compiled.Verb}|{string.Join(", ", paramParts2)}|200|{sourceIp}");
+                    BufferedLogger.LogInfo($"{routeKey}|{method}|{compiled.Verb}|{string.Join(", ", paramParts2)}|200|{sourceIp}");
                     return;
                 }
             }
@@ -530,21 +547,21 @@ public class BareMetalWebServer : IBareWebHost
                 context.Response.StatusCode = StatusCodes.Status405MethodNotAllowed;
                 context.SetPageInfo(ErrorPageInfo);
                 await HtmlRenderer.RenderPage(context);
-                BufferedLogger.LogInfo($"{path}|405|{sourceIp}");
+                BufferedLogger.LogInfo($"{routeKey}|405|{sourceIp}");
                 return;
             }
             context.SetPageInfo(NotFoundPageInfo);
             await HtmlRenderer.RenderPage(context); // Still nothing? 404
-            BufferedLogger.LogInfo($"{path}|404|{sourceIp}");
+            BufferedLogger.LogInfo($"{routeKey}|404|{sourceIp}");
         }
         catch (OperationCanceledException oce)
         {
-            BufferedLogger.LogInfo($"Client disconnected:{path}|{oce.Message}|{sourceIp}");
+            BufferedLogger.LogInfo($"Client disconnected:{routeKey}|{oce.Message}|{sourceIp}");
         }
         catch (Exception ex)
         {
             var errorId = Guid.NewGuid().ToString("N");
-            BufferedLogger.LogError($"Exception: {path} | {sourceIp} | ErrorId={errorId}", ex);
+            BufferedLogger.LogError($"Exception: {routeKey} | {sourceIp} | ErrorId={errorId}", ex);
             if (context.Response.HasStarted)
             {
                 context.Abort();
@@ -564,7 +581,7 @@ public class BareMetalWebServer : IBareWebHost
                 context.SetStringValue("html_message", $"<p>An unexpected error occurred.</p><p>Error ID: <code>{errorId}</code></p>");
                 await HtmlRenderer.RenderPage(context); // Render error page
             }
-            BufferedLogger.LogInfo($"{path}|500|{sourceIp}");
+            BufferedLogger.LogInfo($"{routeKey}|500|{sourceIp}");
         }
         finally
         {

--- a/BareMetalWeb.Host/RouteHash.cs
+++ b/BareMetalWeb.Host/RouteHash.cs
@@ -1,0 +1,44 @@
+using System.Runtime.CompilerServices;
+
+namespace BareMetalWeb.Host;
+
+/// <summary>
+/// FNV-1a hash for route keys. Deterministic, extremely fast, and operates
+/// on <see cref="ReadOnlySpan{T}"/> to avoid allocations.
+/// </summary>
+/// <remarks>
+/// FNV-1a is chosen over xxHash for simplicity — the input sizes (short route
+/// strings) don't benefit from SIMD acceleration, and FNV-1a has excellent
+/// distribution for string keys.
+/// </remarks>
+public static class RouteHash
+{
+    private const uint FnvOffsetBasis = 2166136261u;
+    private const uint FnvPrime = 16777619u;
+
+    /// <summary>Compute FNV-1a hash of a route key string.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static uint Hash(string key)
+    {
+        uint hash = FnvOffsetBasis;
+        for (int i = 0; i < key.Length; i++)
+        {
+            hash ^= key[i];
+            hash *= FnvPrime;
+        }
+        return hash;
+    }
+
+    /// <summary>Compute FNV-1a hash of a route key span.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static uint Hash(ReadOnlySpan<char> key)
+    {
+        uint hash = FnvOffsetBasis;
+        for (int i = 0; i < key.Length; i++)
+        {
+            hash ^= key[i];
+            hash *= FnvPrime;
+        }
+        return hash;
+    }
+}

--- a/BareMetalWeb.Host/RouteJumpTable.cs
+++ b/BareMetalWeb.Host/RouteJumpTable.cs
@@ -1,0 +1,163 @@
+using BareMetalWeb.Core;
+using BareMetalWeb.Core.Interfaces;
+using BareMetalWeb.Interfaces;
+
+namespace BareMetalWeb.Host;
+
+/// <summary>
+/// A hash-indexed dispatch table for exact-match route lookup in O(1).
+/// Routes with parameters (e.g. <c>/api/{type}/{id}</c>) are not eligible
+/// and fall through to the pattern-matching path.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The table uses open addressing with linear probing. Slot count is the
+/// next power-of-two ≥ 2× the route count, giving a load factor ≤ 0.5
+/// for fast probing. Collisions are resolved at startup; at runtime a
+/// single hash + mask + equality check is the fast path.
+/// </para>
+/// <para>
+/// Rebuilt whenever routes change (tracked via a version counter).
+/// The rebuild is cheap — typically &lt;150 routes.
+/// </para>
+/// </remarks>
+public sealed class RouteJumpTable
+{
+    private struct Slot
+    {
+        public uint Hash;
+        public string Key;          // "GET /login" — the exact route key
+        public RouteHandlerData Data;
+        public bool Occupied;
+    }
+
+    private Slot[] _slots = Array.Empty<Slot>();
+    private uint _mask;
+    private int _count;
+    private int _version;
+
+    /// <summary>Number of exact-match routes in the jump table.</summary>
+    public int Count => _count;
+
+    /// <summary>
+    /// Rebuild the jump table from the current route dictionary.
+    /// Only includes routes that have no parameter segments (exact-match only).
+    /// </summary>
+    public void Build(Dictionary<string, RouteHandlerData> routes, Dictionary<string, CompiledRoute> compiledRoutes, IBufferedLogger logger)
+    {
+        // Collect exact-match routes (no parameters, no regex, no catch-all)
+        var exactRoutes = new List<(string Key, RouteHandlerData Data, uint Hash)>();
+        foreach (var kvp in routes)
+        {
+            if (compiledRoutes.TryGetValue(kvp.Key, out var compiled))
+            {
+                if (compiled.IsRegex || compiled.ParameterCount > 0)
+                    continue; // Skip parameterised/regex routes
+            }
+
+            uint hash = RouteHash.Hash(kvp.Key);
+            exactRoutes.Add((kvp.Key, kvp.Value, hash));
+        }
+
+        if (exactRoutes.Count == 0)
+        {
+            _slots = Array.Empty<Slot>();
+            _mask = 0;
+            _count = 0;
+            _version++;
+            return;
+        }
+
+        // Table size = next power-of-two ≥ 2× route count (load factor ≤ 0.5)
+        int tableSize = NextPowerOfTwo(exactRoutes.Count * 2);
+        uint mask = (uint)(tableSize - 1);
+        var slots = new Slot[tableSize];
+
+        // Insert with linear probing; detect collisions at build time
+        for (int i = 0; i < exactRoutes.Count; i++)
+        {
+            var (key, data, hash) = exactRoutes[i];
+            uint idx = hash & mask;
+
+            int probes = 0;
+            while (slots[idx].Occupied)
+            {
+                if (slots[idx].Hash == hash && string.Equals(slots[idx].Key, key, StringComparison.Ordinal))
+                {
+                    // Duplicate route key — overwrite (same as dictionary behaviour)
+                    break;
+                }
+                idx = (idx + 1) & mask;
+                probes++;
+                if (probes >= tableSize)
+                    throw new InvalidOperationException($"Route jump table full — this should never happen (table size {tableSize}, routes {exactRoutes.Count})");
+            }
+
+            slots[idx] = new Slot
+            {
+                Hash = hash,
+                Key = key,
+                Data = data,
+                Occupied = true
+            };
+        }
+
+        _slots = slots;
+        _mask = mask;
+        _count = exactRoutes.Count;
+        _version++;
+
+        logger.LogInfo($"Route jump table built: {exactRoutes.Count} exact routes in {tableSize}-slot table (load factor {(double)exactRoutes.Count / tableSize:P0})");
+    }
+
+    /// <summary>
+    /// Look up an exact-match route by its pre-computed hash and key string.
+    /// Returns true if found; the handler data is written to <paramref name="data"/>.
+    /// </summary>
+    public bool TryLookup(uint hash, string routeKey, out RouteHandlerData data)
+    {
+        var slots = _slots;
+        if (slots.Length == 0)
+        {
+            data = default;
+            return false;
+        }
+
+        uint mask = _mask;
+        uint idx = hash & mask;
+
+        // Linear probing — average 1-2 probes at ≤50% load factor
+        while (true)
+        {
+            ref var slot = ref slots[idx];
+            if (!slot.Occupied)
+            {
+                data = default;
+                return false;
+            }
+            if (slot.Hash == hash && string.Equals(slot.Key, routeKey, StringComparison.Ordinal))
+            {
+                data = slot.Data;
+                return true;
+            }
+            idx = (idx + 1) & mask;
+        }
+    }
+
+    /// <summary>
+    /// Convenience overload that hashes the key inline.
+    /// </summary>
+    public bool TryLookup(string routeKey, out RouteHandlerData data)
+        => TryLookup(RouteHash.Hash(routeKey), routeKey, out data);
+
+    private static int NextPowerOfTwo(int v)
+    {
+        v--;
+        v |= v >> 1;
+        v |= v >> 2;
+        v |= v >> 4;
+        v |= v >> 8;
+        v |= v >> 16;
+        return v + 1;
+    }
+}


### PR DESCRIPTION
## Summary
Introduces the BMW request context abstraction and O(1) hash-indexed route dispatch, laying the foundation for direct Kestrel hosting (#923, #925) and perfect hashing (#924).

## New types

### `BmwContext` (Core)
Lightweight per-request context created once at pipeline entry. Resolves Kestrel `IFeatureCollection` features exactly once:
- `Request` — parsed `BmwRequest` struct
- `RequestBody` / `ResponseBody` — `PipeReader` / `PipeWriter`
- `ResponseFeature` / `ConnectionFeature` — resolved once, not per-access
- `SourceIp` — extracted from connection feature
- `App`, `PageInfo`, `RouteParameters` — BMW runtime state
- `HttpContext` — migration bridge for existing handlers

### `BmwRequest` (Core)
Readonly struct: `Method`, `Path`, `QueryString`, and pre-computed `RouteKey` (`"METHOD /path"`).

### `RouteHash` (Host)
FNV-1a hash function operating on `string` and `ReadOnlySpan<char>`. Deterministic, extremely fast for short route strings.

### `RouteJumpTable` (Host)
Open-addressing hash table with linear probing for O(1) exact-match route dispatch:
- Only indexes routes without parameters (exact-match)
- Load factor ≤ 0.5 (table size = next power-of-two ≥ 2× route count)
- Rebuilt lazily when routes change (version-tracked)
- Collision detection at build time

## Pipeline changes
`RequestHandler` now:
1. Creates `BmwContext` once per request (single feature resolution)
2. Uses jump table as primary fast path for exact-match routes
3. Falls through to sorted pattern matching for parameterised routes
4. Eliminates redundant `string.Concat` for route key (computed once in `BmwRequest`)

Fixes #922