### PR TITLE
feat: Direct Kestrel hosting via BmwApplication and BmwHost (fixes #923)

### DIFF
--- a/BareMetalWeb.Core/BmwContext.cs
+++ b/BareMetalWeb.Core/BmwContext.cs
@@ -98,4 +98,37 @@ public sealed class BmwContext
             app,
             sourceIp);
     }
+
+    /// <summary>
+    /// Creates a <see cref="BmwContext"/> directly from Kestrel's
+    /// <see cref="IFeatureCollection"/> — used by <c>BmwApplication</c>
+    /// when running without the ASP.NET middleware pipeline.
+    /// A <see cref="DefaultHttpContext"/> is created as a migration bridge.
+    /// </summary>
+    public static BmwContext CreateFromFeatures(IFeatureCollection features, IBareWebHost app)
+    {
+        var httpContext = new DefaultHttpContext(features);
+
+        var responseFeature = features.Get<IHttpResponseFeature>()!;
+        var connectionFeature = features.Get<IHttpConnectionFeature>();
+        var responseBodyFeature = features.Get<IHttpResponseBodyFeature>();
+        var requestFeature = features.Get<IHttpRequestFeature>()!;
+
+        var request = new BmwRequest(
+            requestFeature.Method,
+            requestFeature.Path,
+            requestFeature.QueryString ?? string.Empty);
+
+        var sourceIp = connectionFeature?.RemoteIpAddress?.ToString() ?? "unknown";
+
+        return new BmwContext(
+            httpContext,
+            request,
+            httpContext.Request.BodyReader,
+            responseBodyFeature?.Writer ?? httpContext.Response.BodyWriter,
+            responseFeature,
+            connectionFeature,
+            app,
+            sourceIp);
+    }
 }

--- a/BareMetalWeb.Host/BareMetalWebExtensions.cs
+++ b/BareMetalWeb.Host/BareMetalWebExtensions.cs
@@ -26,7 +26,7 @@ public static class BareMetalWebExtensions
     /// authentication, routing, static files, CORS, HTTPS, and proxy support.
     /// Optionally pass <paramref name="configureRoutes"/> to register additional routes.
     /// </summary>
-    public static async Task UseBareMetalWeb(
+    public static async Task<BareMetalWebServer> UseBareMetalWeb(
         this WebApplication app,
         Action<BareMetalWebServer, IRouteHandlers, IPageInfoFactory, IHtmlTemplate>? configureRoutes = null)
     {
@@ -316,5 +316,38 @@ public static class BareMetalWebExtensions
                 Console.WriteLine(warn);
             }
         });
+
+        return appInfo;
+    }
+
+    /// <summary>
+    /// Configures the full BareMetalWeb stack and returns a <see cref="BmwHost"/>
+    /// for direct Kestrel hosting — no ASP.NET middleware pipeline.
+    /// <para>
+    /// Uses <see cref="UseBareMetalWeb"/> for initialization, then replaces the
+    /// serving layer with a direct <c>KestrelServer</c> + <see cref="BmwApplication"/>.
+    /// </para>
+    /// <example>
+    /// <code>
+    /// var builder = WebApplication.CreateBuilder();
+    /// var app = builder.Build();
+    /// await using var host = await app.UseBareMetalWebDirect(
+    ///     configureKestrel: opts => opts.ListenAnyIP(5000));
+    /// await host.RunAsync();
+    /// </code>
+    /// </example>
+    /// </summary>
+    public static async Task<BmwHost> UseBareMetalWebDirect(
+        this WebApplication app,
+        Action<Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions>? configureKestrel = null,
+        Action<BareMetalWebServer, IRouteHandlers, IPageInfoFactory, IHtmlTemplate>? configureRoutes = null)
+    {
+        // Initialize the full stack via UseBareMetalWeb but capture the server instance
+        BareMetalWebServer? appInfo = await app.UseBareMetalWeb(configureRoutes);
+
+        // Re-wire for direct hosting: stop the middleware path, start the direct path
+        await appInfo.WireUpDirectHosting();
+
+        return BmwHost.Create(appInfo, configureKestrel);
     }
 }

--- a/BareMetalWeb.Host/BareMetalWebServer.cs
+++ b/BareMetalWeb.Host/BareMetalWebServer.cs
@@ -339,18 +339,36 @@ public class BareMetalWebServer : IBareWebHost
         EnsureJumpTable();
         // Single terminal request handler. We deliberately do not use routing, MVC, or minimal APIs. All requests are handled explicitly by RequestHandler.
         app.Use(async (HttpContext context, RequestDelegate _) => await RequestHandler(context));
-        // Start everything (logging, request handling etc)
-        Task loggerTask = BufferedLogger.RunAsync(cts.Token); // Run the logging flusher loop
-        Task clientPruneTask = ClientRequests.RunPruningAsync(cts.Token); // Run client pruning loop
-        Task todoPeriodicityTask = new TodoPeriodicityService(BufferedLogger).RunAsync(cts.Token); // Run todo periodicity reset loop
-        Task scheduledActionTask = new ScheduledActionService(BufferedLogger).RunAsync(cts.Token); // Run scheduled action execution loop
-        app.Lifetime.ApplicationStopping.Register(() => BufferedLogger.OnApplicationStopping(cts, loggerTask)); // Setup shutdown to stop the logging flusher loop
-        // log it
+        // Start background services
+        StartBackgroundServices();
+        app.Lifetime.ApplicationStopping.Register(() => BufferedLogger.OnApplicationStopping(cts, _loggerTask!));
         BufferedLogger.LogInfo($"WireUpRequestHandlingAndLoggerAsyncLifetime completed and request handling is live.");
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Prepares the server for direct Kestrel hosting via <see cref="BmwHost"/>.
+    /// Does NOT register ASP.NET middleware — Kestrel calls
+    /// <see cref="BmwApplication.ProcessRequestAsync"/> directly.
+    /// </summary>
+    public Task WireUpDirectHosting()
+    {
+        EnsureJumpTable();
+        StartBackgroundServices();
+        BufferedLogger.LogInfo("WireUpDirectHosting completed — ready for BmwHost.RunAsync().");
+        return Task.CompletedTask;
+    }
+
+    private Task? _loggerTask;
+    private void StartBackgroundServices()
+    {
+        _loggerTask = BufferedLogger.RunAsync(cts.Token);
+        Task clientPruneTask = ClientRequests.RunPruningAsync(cts.Token);
+        Task todoPeriodicityTask = new TodoPeriodicityService(BufferedLogger).RunAsync(cts.Token);
+        Task scheduledActionTask = new ScheduledActionService(BufferedLogger).RunAsync(cts.Token);
         _ = clientPruneTask;
         _ = todoPeriodicityTask;
         _ = scheduledActionTask;
-        return Task.CompletedTask;
     }
     public async Task RequestHandler(HttpContext context)
     {

--- a/BareMetalWeb.Host/BmwApplication.cs
+++ b/BareMetalWeb.Host/BmwApplication.cs
@@ -1,0 +1,55 @@
+using BareMetalWeb.Core;
+using BareMetalWeb.Core.Host;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Http.Features;
+
+namespace BareMetalWeb.Host;
+
+/// <summary>
+/// Implements <see cref="IHttpApplication{TContext}"/> so that Kestrel
+/// drives the BMW request pipeline directly — no ASP.NET middleware,
+/// no <c>WebApplication</c>, no <c>UseRouting</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The lifecycle per request is:
+/// <list type="number">
+///   <item>Kestrel calls <see cref="CreateContext"/> with the raw feature collection.</item>
+///   <item><see cref="ProcessRequestAsync"/> dispatches through the BMW router.</item>
+///   <item><see cref="DisposeContext"/> performs minimal cleanup.</item>
+/// </list>
+/// </para>
+/// </remarks>
+public sealed class BmwApplication : IHttpApplication<BmwContext>
+{
+    private readonly BareMetalWebServer _server;
+
+    public BmwApplication(BareMetalWebServer server)
+    {
+        _server = server;
+    }
+
+    /// <summary>
+    /// Called by Kestrel once per request. Resolves features and builds
+    /// a <see cref="BmwContext"/> with a <c>DefaultHttpContext</c> bridge
+    /// for backward-compatible handler access.
+    /// </summary>
+    public BmwContext CreateContext(IFeatureCollection contextFeatures)
+        => BmwContext.CreateFromFeatures(contextFeatures, _server);
+
+    /// <summary>
+    /// Dispatches the request through the existing <see cref="BareMetalWebServer.RequestHandler"/>.
+    /// </summary>
+    public Task ProcessRequestAsync(BmwContext context)
+        => _server.RequestHandler(context.HttpContext);
+
+    /// <summary>
+    /// Minimal cleanup. The <see cref="BmwContext"/> has no unmanaged resources;
+    /// exceptions are already handled inside <see cref="ProcessRequestAsync"/>.
+    /// </summary>
+    public void DisposeContext(BmwContext context, Exception? exception)
+    {
+        // Nothing to dispose — BmwContext holds only managed references.
+        // Kestrel handles connection/stream cleanup via the feature collection.
+    }
+}

--- a/BareMetalWeb.Host/BmwHost.cs
+++ b/BareMetalWeb.Host/BmwHost.cs
@@ -1,0 +1,98 @@
+using System.Runtime.InteropServices;
+using BareMetalWeb.Core;
+using BareMetalWeb.Core.Interfaces;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace BareMetalWeb.Host;
+
+/// <summary>
+/// Hosts BMW directly on Kestrel without the ASP.NET middleware pipeline.
+/// Replaces <c>WebApplication.Run()</c> with a minimal hosting loop:
+/// <code>
+/// Socket → Kestrel → IHttpApplication&lt;BmwContext&gt; → BMW Router → PipeWriter Response
+/// </code>
+/// </summary>
+public sealed class BmwHost : IAsyncDisposable
+{
+    private readonly KestrelServer _server;
+    private readonly BmwApplication _application;
+    private readonly IBufferedLogger _logger;
+    private readonly CancellationTokenSource _cts;
+
+    private BmwHost(KestrelServer server, BmwApplication application, IBufferedLogger logger, CancellationTokenSource cts)
+    {
+        _server = server;
+        _application = application;
+        _logger = logger;
+        _cts = cts;
+    }
+
+    /// <summary>
+    /// Creates a <see cref="BmwHost"/> wired to the given <see cref="BareMetalWebServer"/>.
+    /// Configures Kestrel listeners from the provided options callback.
+    /// </summary>
+    public static BmwHost Create(
+        BareMetalWebServer server,
+        Action<KestrelServerOptions>? configureKestrel = null,
+        ILoggerFactory? loggerFactory = null)
+    {
+        loggerFactory ??= LoggerFactory.Create(b => b.SetMinimumLevel(LogLevel.Warning));
+
+        var kestrelOptions = new KestrelServerOptions();
+        configureKestrel?.Invoke(kestrelOptions);
+
+        var transportOptions = new SocketTransportOptions();
+        var transportFactory = new SocketTransportFactory(
+            Options.Create(transportOptions),
+            loggerFactory);
+
+        var kestrelServer = new KestrelServer(
+            Options.Create(kestrelOptions),
+            transportFactory,
+            loggerFactory);
+
+        var bmwApp = new BmwApplication(server);
+
+        return new BmwHost(kestrelServer, bmwApp, server.BufferedLogger, server.cts);
+    }
+
+    /// <summary>
+    /// Starts Kestrel, blocks until shutdown is requested (SIGTERM / Ctrl+C),
+    /// then performs graceful shutdown.
+    /// </summary>
+    public async Task RunAsync(CancellationToken cancellationToken = default)
+    {
+        // Merge external cancellation with the server's own CTS
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _cts.Token);
+
+        // Handle SIGTERM / Ctrl+C
+        using var sigterm = PosixSignalRegistration.Create(PosixSignal.SIGTERM, _ => _cts.Cancel());
+        Console.CancelKeyPress += (_, e) => { e.Cancel = true; _cts.Cancel(); };
+
+        await _server.StartAsync(_application, linkedCts.Token).ConfigureAwait(false);
+
+        _logger.LogInfo($"BmwHost started — PID {Environment.ProcessId} — direct Kestrel hosting (no ASP.NET middleware)");
+        Console.WriteLine($"BmwHost started — PID {Environment.ProcessId} — direct Kestrel hosting");
+
+        // Block until cancellation
+        try
+        {
+            await Task.Delay(Timeout.Infinite, linkedCts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) { }
+
+        _logger.LogInfo("BmwHost shutting down...");
+        await _server.StopAsync(CancellationToken.None).ConfigureAwait(false);
+        _logger.LogInfo("BmwHost stopped.");
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _server.Dispose();
+        await ValueTask.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Summary

Adds direct Kestrel hosting support, bypassing the ASP.NET middleware pipeline entirely.

### New Files
- **BmwApplication.cs** — `IHttpApplication<BmwContext>` implementation with CreateContext → ProcessRequestAsync → DisposeContext lifecycle
- **BmwHost.cs** — Direct `KestrelServer` + `SocketTransportFactory` wrapper with SIGTERM/Ctrl+C graceful shutdown

### Modified Files
- **BmwContext.cs** — Added `CreateFromFeatures(IFeatureCollection)` factory for the direct hosting path (creates `DefaultHttpContext` bridge for backward compat)
- **BareMetalWebServer.cs** — Added `WireUpDirectHosting()` and extracted `StartBackgroundServices()` 
- **BareMetalWebExtensions.cs** — `UseBareMetalWeb` now returns `BareMetalWebServer`; added `UseBareMetalWebDirect` entry point

### Usage
```csharp
var app = builder.Build();
await using var host = await app.UseBareMetalWebDirect(
    configureKestrel: opts => opts.ListenAnyIP(5000));
await host.RunAsync();
```

The traditional `app.UseBareMetalWeb()` + `app.Run()` path remains fully functional.

Fixes #923