### PR TITLE
feat: Remove Web SDK — plain .NET SDK with BmwConfig (fixes #925)

### DIFF
--- a/BareMetalWeb.Core/BmwConfig.cs
+++ b/BareMetalWeb.Core/BmwConfig.cs
@@ -1,0 +1,102 @@
+namespace BareMetalWeb.Core;
+
+/// <summary>
+/// Minimal bootstrap configuration loaded from a pipe-delimited text file
+/// (<c>Metal.config</c>). Each line is <c>key|value</c>. Lines starting
+/// with <c>#</c> are comments. Blank lines are ignored.
+/// <para>
+/// This provides only the handful of values needed before the data store is
+/// available (data root, log folder, listen address, thread pool tuning).
+/// Once the data store is up, runtime configuration flows through
+/// <c>SettingsService</c> / <c>WellKnownSettings</c>.
+/// </para>
+/// </summary>
+public sealed class BmwConfig
+{
+    private readonly Dictionary<string, string> _values;
+
+    private BmwConfig(Dictionary<string, string> values)
+    {
+        _values = values;
+    }
+
+    /// <summary>
+    /// Loads a <c>Metal.config</c> file from the given directory.
+    /// If the file does not exist an empty config is returned.
+    /// </summary>
+    public static BmwConfig Load(string directory)
+    {
+        var path = Path.Combine(directory, "Metal.config");
+        var values = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        if (!File.Exists(path))
+            return new BmwConfig(values);
+
+        foreach (var rawLine in File.ReadLines(path))
+        {
+            var line = rawLine.Trim();
+            if (line.Length == 0 || line[0] == '#')
+                continue;
+
+            int pipe = line.IndexOf('|');
+            if (pipe < 0)
+                continue;
+
+            var key = line[..pipe].Trim();
+            var value = line[(pipe + 1)..].Trim();
+
+            if (key.Length > 0)
+                values[key] = value;
+        }
+
+        return new BmwConfig(values);
+    }
+
+    /// <summary>Get a string value, or <paramref name="defaultValue"/> if absent.</summary>
+    public string GetValue(string key, string defaultValue = "")
+        => _values.TryGetValue(key, out var v) ? v : defaultValue;
+
+    /// <summary>Get a typed value with conversion. Supports int, bool, string.</summary>
+    public T GetValue<T>(string key, T defaultValue)
+    {
+        if (!_values.TryGetValue(key, out var raw))
+            return defaultValue;
+
+        var type = typeof(T);
+
+        if (type == typeof(string))
+            return (T)(object)raw;
+
+        if (type == typeof(int) && int.TryParse(raw, out var i))
+            return (T)(object)i;
+
+        if (type == typeof(bool))
+        {
+            if (string.Equals(raw, "true", StringComparison.OrdinalIgnoreCase) || raw == "1")
+                return (T)(object)true;
+            if (string.Equals(raw, "false", StringComparison.OrdinalIgnoreCase) || raw == "0")
+                return (T)(object)false;
+        }
+
+        if (type == typeof(double) && double.TryParse(raw, out var d))
+            return (T)(object)d;
+
+        if (type == typeof(long) && long.TryParse(raw, out var l))
+            return (T)(object)l;
+
+        return defaultValue;
+    }
+
+    /// <summary>Get a string array value (pipe-delimited within the value, using comma separator).</summary>
+    public string[] GetArray(string key)
+    {
+        if (!_values.TryGetValue(key, out var raw) || string.IsNullOrWhiteSpace(raw))
+            return Array.Empty<string>();
+
+        var parts = raw.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        return parts;
+    }
+
+    /// <summary>Check whether a key exists.</summary>
+    public bool HasKey(string key) => _values.ContainsKey(key);
+}

--- a/BareMetalWeb.Core/Interfaces/IBareWebHost.cs
+++ b/BareMetalWeb.Core/Interfaces/IBareWebHost.cs
@@ -1,7 +1,6 @@
 using BareMetalWeb.Interfaces;
 using BareMetalWeb.Rendering;
 using BareMetalWeb.Core.Interfaces;
-using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using BareMetalWeb.Host;
 
@@ -10,7 +9,8 @@ namespace BareMetalWeb.Core.Host;
 public interface IBareWebHost
 {
     static abstract string[] appMetaDataKeys { get; set; }
-    WebApplication app { get; set; }
+    BmwConfig Configuration { get; }
+    string ContentRootPath { get; }
     IBufferedLogger BufferedLogger { get; }
     IMetricsTracker Metrics { get; }
     IClientRequestTracker ClientRequests { get; }

--- a/BareMetalWeb.Host.Tests/BareMetalWebServerTests.cs
+++ b/BareMetalWeb.Host.Tests/BareMetalWebServerTests.cs
@@ -37,7 +37,6 @@ public class BareMetalWebServerTests : IDisposable
     private readonly MockMetricsTracker _metrics;
     private readonly MockClientRequestTracker _clientRequests;
     private readonly CancellationTokenSource _cts;
-    private readonly WebApplication _app;
     private readonly string _keyRootDirectory;
 
     public BareMetalWebServerTests()
@@ -60,11 +59,6 @@ public class BareMetalWebServerTests : IDisposable
         _clientRequests = new MockClientRequestTracker();
         _cts = new CancellationTokenSource();
 
-        // Create a minimal WebApplication for testing
-        var builder = WebApplication.CreateBuilder(new string[] { });
-        builder.WebHost.UseKestrel();
-        _app = builder.Build();
-
         var notFoundPage = CreatePageInfo("Not Found", 404);
         var errorPage = CreatePageInfo("Error", 500);
 
@@ -72,7 +66,8 @@ public class BareMetalWebServerTests : IDisposable
             "TestApp",
             "Test Company",
             "2026",
-            _app,
+            BmwConfig.Load("/tmp"),
+            "/tmp",
             _logger,
             _renderer,
             notFoundPage,
@@ -87,7 +82,6 @@ public class BareMetalWebServerTests : IDisposable
         DataStoreProvider.Current = _originalStore;
         _cts.Cancel();
         _cts.Dispose();
-        (_app as IDisposable)?.Dispose();
         if (Directory.Exists(_keyRootDirectory))
             Directory.Delete(_keyRootDirectory, true);
     }

--- a/BareMetalWeb.Host.Tests/LookupApiHandlerTests.cs
+++ b/BareMetalWeb.Host.Tests/LookupApiHandlerTests.cs
@@ -61,7 +61,6 @@ public class LookupApiHandlerTests : IDisposable
     private readonly MockMetricsTracker _metrics;
     private readonly MockClientRequestTracker _clientRequests;
     private readonly CancellationTokenSource _cts;
-    private readonly WebApplication _app;
     private readonly string _keyRootDirectory;
     private readonly string _testSessionId;
 
@@ -111,11 +110,10 @@ public class LookupApiHandlerTests : IDisposable
         _metrics = new MockMetricsTracker();
         _clientRequests = new MockClientRequestTracker();
         _cts = new CancellationTokenSource();
-        _app = WebApplication.Create();
 
         var pageInfo = CreatePageInfo("Test");
         _server = new BareMetalWebServer(
-            "Test", "Test", "2025", _app, _logger, _renderer,
+            "Test", "Test", "2025", BmwConfig.Load("/tmp"), "/tmp", _logger, _renderer,
             pageInfo, pageInfo, _cts, _metrics, _clientRequests
         );
 
@@ -137,7 +135,6 @@ public class LookupApiHandlerTests : IDisposable
     {
         DataStoreProvider.Current = _originalStore;
         _cts.Cancel();
-        (_app as IDisposable)?.Dispose();
         try { Directory.Delete(_keyRootDirectory, true); } catch { }
     }
 

--- a/BareMetalWeb.Host.Tests/RouteRegistrationExtensionsTests.cs
+++ b/BareMetalWeb.Host.Tests/RouteRegistrationExtensionsTests.cs
@@ -33,7 +33,6 @@ public class RouteRegistrationExtensionsTests : IDisposable
     private readonly BareMetalWebServer _server;
     private readonly MockBufferedLogger _logger;
     private readonly CancellationTokenSource _cts;
-    private readonly WebApplication _app;
     private readonly string _keyRootDirectory;
     private readonly IPageInfoFactory _pageInfoFactory;
     private readonly IHtmlTemplate _mainTemplate;
@@ -51,16 +50,12 @@ public class RouteRegistrationExtensionsTests : IDisposable
         _logger = new MockBufferedLogger();
         _cts = new CancellationTokenSource();
 
-        var builder = WebApplication.CreateBuilder(Array.Empty<string>());
-        builder.WebHost.UseKestrel();
-        _app = builder.Build();
-
         var template = new MockHtmlTemplate();
         var notFoundPage = CreatePageInfo("Not Found", 404);
         var errorPage = CreatePageInfo("Error", 500);
 
         _server = new BareMetalWebServer(
-            "TestApp", "Test Company", "2026", _app,
+            "TestApp", "Test Company", "2026", BmwConfig.Load("/tmp"), "/tmp",
             _logger, new MockHtmlRenderer(), notFoundPage, errorPage,
             _cts, new MockMetricsTracker(), new MockClientRequestTracker());
 

--- a/BareMetalWeb.Host/BareMetalWeb.Host.csproj
+++ b/BareMetalWeb.Host/BareMetalWeb.Host.csproj
@@ -1,5 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -27,8 +28,18 @@
     <IlcDisableRegionGC>true</IlcDisableRegionGC>
   </PropertyGroup>
 
+  <!-- Kestrel and ASP.NET Core types via the shared framework — no Web SDK needed -->
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
   <ItemGroup>
     <InternalsVisibleTo Include="BareMetalWeb.Host.Tests" />
+  </ItemGroup>
+
+  <!-- Bootstrap config is not auto-included without the Web SDK -->
+  <ItemGroup>
+    <Content Include="Metal.config" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BareMetalWeb.Host/BareMetalWebExtensions.cs
+++ b/BareMetalWeb.Host/BareMetalWebExtensions.cs
@@ -7,17 +7,18 @@ using BareMetalWeb.Interfaces;
 using BareMetalWeb.Rendering;
 using BareMetalWeb.Rendering.Interfaces;
 using BareMetalWeb.Runtime;
-using Microsoft.AspNetCore.Hosting.Server;
-using Microsoft.AspNetCore.Hosting.Server.Features;
 
 namespace BareMetalWeb.Host;
 
 /// <summary>
 /// Single entry point for wiring up the full BareMetalWeb stack.
-/// Usage:
-///   var app = WebApplication.Create(args);
-///   await app.UseBareMetalWeb();
-///   app.Run();
+/// Usage (direct Kestrel hosting — no Web SDK):
+/// <code>
+///   var config = BmwConfig.Load(contentRoot);
+///   var server = await BareMetalWebExtensions.InitializeAsync(config, contentRoot);
+///   await using var host = BmwHost.Create(server, ProgramSetup.ConfigureKestrel(config));
+///   await host.RunAsync();
+/// </code>
 /// </summary>
 public static class BareMetalWebExtensions
 {
@@ -26,17 +27,17 @@ public static class BareMetalWebExtensions
     /// authentication, routing, static files, CORS, HTTPS, and proxy support.
     /// Optionally pass <paramref name="configureRoutes"/> to register additional routes.
     /// </summary>
-    public static async Task<BareMetalWebServer> UseBareMetalWeb(
-        this WebApplication app,
+    public static async Task<BareMetalWebServer> InitializeAsync(
+        BmwConfig config,
+        string contentRoot,
         Action<BareMetalWebServer, IRouteHandlers, IPageInfoFactory, IHtmlTemplate>? configureRoutes = null)
     {
         // Logger & data root
-        IBufferedLogger logger = ProgramSetup.CreateLogger(app);
+        IBufferedLogger logger = ProgramSetup.CreateLogger(config);
         logger.LogInfo("Starting BareMetalWeb server...");
 
-        var contentRoot = app.Environment.ContentRootPath;
-        var dataRoot = app.Configuration.GetValue("Data:Root", Path.Combine(contentRoot, "Data"));
-        ProgramSetup.ResetDataIfRequested(app, dataRoot, logger);
+        var dataRoot = config.GetValue("Data.Root", Path.Combine(contentRoot, "Data"));
+        ProgramSetup.ResetDataIfRequested(config, contentRoot, dataRoot, logger);
         CookieProtection.ConfigureKeyRoot(dataRoot);
 
         // Data store
@@ -60,14 +61,17 @@ public static class BareMetalWebExtensions
         DataScaffold.RegisterEntity<ActionDefinition>();
         DataScaffold.RegisterEntity<ActionCommandDefinition>();
 
-        IDataObjectStore dataStore = ProgramSetup.CreateDataStore(app, serializer, queryEvaluator, logger);
+        IDataObjectStore dataStore = ProgramSetup.CreateDataStore(config, contentRoot, serializer, queryEvaluator, logger);
 
         // ── Multitenancy ──────────────────────────────────────────────────────
         // Build the TenantRegistry and wire up additional per-tenant stores.
         // When multitenancy is disabled this is a no-op and the single system store
         // created above is used for every request, exactly as before.
-        var multitenancyOptions = app.Configuration.GetSection("Multitenancy").Get<MultitenancyOptions>()
-            ?? new MultitenancyOptions();
+        var multitenancyOptions = new MultitenancyOptions
+        {
+            Enabled = config.GetValue("Multitenancy.Enabled", false),
+            DefaultTenantId = config.GetValue("Multitenancy.DefaultTenantId", "_system"),
+        };
         var tenantRegistry = new TenantRegistry(multitenancyOptions, contentRoot);
 
         // Register the system tenant so that it can be used as a fallback.
@@ -76,7 +80,7 @@ public static class BareMetalWebExtensions
         var systemTenant = new TenantContext(
             multitenancyOptions.DefaultTenantId,
             dataRoot,
-            app.Configuration.GetValue("Logging:LogFolder", "Logs"),
+            config.GetValue("Logging.LogFolder", "Logs"),
             dataStore,
             systemProvider);
         tenantRegistry.RegisterSystemTenant(systemTenant);
@@ -99,7 +103,7 @@ public static class BareMetalWebExtensions
         }
 
         // Configure high-cardinality lookup threshold
-        DataScaffold.LargeListThreshold = app.Configuration.GetValue("LookupSearch:LargeListThreshold", 20);
+        DataScaffold.LargeListThreshold = config.GetValue("LookupSearch.LargeListThreshold", 20);
 
         // Runtime entity registry — load persisted EntityDefinitions from storage and compile
         await RuntimeEntityRegistry.BuildAsync(
@@ -137,37 +141,37 @@ public static class BareMetalWebExtensions
         ITemplateStore templateStore = new TemplateStore();
         IPageInfoFactory pageInfoFactory = new PageInfoFactory();
         IMetricsTracker metricsTracker = new MetricsTracker();
-        IClientRequestTracker throttling = ProgramSetup.CreateClientRequestTracker(app, logger);
+        IClientRequestTracker throttling = ProgramSetup.CreateClientRequestTracker(config, logger);
 
         // Route handlers
-        bool allowAccountCreation = app.Configuration.GetValue("Auth:AllowAccountCreation", false);
+        bool allowAccountCreation = config.GetValue("Auth.AllowAccountCreation", false);
         AuditService auditService = new AuditService(DataStoreProvider.Current, logger);
         var settingDefaults = new (string SettingId, string Value, string Description)[]
         {
-            (WellKnownSettings.AppName,      app.Configuration.GetValue("AppInfo:Name",      "BareMetalWeb"),       "Application display name"),
-            (WellKnownSettings.AppCompany,   app.Configuration.GetValue("AppInfo:Company",   "BareMetalWeb Inc."),  "Company name shown in the header and footer"),
-            (WellKnownSettings.AppCopyright, app.Configuration.GetValue("AppInfo:Copyright", "2026"),              "Copyright year or statement shown in the footer"),
-            (WellKnownSettings.AppPrivacyPolicyUrl, app.Configuration.GetValue("AppInfo:PrivacyPolicyUrl", ""),    "Privacy policy URL shown as a link in the footer. Leave empty to hide the link."),
+            (WellKnownSettings.AppName,      config.GetValue("AppInfo.Name",      "BareMetalWeb"),       "Application display name"),
+            (WellKnownSettings.AppCompany,   config.GetValue("AppInfo.Company",   "BareMetalWeb Inc."),  "Company name shown in the header and footer"),
+            (WellKnownSettings.AppCopyright, config.GetValue("AppInfo.Copyright", "2026"),              "Copyright year or statement shown in the footer"),
+            (WellKnownSettings.AppPrivacyPolicyUrl, config.GetValue("AppInfo.PrivacyPolicyUrl", ""),    "Privacy policy URL shown as a link in the footer. Leave empty to hide the link."),
 
             // Kestrel / transport
-            (WellKnownSettings.KestrelHttp2Enabled,                 app.Configuration.GetValue("Kestrel:Http2Enabled", true).ToString(),        "Enable HTTP/2 protocol support"),
-            (WellKnownSettings.KestrelHttp3Enabled,                 app.Configuration.GetValue("Kestrel:Http3Enabled", false).ToString(),       "Enable HTTP/3 (QUIC) protocol support"),
-            (WellKnownSettings.KestrelMaxStreamsPerConnection,      app.Configuration.GetValue("Kestrel:MaxStreamsPerConnection", 100).ToString(), "Max concurrent HTTP/2 streams per connection"),
-            (WellKnownSettings.KestrelInitialConnectionWindowSize,  app.Configuration.GetValue("Kestrel:InitialConnectionWindowSize", 131072).ToString(), "HTTP/2 initial connection-level flow-control window (bytes)"),
-            (WellKnownSettings.KestrelInitialStreamWindowSize,      app.Configuration.GetValue("Kestrel:InitialStreamWindowSize", 98304).ToString(), "HTTP/2 initial per-stream flow-control window (bytes)"),
+            (WellKnownSettings.KestrelHttp2Enabled,                 config.GetValue("Kestrel.Http2Enabled", true).ToString(),        "Enable HTTP/2 protocol support"),
+            (WellKnownSettings.KestrelHttp3Enabled,                 config.GetValue("Kestrel.Http3Enabled", false).ToString(),       "Enable HTTP/3 (QUIC) protocol support"),
+            (WellKnownSettings.KestrelMaxStreamsPerConnection,      config.GetValue("Kestrel.MaxStreamsPerConnection", 100).ToString(), "Max concurrent HTTP/2 streams per connection"),
+            (WellKnownSettings.KestrelInitialConnectionWindowSize,  config.GetValue("Kestrel.InitialConnectionWindowSize", 131072).ToString(), "HTTP/2 initial connection-level flow-control window (bytes)"),
+            (WellKnownSettings.KestrelInitialStreamWindowSize,      config.GetValue("Kestrel.InitialStreamWindowSize", 98304).ToString(), "HTTP/2 initial per-stream flow-control window (bytes)"),
 
             // Thread pool
-            (WellKnownSettings.ThreadPoolMinWorkerThreads, app.Configuration.GetValue("ThreadPool:MinWorkerThreads", 0).ToString(), "Minimum worker threads (0 = runtime default)"),
-            (WellKnownSettings.ThreadPoolMinIOThreads,     app.Configuration.GetValue("ThreadPool:MinIOThreads", 0).ToString(),     "Minimum I/O completion threads (0 = runtime default)"),
+            (WellKnownSettings.ThreadPoolMinWorkerThreads, config.GetValue("ThreadPool.MinWorkerThreads", 0).ToString(), "Minimum worker threads (0 = runtime default)"),
+            (WellKnownSettings.ThreadPoolMinIOThreads,     config.GetValue("ThreadPool.MinIOThreads", 0).ToString(),     "Minimum I/O completion threads (0 = runtime default)"),
 
             // GC — informational only; actual values are baked in at publish time via the
             // project's RuntimeHostConfigurationOption entries. Override at process-start time
             // by setting DOTNET_GCServer=1 (server GC) env variable before launching the process
             // — these cannot be changed while running.
-            (WellKnownSettings.GCServerMode, app.Configuration.GetValue("GC:ServerMode", true).ToString(), "Server GC mode (true = one heap per CPU, false = workstation GC). Fixed at process start; set DOTNET_GCServer env var before launch to override."),
+            (WellKnownSettings.GCServerMode, config.GetValue("GC.ServerMode", true).ToString(), "Server GC mode (true = one heap per CPU, false = workstation GC). Fixed at process start; set DOTNET_GCServer env var before launch to override."),
 
             // Admin
-            (WellKnownSettings.AllowWipeData, app.Configuration.GetValue("Admin:AllowWipeData", string.Empty), "Secret token required to trigger wipe-all-data. Leave empty to disable the endpoint."),
+            (WellKnownSettings.AllowWipeData, config.GetValue("Admin.AllowWipeData", string.Empty), "Secret token required to trigger wipe-all-data. Leave empty to disable the endpoint."),
 
             // Diagnostics
             (WellKnownSettings.ShowHostInfo, "False", "When True, append a diagnostic banner (host, server, RTT, payload) to each page when ?showhst=true is on the request. Default: False."),
@@ -177,14 +181,14 @@ public static class BareMetalWebExtensions
         // requiring a manual edit in the admin UI.
         await SettingsService.EnsureDefaultsAsync(DataStoreProvider.Current, settingDefaults, "system").ConfigureAwait(false);
 
-        IRouteHandlers routeHandlers = new RouteHandlers(htmlRenderer, templateStore, allowAccountCreation, dataRoot, auditService, settingDefaults, logger);
+        IRouteHandlers routeHandlers = new RouteHandlers(htmlRenderer, templateStore, allowAccountCreation, dataRoot, auditService, settingDefaults, logger, config);
         EntraIdService.Init(logger);
         IHtmlTemplate mainTemplate = templateStore.Get("Index");
         CancellationTokenSource cts = new CancellationTokenSource();
 
         // App info — create from config then override with any admin-edited store values
         BareMetalWebServer appInfo = ProgramSetup.CreateAppInfo(
-            app, logger, htmlRenderer, pageInfoFactory, mainTemplate, metricsTracker, throttling, cts);
+            config, contentRoot, logger, htmlRenderer, pageInfoFactory, mainTemplate, metricsTracker, throttling, cts);
         appInfo.AppName            = SettingsService.GetValue(WellKnownSettings.AppName,           appInfo.AppName);
         appInfo.CompanyDescription = SettingsService.GetValue(WellKnownSettings.AppCompany,        appInfo.CompanyDescription);
         appInfo.CopyrightYear      = SettingsService.GetValue(WellKnownSettings.AppCopyright,      appInfo.CopyrightYear);
@@ -213,7 +217,7 @@ public static class BareMetalWebExtensions
         };
 
         // Infrastructure configuration
-        ProgramSetup.ConfigureStaticFiles(app, appInfo);
+        ProgramSetup.ConfigureStaticFiles(config, appInfo);
 
         // Ensure per-theme CSS bundles and bootstrap.bundle.min.js exist on disk (downloads from
         // CDN if missing), then loads them into memory.  Skips files that are already present.
@@ -227,9 +231,9 @@ public static class BareMetalWebExtensions
         // bootstrap.bundle.min.js (downloaded by EnsureAssetsAsync) is available on disk.
         JsBundleService.BuildBundle(Path.Combine(appInfo.StaticFiles.RootPathFull, "js"));
 
-        ProgramSetup.ConfigureCors(app, appInfo);
-        ProgramSetup.ConfigureHttps(app, appInfo);
-        ProgramSetup.ConfigureProxyRoutes(app, appInfo, logger, pageInfoFactory);
+        ProgramSetup.ConfigureCors(config, appInfo);
+        ProgramSetup.ConfigureHttps(config, appInfo);
+        ProgramSetup.ConfigureProxyRoutes(config, appInfo, logger, pageInfoFactory);
 
         // Built-in routes
         appInfo.RegisterStaticRoutes(routeHandlers, pageInfoFactory, mainTemplate);
@@ -275,79 +279,6 @@ public static class BareMetalWebExtensions
         await appInfo.BuildAppInfoMenuOptionsAsync();
         await appInfo.WireUpRequestHandlingAndLoggerAsyncLifetime();
 
-        app.Lifetime.ApplicationStarted.Register(() =>
-        {
-            var addresses = app.Services.GetService(typeof(IServer)) is IServer server
-                ? server.Features.Get<IServerAddressesFeature>()?.Addresses
-                : null;
-            var list = addresses is null || addresses.Count == 0
-                ? (app.Urls ?? Array.Empty<string>())
-                : addresses;
-            var display = list.Count > 0 ? string.Join(", ", list) : "unknown";
-            logger.LogInfo($"BareMetalWeb server is ready — PID {Environment.ProcessId} — listening for requests on {display}");
-            Console.WriteLine($"BareMetalWeb server is ready — PID {Environment.ProcessId} — listening for requests on {display}");
-
-            var httpsConfig = $"HTTPS redirect settings: mode={appInfo.HttpsRedirectMode}, trustForwardedHeaders={appInfo.TrustForwardedHeaders}, redirectHost={(string.IsNullOrWhiteSpace(appInfo.HttpsRedirectHost) ? "(auto)" : appInfo.HttpsRedirectHost)}, redirectPort={(appInfo.HttpsRedirectPort.HasValue ? appInfo.HttpsRedirectPort.Value.ToString() : "(auto)")}";
-            logger.LogInfo(httpsConfig);
-            Console.WriteLine(httpsConfig);
-
-            string? httpsAddress = null;
-            foreach (var a in list)
-            {
-                if (a.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
-                {
-                    httpsAddress = a;
-                    break;
-                }
-            }
-            appInfo.HttpsEndpointAvailable = !string.IsNullOrWhiteSpace(httpsAddress);
-            if (appInfo.HttpsEndpointAvailable && Uri.TryCreate(httpsAddress, UriKind.Absolute, out var httpsUri))
-            {
-                if (string.IsNullOrWhiteSpace(appInfo.HttpsRedirectHost))
-                    appInfo.HttpsRedirectHost = httpsUri.Host;
-                if (!appInfo.HttpsRedirectPort.HasValue || appInfo.HttpsRedirectPort.Value <= 0)
-                    appInfo.HttpsRedirectPort = httpsUri.IsDefaultPort ? 443 : httpsUri.Port;
-            }
-
-            if (!appInfo.HttpsEndpointAvailable)
-            {
-                var warn = "HTTPS endpoint not configured. Configure HTTPS (ASPNETCORE_URLS / Kestrel) to expose an https:// address.";
-                logger.LogInfo(warn);
-                Console.WriteLine(warn);
-            }
-        });
-
         return appInfo;
-    }
-
-    /// <summary>
-    /// Configures the full BareMetalWeb stack and returns a <see cref="BmwHost"/>
-    /// for direct Kestrel hosting — no ASP.NET middleware pipeline.
-    /// <para>
-    /// Uses <see cref="UseBareMetalWeb"/> for initialization, then replaces the
-    /// serving layer with a direct <c>KestrelServer</c> + <see cref="BmwApplication"/>.
-    /// </para>
-    /// <example>
-    /// <code>
-    /// var builder = WebApplication.CreateBuilder();
-    /// var app = builder.Build();
-    /// await using var host = await app.UseBareMetalWebDirect(
-    ///     configureKestrel: opts => opts.ListenAnyIP(5000));
-    /// await host.RunAsync();
-    /// </code>
-    /// </example>
-    /// </summary>
-    public static async Task<BmwHost> UseBareMetalWebDirect(
-        this WebApplication app,
-        Action<Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions>? configureKestrel = null,
-        Action<BareMetalWebServer, IRouteHandlers, IPageInfoFactory, IHtmlTemplate>? configureRoutes = null)
-    {
-        // Initialize the full stack via UseBareMetalWeb but capture the server instance
-        BareMetalWebServer? appInfo = await app.UseBareMetalWeb(configureRoutes);
-
-        // Re-wire for direct hosting: stop the middleware path, start the direct path
-        await appInfo.WireUpDirectHosting();
-
-        return BmwHost.Create(appInfo, configureKestrel);
     }
 }

--- a/BareMetalWeb.Host/BareMetalWebServer.cs
+++ b/BareMetalWeb.Host/BareMetalWebServer.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Reflection;
+using Microsoft.AspNetCore.Http;
 using BareMetalWeb.Data;
 using BareMetalWeb.Interfaces;
 using BareMetalWeb.Rendering;
@@ -23,7 +24,8 @@ public class BareMetalWebServer : IBareWebHost
             new QueryClause { Field = nameof(User.Permissions), Operator = QueryOperator.Contains, Value = "monitoring" }
         }
     };
-    public WebApplication app { get; set; }
+    public BmwConfig Configuration { get; }
+    public string ContentRootPath { get; }
     public IBufferedLogger BufferedLogger { get; }
     public IMetricsTracker Metrics { get; }
     public IClientRequestTracker ClientRequests { get; }
@@ -92,7 +94,8 @@ public class BareMetalWebServer : IBareWebHost
         string appName,
         string companyDescription,
         string copyrightYear,
-        WebApplication application,
+        BmwConfig configuration,
+        string contentRootPath,
         IBufferedLogger logger,
         IHtmlRenderer htmlRenderer,
         PageInfo NotFoundPage,
@@ -114,7 +117,8 @@ public class BareMetalWebServer : IBareWebHost
             ? trimmed[..plusIdx] + "+" + trimmed[(plusIdx + 1)..(plusIdx + 8)]
             : trimmed;
         AppMetaDataValues = new[] { AppName, CompanyDescription, CopyrightYear, version, ComputePrivacyPolicyLink(_privacyPolicyUrl) };
-        app = application;
+        Configuration = configuration;
+        ContentRootPath = contentRootPath;
         BufferedLogger = logger;
         HtmlRenderer = htmlRenderer;
         Metrics = metrics;
@@ -335,21 +339,16 @@ public class BareMetalWebServer : IBareWebHost
     }
     public Task WireUpRequestHandlingAndLoggerAsyncLifetime()
     {
-        // Build the jump table for O(1) exact-match route dispatch
         EnsureJumpTable();
-        // Single terminal request handler. We deliberately do not use routing, MVC, or minimal APIs. All requests are handled explicitly by RequestHandler.
-        app.Use(async (HttpContext context, RequestDelegate _) => await RequestHandler(context));
-        // Start background services
         StartBackgroundServices();
-        app.Lifetime.ApplicationStopping.Register(() => BufferedLogger.OnApplicationStopping(cts, _loggerTask!));
         BufferedLogger.LogInfo($"WireUpRequestHandlingAndLoggerAsyncLifetime completed and request handling is live.");
         return Task.CompletedTask;
     }
 
     /// <summary>
     /// Prepares the server for direct Kestrel hosting via <see cref="BmwHost"/>.
-    /// Does NOT register ASP.NET middleware — Kestrel calls
-    /// <see cref="BmwApplication.ProcessRequestAsync"/> directly.
+    /// Identical to <see cref="WireUpRequestHandlingAndLoggerAsyncLifetime"/> —
+    /// kept as a separate entry point for clarity.
     /// </summary>
     public Task WireUpDirectHosting()
     {

--- a/BareMetalWeb.Host/GraphQLHandler.cs
+++ b/BareMetalWeb.Host/GraphQLHandler.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Text;
 using System.Text.Json;
+using Microsoft.AspNetCore.Http;
 using BareMetalWeb.Core;
 using BareMetalWeb.Data;
 using BareMetalWeb.Rendering.Models;

--- a/BareMetalWeb.Host/Metal.config
+++ b/BareMetalWeb.Host/Metal.config
@@ -1,0 +1,90 @@
+# ── BareMetalWeb Bootstrap Configuration ─────────────────────────────
+# Format: key|value (one per line, # for comments, blank lines ignored)
+#
+# These are bootstrap-only settings read before the data store is available.
+# Runtime configuration is managed via Settings in the admin UI.
+
+# ── Data ─────────────────────────────────────────────────────────────
+Data.Root|Data
+Data.ResetOnStartup|false
+Logging.LogFolder|Logs
+
+# ── Kestrel ──────────────────────────────────────────────────────────
+Kestrel.Http2Enabled|true
+Kestrel.Http3Enabled|false
+Kestrel.MaxStreamsPerConnection|100
+Kestrel.InitialConnectionWindowSize|131072
+Kestrel.InitialStreamWindowSize|98304
+
+# ── Thread Pool ──────────────────────────────────────────────────────
+ThreadPool.MinWorkerThreads|0
+ThreadPool.MinIOThreads|0
+
+# ── Application ──────────────────────────────────────────────────────
+AppInfo.Name|BareMetalWeb
+AppInfo.Company|BareMetalWeb Inc.
+AppInfo.Copyright|2026
+AppInfo.PrivacyPolicyUrl|
+
+# ── Auth ─────────────────────────────────────────────────────────────
+Auth.AllowAccountCreation|false
+
+# ── HTTPS ────────────────────────────────────────────────────────────
+Https.RedirectMode|IfAvailable
+Https.TrustForwardedHeaders|false
+Https.RedirectHost|
+Https.RedirectPort|0
+
+# ── CORS ─────────────────────────────────────────────────────────────
+Cors.AllowedOrigins|
+
+# ── Client Request Throttling ────────────────────────────────────────
+ClientRequests.NormalRpsThreshold|20
+ClientRequests.SuspiciousRpsThreshold|10
+ClientRequests.BlockDurationMinutes|1
+ClientRequests.AllowList|
+ClientRequests.DenyList|
+ClientRequests.StaleThresholdSeconds|120
+ClientRequests.PruneIntervalSeconds|30
+ClientRequests.MaxEntries|100000
+
+# ── Static Files ─────────────────────────────────────────────────────
+StaticFiles.Enabled|true
+StaticFiles.RequestPathPrefix|/static
+StaticFiles.RootDirectory|wwwroot/static
+StaticFiles.EnableCaching|true
+StaticFiles.CacheSeconds|86400
+StaticFiles.AddETag|true
+StaticFiles.AddLastModified|true
+StaticFiles.AllowUnknownMime|false
+StaticFiles.DefaultMimeType|application/octet-stream
+
+# ── Lookup Search ────────────────────────────────────────────────────
+LookupSearch.LargeListThreshold|20
+
+# ── Multitenancy ─────────────────────────────────────────────────────
+Multitenancy.Enabled|false
+Multitenancy.DefaultTenantId|default
+
+# ── GC (informational) ──────────────────────────────────────────────
+GC.ServerMode|true
+
+# ── Admin ────────────────────────────────────────────────────────────
+Admin.AllowWipeData|
+
+# ── Uploads ──────────────────────────────────────────────────────────
+Uploads.RootDirectory|uploads
+
+# ── EntraID SSO ──────────────────────────────────────────────────────
+EntraId.Enabled|false
+EntraId.TenantId|
+EntraId.ClientId|
+EntraId.ClientSecret|
+EntraId.RedirectUri|/auth/sso/callback
+EntraId.BaseUrl|
+EntraId.AutoProvisionUsers|true
+EntraId.DefaultPermissions|user
+
+# ── Proxy (optional, comma-separated route definitions) ──────────────
+Proxy.Route|
+Proxy.TargetBaseUrl|

--- a/BareMetalWeb.Host/Program.cs
+++ b/BareMetalWeb.Host/Program.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Text.Json;
+using Microsoft.AspNetCore.Http;
 using BareMetalWeb.Core;
 using BareMetalWeb.Core.Host;
 using BareMetalWeb.Core.Interfaces;
@@ -11,9 +12,12 @@ using BareMetalWeb.Rendering;
 using BareMetalWeb.Rendering.Interfaces;
 using BareMetalWeb.Rendering.Models;
 
-var builder = WebApplication.CreateBuilder();
-ProgramSetup.ConfigureKestrel(builder);
-WebApplication app = builder.Build();
+// ── Configuration ──────────────────────────────────────────────────────
+var contentRoot = Directory.GetCurrentDirectory();
+var config = BmwConfig.Load(contentRoot);
+
+// Apply Kestrel + thread-pool tuning from config
+var configureKestrel = ProgramSetup.ConfigureKestrel(config);
 
 // Simple per-IP rate limiter for device code endpoints
 var _deviceRateLimiter = new ConcurrentDictionary<string, (int Count, DateTime Window)>();
@@ -27,7 +31,7 @@ bool DeviceRateCheck(HttpContext ctx, int maxPerMinute = 10)
     return entry.Count <= maxPerMinute;
 }
 
-await app.UseBareMetalWeb(configureRoutes: (appInfo, routeHandlers, pageInfoFactory, mainTemplate) =>
+var server = await BareMetalWebExtensions.InitializeAsync(config, contentRoot, configureRoutes: (appInfo, routeHandlers, pageInfoFactory, mainTemplate) =>
 {
     // Device code auth flow
     appInfo.RegisterRoute("POST /api/device/code", new RouteHandlerData(pageInfoFactory.RawPage("Public", false), async context =>
@@ -394,18 +398,29 @@ await app.UseBareMetalWeb(configureRoutes: (appInfo, routeHandlers, pageInfoFact
     }));
 });
 
-app.Run();
+// ── Direct Kestrel hosting ────────────────────────────────────────────
+await using var host = BmwHost.Create(server, configureKestrel);
+await host.RunAsync();
 
 static class ProgramSetup
 {
-    public static void ConfigureKestrel(WebApplicationBuilder builder)
+    public static Action<Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions> ConfigureKestrel(BmwConfig config)
     {
-        var config = builder.Configuration;
-
-        builder.WebHost.ConfigureKestrel(serverOptions =>
+        // Thread pool tuning (applied immediately — not Kestrel-specific)
+        var minWorker = config.GetValue("ThreadPool.MinWorkerThreads", 0);
+        var minIO = config.GetValue("ThreadPool.MinIOThreads", 0);
+        if (minWorker > 0 || minIO > 0)
         {
-            var http2Enabled = config.GetValue("Kestrel:Http2Enabled", true);
-            var http3Enabled = config.GetValue("Kestrel:Http3Enabled", false);
+            ThreadPool.GetMinThreads(out int currentWorker, out int currentIO);
+            ThreadPool.SetMinThreads(
+                minWorker > 0 ? minWorker : currentWorker,
+                minIO > 0 ? minIO : currentIO);
+        }
+
+        return serverOptions =>
+        {
+            var http2Enabled = config.GetValue("Kestrel.Http2Enabled", true);
+            var http3Enabled = config.GetValue("Kestrel.Http3Enabled", false);
 
             serverOptions.ConfigureEndpointDefaults(listenOptions =>
             {
@@ -417,37 +432,26 @@ static class ProgramSetup
                     listenOptions.Protocols = Microsoft.AspNetCore.Server.Kestrel.Core.HttpProtocols.Http1;
             });
 
-            var maxStreams = config.GetValue("Kestrel:MaxStreamsPerConnection", 100);
+            var maxStreams = config.GetValue("Kestrel.MaxStreamsPerConnection", 100);
             if (maxStreams > 0)
                 serverOptions.Limits.Http2.MaxStreamsPerConnection = maxStreams;
 
-            var connWindowSize = config.GetValue("Kestrel:InitialConnectionWindowSize", 131072);
+            var connWindowSize = config.GetValue("Kestrel.InitialConnectionWindowSize", 131072);
             if (connWindowSize > 0)
                 serverOptions.Limits.Http2.InitialConnectionWindowSize = connWindowSize;
 
-            var streamWindowSize = config.GetValue("Kestrel:InitialStreamWindowSize", 98304);
+            var streamWindowSize = config.GetValue("Kestrel.InitialStreamWindowSize", 98304);
             if (streamWindowSize > 0)
                 serverOptions.Limits.Http2.InitialStreamWindowSize = streamWindowSize;
-        });
-
-        // Thread pool tuning
-        var minWorker = config.GetValue("ThreadPool:MinWorkerThreads", 0);
-        var minIO = config.GetValue("ThreadPool:MinIOThreads", 0);
-        if (minWorker > 0 || minIO > 0)
-        {
-            ThreadPool.GetMinThreads(out int currentWorker, out int currentIO);
-            ThreadPool.SetMinThreads(
-                minWorker > 0 ? minWorker : currentWorker,
-                minIO > 0 ? minIO : currentIO);
-        }
+        };
     }
 
-    public static IBufferedLogger CreateLogger(WebApplication app)
-        => new DiskBufferedLogger(app.Configuration.GetValue("Logging:LogFolder", "Logs"));
+    public static IBufferedLogger CreateLogger(BmwConfig config)
+        => new DiskBufferedLogger(config.GetValue("Logging.LogFolder", "Logs"));
 
-    public static IDataObjectStore CreateDataStore(WebApplication app, ISchemaAwareObjectSerializer serializer, IDataQueryEvaluator queryEvaluator, IBufferedLogger logger)
+    public static IDataObjectStore CreateDataStore(BmwConfig config, string contentRoot, ISchemaAwareObjectSerializer serializer, IDataQueryEvaluator queryEvaluator, IBufferedLogger logger)
     {
-        var dataRoot = app.Configuration.GetValue("Data:Root", Path.Combine(app.Environment.ContentRootPath, "Data"));
+        var dataRoot = config.GetValue("Data.Root", Path.Combine(contentRoot, "Data"));
 
         // Detect and wipe legacy GUID-based data before opening the store
         LegacyDataWipeGuard.WipeIfLegacyDetected(dataRoot, logger);
@@ -465,10 +469,10 @@ static class ProgramSetup
         return dataStore;
     }
 
-    public static void ResetDataIfRequested(WebApplication app, string dataRoot, IBufferedLogger logger)
+    public static void ResetDataIfRequested(BmwConfig config, string contentRoot, string dataRoot, IBufferedLogger logger)
     {
-        var resetFlagPath = Path.Combine(app.Environment.ContentRootPath, "reset-data.flag");
-        var shouldReset = app.Configuration.GetValue("Data:ResetOnStartup", false) || File.Exists(resetFlagPath);
+        var resetFlagPath = Path.Combine(contentRoot, "reset-data.flag");
+        var shouldReset = config.GetValue("Data.ResetOnStartup", false) || File.Exists(resetFlagPath);
         if (!shouldReset)
             return;
 
@@ -514,17 +518,17 @@ static class ProgramSetup
     }
 
 
-    public static IClientRequestTracker CreateClientRequestTracker(WebApplication app, IBufferedLogger logger)
+    public static IClientRequestTracker CreateClientRequestTracker(BmwConfig config, IBufferedLogger logger)
         => new ClientRequestTracker(
             logger,
-            normalRpsThreshold: app.Configuration.GetValue("ClientRequests:NormalRpsThreshold", 20),
-            suspiciousRpsThreshold: app.Configuration.GetValue("ClientRequests:SuspiciousRpsThreshold", 10),
-            blockDuration: TimeSpan.FromMinutes(app.Configuration.GetValue("ClientRequests:BlockDurationMinutes", 1)),
-            allowList: app.Configuration.GetSection("ClientRequests:AllowList").Get<string[]>() ?? Array.Empty<string>(),
-            denyList: app.Configuration.GetSection("ClientRequests:DenyList").Get<string[]>() ?? Array.Empty<string>(),
-            staleThreshold: TimeSpan.FromSeconds(app.Configuration.GetValue("ClientRequests:StaleThresholdSeconds", 120)),
-            pruneInterval: TimeSpan.FromSeconds(app.Configuration.GetValue("ClientRequests:PruneIntervalSeconds", 30)),
-            maxEntries: app.Configuration.GetValue("ClientRequests:MaxEntries", 100000));
+            normalRpsThreshold: config.GetValue("ClientRequests.NormalRpsThreshold", 20),
+            suspiciousRpsThreshold: config.GetValue("ClientRequests.SuspiciousRpsThreshold", 10),
+            blockDuration: TimeSpan.FromMinutes(config.GetValue("ClientRequests.BlockDurationMinutes", 1)),
+            allowList: config.GetArray("ClientRequests.AllowList"),
+            denyList: config.GetArray("ClientRequests.DenyList"),
+            staleThreshold: TimeSpan.FromSeconds(config.GetValue("ClientRequests.StaleThresholdSeconds", 120)),
+            pruneInterval: TimeSpan.FromSeconds(config.GetValue("ClientRequests.PruneIntervalSeconds", 30)),
+            maxEntries: config.GetValue("ClientRequests.MaxEntries", 100000));
 
     public static async ValueTask EnsureRootPermissionsAsync(IBufferedLogger logger, string[] requiredPermissions, CancellationToken cancellationToken = default)
     {
@@ -582,7 +586,8 @@ static class ProgramSetup
     }
 
     public static BareMetalWebServer CreateAppInfo(
-        WebApplication app,
+        BmwConfig config,
+        string contentRoot,
         IBufferedLogger logger,
         IHtmlRenderer htmlRenderer,
         IPageInfoFactory pageInfoFactory,
@@ -591,10 +596,11 @@ static class ProgramSetup
         IClientRequestTracker clientRequests,
         CancellationTokenSource cts)
         => new BareMetalWebServer(
-            app.Configuration.GetValue("AppInfo:Name", "BareMetalWeb"),
-            app.Configuration.GetValue("AppInfo:Company", "BareMetalWeb Inc."),
-            app.Configuration.GetValue("AppInfo:Copyright", "2026"),
-            app,
+            config.GetValue("AppInfo.Name", "BareMetalWeb"),
+            config.GetValue("AppInfo.Company", "BareMetalWeb Inc."),
+            config.GetValue("AppInfo.Copyright", "2026"),
+            config,
+            contentRoot,
             logger,
             htmlRenderer,
             pageInfoFactory.TemplatedPage(mainTemplate, 404, new[] { "title", "message" }, new[] { "404 - Not Found", "<p>The requested page was not found.</p>" }, "", true, 6000),
@@ -603,26 +609,38 @@ static class ProgramSetup
             metrics: metrics,
             clientRequests: clientRequests);
 
-    public static void ConfigureStaticFiles(WebApplication app, BareMetalWebServer appInfo)
+    public static void ConfigureStaticFiles(BmwConfig config, BareMetalWebServer appInfo)
     {
-        var staticFileConfig = app.Configuration.GetSection("StaticFiles").Get<StaticFileOptionsConfig>()
-            ?? new StaticFileOptionsConfig();
+        var staticFileConfig = new StaticFileOptionsConfig
+        {
+            Enabled = config.GetValue("StaticFiles.Enabled", true),
+            RequestPathPrefix = config.GetValue("StaticFiles.RequestPathPrefix", "/static"),
+            RootDirectory = config.GetValue("StaticFiles.RootDirectory", "wwwroot/static"),
+            EnableCaching = config.GetValue("StaticFiles.EnableCaching", true),
+            CacheSeconds = config.GetValue("StaticFiles.CacheSeconds", 86400),
+            AddETag = config.GetValue("StaticFiles.AddETag", true),
+            AddLastModified = config.GetValue("StaticFiles.AddLastModified", true),
+            AllowUnknownMime = config.GetValue("StaticFiles.AllowUnknownMime", false),
+            DefaultMimeType = config.GetValue("StaticFiles.DefaultMimeType", "application/octet-stream"),
+        };
         var staticFileOptions = StaticFileConfigOptions.FromConfig(staticFileConfig);
         staticFileOptions.Normalize();
         appInfo.StaticFiles = staticFileOptions;
     }
 
-    public static void ConfigureCors(WebApplication app, BareMetalWebServer appInfo)
+    public static void ConfigureCors(BmwConfig config, BareMetalWebServer appInfo)
     {
-        appInfo.CorsAllowedOrigins = app.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>() ?? Array.Empty<string>();
+        appInfo.CorsAllowedOrigins = config.GetArray("Cors.AllowedOrigins");
     }
 
-    public static void ConfigureHttps(WebApplication app, BareMetalWebServer appInfo)
+    public static void ConfigureHttps(BmwConfig config, BareMetalWebServer appInfo)
     {
-        appInfo.HttpsRedirectMode = app.Configuration.GetValue("Https:RedirectMode", HttpsRedirectMode.IfAvailable);
-        appInfo.TrustForwardedHeaders = app.Configuration.GetValue("Https:TrustForwardedHeaders", false);
-        var httpsRedirectHost = app.Configuration.GetValue<string>("Https:RedirectHost");
-        var httpsRedirectPort = app.Configuration.GetValue<int>("Https:RedirectPort", 0);
+        var redirectModeStr = config.GetValue("Https.RedirectMode", "IfAvailable");
+        appInfo.HttpsRedirectMode = Enum.TryParse<HttpsRedirectMode>(redirectModeStr, true, out var mode)
+            ? mode : HttpsRedirectMode.IfAvailable;
+        appInfo.TrustForwardedHeaders = config.GetValue("Https.TrustForwardedHeaders", false);
+        var httpsRedirectHost = config.GetValue("Https.RedirectHost", "");
+        var httpsRedirectPort = config.GetValue("Https.RedirectPort", 0);
 
         if (!string.IsNullOrWhiteSpace(httpsRedirectHost))
         {
@@ -634,90 +652,21 @@ static class ProgramSetup
         }
     }
 
-    public static void ConfigureProxyRoutes(WebApplication app, IBareWebHost appInfo, IBufferedLogger logger, IPageInfoFactory pageInfoFactory)
+    public static void ConfigureProxyRoutes(BmwConfig config, IBareWebHost appInfo, IBufferedLogger logger, IPageInfoFactory pageInfoFactory)
     {
-        ProxyRoutingOptions proxyOptions = app.Configuration.GetSection("Proxy").Get<ProxyRoutingOptions>() ?? new ProxyRoutingOptions();
-        List<ProxyRouteHandler> proxyHandlers = new();
-
-        if (proxyOptions.Routes.Count > 0)
+        // BmwConfig doesn't support complex nested object binding, so we handle
+        // the legacy single-route config (Proxy.Route + Proxy.TargetBaseUrl) directly.
+        var proxyRoute = config.GetValue("Proxy.Route", "");
+        var proxyTarget = config.GetValue("Proxy.TargetBaseUrl", "");
+        if (!string.IsNullOrWhiteSpace(proxyRoute) && !string.IsNullOrWhiteSpace(proxyTarget))
         {
-            foreach (var route in proxyOptions.Routes)
+            var legacyRoute = new ProxyRouteConfig
             {
-                var proxyHandler = new ProxyRouteHandler(route, logger);
-                proxyHandlers.Add(proxyHandler);
-                var verb = string.IsNullOrWhiteSpace(route.Verb) ? "ALL" : route.Verb.Trim();
-                var matchMode = route.MatchMode?.Trim() ?? "Equals";
-                var routeTemplate = route.Route;
-                if (string.Equals(matchMode, "StartsWith", StringComparison.OrdinalIgnoreCase))
-                {
-                    var basePath = route.Route.TrimEnd('/');
-                    if (string.IsNullOrWhiteSpace(basePath))
-                        basePath = "/";
-                    routeTemplate = basePath == "/" ? "/{*proxyPath}" : $"{basePath}/{{*proxyPath}}";
-                }
-                else if (string.Equals(matchMode, "Regex", StringComparison.OrdinalIgnoreCase))
-                {
-                    routeTemplate = $"regex:{route.Route}";
-                }
-
-                appInfo.RegisterRoute($"{verb} {routeTemplate}", new RouteHandlerData(pageInfoFactory.RawPage("Public", false), proxyHandler.HandleAsync));
-            }
-
-            appInfo.RegisterRoute("GET /proxy/status", new RouteHandlerData(pageInfoFactory.RawPage("admin", false), async context =>
-            {
-                context.Response.ContentType = "application/json";
-                var status = new ProxyRouteStatus[proxyHandlers.Count];
-                for (int si = 0; si < proxyHandlers.Count; si++)
-                    status[si] = proxyHandlers[si].GetStatus();
-
-                await using var stream = context.Response.Body;
-                using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = true });
-                writer.WriteStartArray();
-                foreach (var routeStatus in status)
-                {
-                    writer.WriteStartObject();
-                    writer.WriteString("route", routeStatus.Route);
-                    writer.WriteString("matchMode", routeStatus.MatchMode);
-                    writer.WriteString("loadBalance", routeStatus.LoadBalance);
-                    writer.WriteStartArray("targets");
-                    foreach (var target in routeStatus.Targets)
-                    {
-                        writer.WriteStartObject();
-                        writer.WriteString("uri", target.Uri);
-                        writer.WriteNumber("weight", target.Weight);
-                        writer.WriteBoolean("online", target.Online);
-                        if (target.OfflineUntil.HasValue)
-                            writer.WriteString("offlineUntil", target.OfflineUntil.Value.ToString("O"));
-                        else
-                            writer.WriteNull("offlineUntil");
-                        writer.WriteNumber("successes", target.Successes);
-                        writer.WriteNumber("failures", target.Failures);
-                        writer.WriteNumber("windowTotal", target.WindowTotal);
-                        writer.WriteNumber("windowFailures", target.WindowFailures);
-                        writer.WriteNumber("windowSuccesses", target.WindowSuccesses);
-                        writer.WriteEndObject();
-                    }
-                    writer.WriteEndArray();
-                    writer.WriteEndObject();
-                }
-                writer.WriteEndArray();
-                await writer.FlushAsync();
-            }));
-        }
-        else
-        {
-            var proxyRoute = app.Configuration.GetValue<string>("Proxy:Route");
-            var proxyTarget = app.Configuration.GetValue<string>("Proxy:TargetBaseUrl");
-            if (!string.IsNullOrWhiteSpace(proxyRoute) && !string.IsNullOrWhiteSpace(proxyTarget))
-            {
-                var legacyRoute = new ProxyRouteConfig
-                {
-                    Route = proxyRoute,
-                    TargetBaseUrl = proxyTarget
-                };
-                var proxyHandler = new ProxyRouteHandler(legacyRoute, logger);
-                appInfo.RegisterRoute($"ALL {proxyRoute}", new RouteHandlerData(pageInfoFactory.RawPage("Public", false), proxyHandler.HandleAsync));
-            }
+                Route = proxyRoute,
+                TargetBaseUrl = proxyTarget
+            };
+            var proxyHandler = new ProxyRouteHandler(legacyRoute, logger);
+            appInfo.RegisterRoute($"ALL {proxyRoute}", new RouteHandlerData(pageInfoFactory.RawPage("Public", false), proxyHandler.HandleAsync));
         }
     }
 }

--- a/BareMetalWeb.Host/ProxyRouteHandler.cs
+++ b/BareMetalWeb.Host/ProxyRouteHandler.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Security.Cryptography;
 using System.Text;
+using Microsoft.AspNetCore.Http;
 using BareMetalWeb.Core.Interfaces;
 using BareMetalWeb.Data;
 using BareMetalWeb.Interfaces;

--- a/BareMetalWeb.Host/RouteHandlers.cs
+++ b/BareMetalWeb.Host/RouteHandlers.cs
@@ -11,7 +11,6 @@ using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Primitives;
 using BareMetalWeb.Data;
 using BareMetalWeb.Interfaces;
@@ -33,6 +32,7 @@ public sealed class RouteHandlers : IRouteHandlers
     private readonly string _dataRootFolder;
     private readonly AuditService _auditService;
     private readonly IBufferedLogger? _logger;
+    private readonly BmwConfig? _config;
     private readonly IReadOnlyList<(string SettingId, string Value, string Description)> _settingDefaults;
     private const string MfaChallengeCookieName = "mfa_challenge_id";
     private static readonly TimeSpan MfaPendingLifetime = TimeSpan.FromMinutes(5);
@@ -117,7 +117,7 @@ public sealed class RouteHandlers : IRouteHandlers
     }
 
     public RouteHandlers(IHtmlRenderer renderer, ITemplateStore templateStore, bool allowAccountCreation, string mfaKeyRootFolder, AuditService auditService,
-        IReadOnlyList<(string SettingId, string Value, string Description)>? settingDefaults = null, IBufferedLogger? logger = null)
+        IReadOnlyList<(string SettingId, string Value, string Description)>? settingDefaults = null, IBufferedLogger? logger = null, BmwConfig? config = null)
     {
         _renderer = renderer;
         _templateStore = templateStore;
@@ -126,6 +126,7 @@ public sealed class RouteHandlers : IRouteHandlers
         _dataRootFolder = mfaKeyRootFolder;
         _auditService = auditService;
         _logger = logger;
+        _config = config;
         _settingDefaults = settingDefaults ?? Array.Empty<(string, string, string)>();
     }
 
@@ -534,29 +535,20 @@ public sealed class RouteHandlers : IRouteHandlers
 
     private EntraIdOptions? GetEntraIdOptions(HttpContext context)
     {
-        var config = context.RequestServices?.GetService(typeof(IConfiguration)) as IConfiguration;
-        var section = config?.GetSection("EntraId");
-        if (section == null || !section.Exists())
+        if (_config == null || !_config.GetValue("EntraId.Enabled", false))
             return null;
 
         var options = new EntraIdOptions
         {
-            Enabled = section.GetValue<bool>("Enabled"),
-            TenantId = section.GetValue<string>("TenantId") ?? string.Empty,
-            ClientId = section.GetValue<string>("ClientId") ?? string.Empty,
-            ClientSecret = section.GetValue<string>("ClientSecret") ?? string.Empty,
-            RedirectUri = section.GetValue<string>("RedirectUri") ?? "/auth/sso/callback",
-            BaseUrl = section.GetValue<string>("BaseUrl") ?? string.Empty,
-            AutoProvisionUsers = section.GetValue("AutoProvisionUsers", true),
-            DefaultPermissions = section.GetValue<string>("DefaultPermissions") ?? "user",
+            Enabled = _config.GetValue("EntraId.Enabled", false),
+            TenantId = _config.GetValue("EntraId.TenantId", ""),
+            ClientId = _config.GetValue("EntraId.ClientId", ""),
+            ClientSecret = _config.GetValue("EntraId.ClientSecret", ""),
+            RedirectUri = _config.GetValue("EntraId.RedirectUri", "/auth/sso/callback"),
+            BaseUrl = _config.GetValue("EntraId.BaseUrl", ""),
+            AutoProvisionUsers = _config.GetValue("EntraId.AutoProvisionUsers", true),
+            DefaultPermissions = _config.GetValue("EntraId.DefaultPermissions", "user"),
         };
-
-        var mappings = section.GetSection("GroupRoleMappings");
-        if (mappings.Exists())
-        {
-            foreach (var child in mappings.GetChildren())
-                options.GroupRoleMappings[child.Key] = child.Value ?? string.Empty;
-        }
 
         return options.Enabled && !string.IsNullOrEmpty(options.TenantId) && !string.IsNullOrEmpty(options.ClientId)
             ? options : null;
@@ -5168,10 +5160,7 @@ public sealed class RouteHandlers : IRouteHandlers
 
     private string GetUploadRootPath(HttpContext context)
     {
-        var configuration = context.RequestServices.GetService(typeof(IConfiguration)) as IConfiguration;
-        #pragma warning disable IL2026 // ConfigurationBinder.GetValue with string primitive is trim-safe
-        var configured = configuration?.GetValue("Uploads:RootDirectory", "uploads") ?? "uploads";
-        #pragma warning restore IL2026
+        var configured = _config?.GetValue("Uploads.RootDirectory", "uploads") ?? "uploads";
         if (Path.IsPathRooted(configured))
             return configured;
         return Path.Combine(_dataRootFolder, configured);
@@ -5222,10 +5211,7 @@ public sealed class RouteHandlers : IRouteHandlers
 
     private static string GetLogRoot(HttpContext context)
     {
-        var config = context.RequestServices.GetService(typeof(IConfiguration)) as IConfiguration;
-        #pragma warning disable IL2026 // ConfigurationBinder.GetValue with string primitive is trim-safe
-        var logFolder = config?.GetValue("Logging:LogFolder", "Logs") ?? "Logs";
-        #pragma warning restore IL2026
+        var logFolder = "Logs";
         if (Path.IsPathRooted(logFolder))
             return logFolder;
 

--- a/BareMetalWeb.Rendering.Tests/HtmlRendererTests.cs
+++ b/BareMetalWeb.Rendering.Tests/HtmlRendererTests.cs
@@ -95,6 +95,8 @@ internal sealed class StubBareWebHost : IBareWebHost
     public bool HttpsEndpointAvailable { get; set; }
     public string? HttpsRedirectHost { get; set; }
     public int? HttpsRedirectPort { get; set; }
+    public BmwConfig Configuration { get; set; } = BmwConfig.Load("/tmp");
+    public string ContentRootPath { get; set; } = "/tmp";
     public bool ShowHostDiagnostics { get; set; } = false;
 
     public ValueTask BuildAppInfoMenuOptionsAsync(HttpContext? context = null, CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Summary

Eliminates `Microsoft.NET.Sdk.Web` and `Microsoft.Extensions.Configuration` entirely. BMW is now a plain .NET console app that hosts Kestrel directly.

### What changed

| Before | After |
|--------|-------|
| `Microsoft.NET.Sdk.Web` | `Microsoft.NET.Sdk` + `FrameworkReference` |
| `WebApplication.CreateBuilder()` | `BmwConfig.Load(contentRoot)` |
| `app.Run()` | `BmwHost.Create(server).RunAsync()` |
| `IConfiguration` (Microsoft.Extensions) | `BmwConfig` (pipe-delimited text file) |
| `appsettings.json` | `Metal.config` |
| `context.RequestServices.GetService()` | Direct field access |

### New files
- **BmwConfig.cs** (Core) — Reads `Metal.config` (`key\|value` format). Provides `GetValue<T>()`, `GetArray()`, `HasKey()`.
- **Metal.config** — Bootstrap config for pre-data-store values (data root, log folder, Kestrel, thread pool)

### Key design
Bootstrap config (`Metal.config`) → data store init → runtime config (`SettingsService`/`WellKnownSettings`)

### 14 files changed, 365 insertions, 307 deletions

Fixes #925