### PR TITLE
feat: WAL segment index for O(rows-in-segment) compaction (fixes #931)

### DIFF
--- a/BareMetalWeb.Data/WalCompactor.cs
+++ b/BareMetalWeb.Data/WalCompactor.cs
@@ -32,9 +32,6 @@ public sealed class WalCompactor
         var segmentIds = _store.GetSegmentIds();
         uint? activeId = _store.ActiveSegmentId;
 
-        // Snapshot the head map once for the benefit check
-        _store.HeadMap.CopyArrays(out ulong[] keys, out ulong[] heads);
-
         for (int s = 0; s < segmentIds.Count; s++)
         {
             uint segId = segmentIds[s];
@@ -42,12 +39,7 @@ public sealed class WalCompactor
                 continue;
 
             // Count how many live head-map entries reference this segment
-            int liveCount = 0;
-            for (int i = 0; i < heads.Length; i++)
-            {
-                var (headSeg, _) = WalConstants.UnpackPtr(heads[i]);
-                if (headSeg == segId) liveCount++;
-            }
+            int liveCount = _store.SegmentIndex.GetCount(segId);
 
             if (liveCount == 0)
             {

--- a/BareMetalWeb.Data/WalSegmentIndex.cs
+++ b/BareMetalWeb.Data/WalSegmentIndex.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace BareMetalWeb.Data;
+
+/// <summary>
+/// Lightweight in-memory index: segmentId → set of WAL keys whose latest
+/// version resides in that segment. Enables O(rows-in-segment) compaction
+/// lookups instead of scanning the entire head map.
+/// Thread-safe via a ReaderWriterLockSlim.
+/// </summary>
+public sealed class WalSegmentIndex : IDisposable
+{
+    private readonly ReaderWriterLockSlim _lock = new(LockRecursionPolicy.NoRecursion);
+    private readonly Dictionary<uint, HashSet<ulong>> _map = new();
+
+    /// <summary>Register that <paramref name="walKey"/>'s head is in <paramref name="segmentId"/>.</summary>
+    public void Add(ulong walKey, uint segmentId)
+    {
+        _lock.EnterWriteLock();
+        try
+        {
+            if (!_map.TryGetValue(segmentId, out var set))
+            {
+                set = new HashSet<ulong>();
+                _map[segmentId] = set;
+            }
+            set.Add(walKey);
+        }
+        finally { _lock.ExitWriteLock(); }
+    }
+
+    /// <summary>Atomically remove <paramref name="walKey"/> from <paramref name="oldSegmentId"/> and add to <paramref name="newSegmentId"/>.</summary>
+    public void Move(ulong walKey, uint oldSegmentId, uint newSegmentId)
+    {
+        _lock.EnterWriteLock();
+        try
+        {
+            if (_map.TryGetValue(oldSegmentId, out var oldSet))
+            {
+                oldSet.Remove(walKey);
+                if (oldSet.Count == 0)
+                    _map.Remove(oldSegmentId);
+            }
+
+            if (!_map.TryGetValue(newSegmentId, out var newSet))
+            {
+                newSet = new HashSet<ulong>();
+                _map[newSegmentId] = newSet;
+            }
+            newSet.Add(walKey);
+        }
+        finally { _lock.ExitWriteLock(); }
+    }
+
+    /// <summary>Remove <paramref name="walKey"/> from <paramref name="segmentId"/>'s set.</summary>
+    public void Remove(ulong walKey, uint segmentId)
+    {
+        _lock.EnterWriteLock();
+        try
+        {
+            if (_map.TryGetValue(segmentId, out var set))
+            {
+                set.Remove(walKey);
+                if (set.Count == 0)
+                    _map.Remove(segmentId);
+            }
+        }
+        finally { _lock.ExitWriteLock(); }
+    }
+
+    /// <summary>Returns a snapshot of all keys in <paramref name="segmentId"/>.</summary>
+    public void GetKeys(uint segmentId, out ulong[] keys)
+    {
+        _lock.EnterReadLock();
+        try
+        {
+            if (_map.TryGetValue(segmentId, out var set))
+            {
+                keys = new ulong[set.Count];
+                int i = 0;
+                foreach (ulong k in set)
+                    keys[i++] = k;
+            }
+            else
+            {
+                keys = Array.Empty<ulong>();
+            }
+        }
+        finally { _lock.ExitReadLock(); }
+    }
+
+    /// <summary>Returns count of keys in <paramref name="segmentId"/> (O(1)).</summary>
+    public int GetCount(uint segmentId)
+    {
+        _lock.EnterReadLock();
+        try
+        {
+            if (_map.TryGetValue(segmentId, out var set))
+                return set.Count;
+            return 0;
+        }
+        finally { _lock.ExitReadLock(); }
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        _lock.Dispose();
+    }
+}

--- a/BareMetalWeb.Data/WalStore.cs
+++ b/BareMetalWeb.Data/WalStore.cs
@@ -43,6 +43,9 @@ public sealed class WalStore : IDisposable
     /// <summary>In-memory head map: key → Ptr of the latest committed record for that key.</summary>
     public WalHeadMap HeadMap { get; } = new();
 
+    /// <summary>In-memory segment index: segmentId → set of WAL keys in that segment.</summary>
+    public WalSegmentIndex SegmentIndex { get; } = new();
+
     /// <summary>
     /// Global monotonic commit watermark (V2 spec §3.1 VisibleCommitPtr).
     /// Queries and projections should only observe versions ≤ this value.
@@ -168,6 +171,21 @@ public sealed class WalStore : IDisposable
                 opKeys[i] = filledOps[i].Key;
             HeadMap.BatchSetHeads(opKeys, ptr);
 
+            // Maintain segment index
+            var (newSegId, _) = WalConstants.UnpackPtr(ptr);
+            for (int i = 0; i < filledOps.Length; i++)
+            {
+                if (filledOps[i].PrevPtr != WalConstants.NullPtr)
+                {
+                    var (oldSegId, _) = WalConstants.UnpackPtr(filledOps[i].PrevPtr);
+                    SegmentIndex.Move(filledOps[i].Key, oldSegId, newSegId);
+                }
+                else
+                {
+                    SegmentIndex.Add(filledOps[i].Key, newSegId);
+                }
+            }
+
             Volatile.Write(ref _visibleCommitPtr, ptr);
         }
 
@@ -228,6 +246,7 @@ public sealed class WalStore : IDisposable
         ProjectionManager.Dispose();
         KeyAllocator.Dispose();
         HeadMap.Dispose();
+        SegmentIndex.Dispose();
     }
 
     // ── Private helpers ───────────────────────────────────────────────────────
@@ -293,6 +312,14 @@ public sealed class WalStore : IDisposable
             }
         }
 
+        // Rebuild segment index from head map
+        HeadMap.CopyArrays(out var skeys, out var sheads);
+        for (int i = 0; i < skeys.Length; i++)
+        {
+            var (segId, _) = WalConstants.UnpackPtr(sheads[i]);
+            SegmentIndex.Add(skeys[i], segId);
+        }
+
         // Always start a new segment; don't resume the previous active segment.
         _nextSegmentId = segments.Count > 0 ? segments[0].segId + 1 : 0;
     }
@@ -346,18 +373,10 @@ public sealed class WalStore : IDisposable
         long startTicks = EngineMetrics.StartTiming();
         long originalSize = new FileInfo(originalPath).Length;
 
-        // ── 1. Snapshot head map ────────────────────────────────────────────
-        HeadMap.CopyArrays(out ulong[] allKeys, out ulong[] allHeads);
+        // ── 1. Get keys from segment index ────────────────────────────────
+        SegmentIndex.GetKeys(segmentId, out ulong[] matchKeys);
 
-        // ── 2. Collect keys whose latest version lives in this segment ──────
-        int matchCount = 0;
-        for (int i = 0; i < allKeys.Length; i++)
-        {
-            var (segId, _) = WalConstants.UnpackPtr(allHeads[i]);
-            if (segId == segmentId) matchCount++;
-        }
-
-        if (matchCount == 0)
+        if (matchKeys.Length == 0)
         {
             // No live keys reference this segment — it can be deleted
             try { File.Delete(originalPath); } catch { /* best effort */ }
@@ -365,37 +384,41 @@ public sealed class WalStore : IDisposable
             return;
         }
 
-        // Gather matching entries (avoid LINQ; pre-sized arrays)
-        var matchKeys  = new ulong[matchCount];
-        var matchHeads = new ulong[matchCount];
-        int w = 0;
-        for (int i = 0; i < allKeys.Length; i++)
+        // ── 2. Look up head pointers for each key ──────────────────────────
+        var matchHeads = new ulong[matchKeys.Length];
+        for (int i = 0; i < matchKeys.Length; i++)
         {
-            var (segId, _) = WalConstants.UnpackPtr(allHeads[i]);
-            if (segId == segmentId)
-            {
-                matchKeys[w]  = allKeys[i];
-                matchHeads[w] = allHeads[i];
-                w++;
-            }
+            HeadMap.TryGetHead(matchKeys[i], out matchHeads[i]);
         }
 
         // ── 3. Read payloads from disk, skipping tombstones ─────────────────
-        var ops    = new WalOp[matchCount];
-        var opKeys = new ulong[matchCount]; // keys for head map update
+        var ops    = new WalOp[matchKeys.Length];
+        var opKeys = new ulong[matchKeys.Length]; // keys for head map update
         int opCount = 0;
+        var deadKeys = new ulong[matchKeys.Length]; // keys to remove from segment index
+        int deadCount = 0;
 
-        for (int i = 0; i < matchCount; i++)
+        for (int i = 0; i < matchKeys.Length; i++)
         {
             if (!TryReadFullOp(matchHeads[i], matchKeys[i], out WalOp op))
+            {
+                deadKeys[deadCount++] = matchKeys[i];
                 continue;
+            }
             if (op.OpType == WalConstants.OpTypeDeleteTombstone)
+            {
+                deadKeys[deadCount++] = matchKeys[i];
                 continue;
+            }
 
             ops[opCount]    = op;
             opKeys[opCount] = matchKeys[i];
             opCount++;
         }
+
+        // Remove dead keys from segment index
+        for (int i = 0; i < deadCount; i++)
+            SegmentIndex.Remove(deadKeys[i], segmentId);
 
         if (opCount == 0)
         {


### PR DESCRIPTION
## WAL Segment Index

Adds a lightweight in-memory `WalSegmentIndex` (`segmentId → HashSet<ulong>`) so compaction operates in O(rows in segment) time instead of scanning the entire head map.

### Changes

**`WalSegmentIndex.cs`** — new class:
- `Add(walKey, segmentId)`, `Move(walKey, old, new)`, `Remove(walKey, segmentId)`
- `GetKeys(segmentId, out keys)` — snapshot for compaction
- `GetCount(segmentId)` — O(1) benefit check
- Thread-safe via `ReaderWriterLockSlim` (reads don't block each other)

**`WalStore` integration:**
- **`Recover()`** — rebuilds segment index from head map after WAL replay
- **`CommitAsync()`** — maintains index during writes using PrevPtr to detect old→new segment moves
- **`CompactSegment()`** — replaced O(all-keys) head map scan with `SegmentIndex.GetKeys()`; dead keys/tombstones cleaned from index
- **`Dispose()`** — disposes index

**`WalCompactor`** — replaced head map snapshot + linear scan benefit check with `SegmentIndex.GetCount()` for O(1) lookups. No longer needs to snapshot the entire head map just to count references.

### Performance impact

| Operation | Before | After |
|---|---|---|
| Find keys in segment | O(all keys in head map) | O(keys in segment) |
| Compaction benefit check | O(all keys in head map) | O(1) |
| Per-commit overhead | None | O(ops in batch) — negligible |

Correctness-first implementation using `HashSet<ulong>`. Issue #932 will replace with pooled arrays.

Fixes #931