### PR TITLE
feat: Replace HashSet with pooled array segment index (fixes #932)

### DIFF
--- a/BareMetalWeb.Data/WalSegmentIndex.cs
+++ b/BareMetalWeb.Data/WalSegmentIndex.cs
@@ -1,19 +1,25 @@
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Threading;
 
 namespace BareMetalWeb.Data;
 
 /// <summary>
-/// Lightweight in-memory index: segmentId → set of WAL keys whose latest
-/// version resides in that segment. Enables O(rows-in-segment) compaction
-/// lookups instead of scanning the entire head map.
+/// Lightweight in-memory index: segmentId → contiguous pooled array of WAL keys
+/// whose latest version resides in that segment.
+/// Enables O(rows-in-segment) compaction lookups instead of scanning the entire head map.
 /// Thread-safe via a ReaderWriterLockSlim.
+///
+/// Backing storage uses <see cref="ArrayPool{T}"/>-rented arrays with swap-remove
+/// semantics — zero per-key heap allocations during steady-state operation.
 /// </summary>
 public sealed class WalSegmentIndex : IDisposable
 {
+    private const int InitialCapacity = 64;
+
     private readonly ReaderWriterLockSlim _lock = new(LockRecursionPolicy.NoRecursion);
-    private readonly Dictionary<uint, HashSet<ulong>> _map = new();
+    private readonly Dictionary<uint, KeyBucket> _map = new();
 
     /// <summary>Register that <paramref name="walKey"/>'s head is in <paramref name="segmentId"/>.</summary>
     public void Add(ulong walKey, uint segmentId)
@@ -21,12 +27,12 @@ public sealed class WalSegmentIndex : IDisposable
         _lock.EnterWriteLock();
         try
         {
-            if (!_map.TryGetValue(segmentId, out var set))
+            if (!_map.TryGetValue(segmentId, out var bucket))
             {
-                set = new HashSet<ulong>();
-                _map[segmentId] = set;
+                bucket = new KeyBucket(InitialCapacity);
+                _map[segmentId] = bucket;
             }
-            set.Add(walKey);
+            bucket.Add(walKey);
         }
         finally { _lock.ExitWriteLock(); }
     }
@@ -37,19 +43,22 @@ public sealed class WalSegmentIndex : IDisposable
         _lock.EnterWriteLock();
         try
         {
-            if (_map.TryGetValue(oldSegmentId, out var oldSet))
+            if (_map.TryGetValue(oldSegmentId, out var oldBucket))
             {
-                oldSet.Remove(walKey);
-                if (oldSet.Count == 0)
+                oldBucket.Remove(walKey);
+                if (oldBucket.Count == 0)
+                {
+                    oldBucket.Return();
                     _map.Remove(oldSegmentId);
+                }
             }
 
-            if (!_map.TryGetValue(newSegmentId, out var newSet))
+            if (!_map.TryGetValue(newSegmentId, out var newBucket))
             {
-                newSet = new HashSet<ulong>();
-                _map[newSegmentId] = newSet;
+                newBucket = new KeyBucket(InitialCapacity);
+                _map[newSegmentId] = newBucket;
             }
-            newSet.Add(walKey);
+            newBucket.Add(walKey);
         }
         finally { _lock.ExitWriteLock(); }
     }
@@ -60,11 +69,14 @@ public sealed class WalSegmentIndex : IDisposable
         _lock.EnterWriteLock();
         try
         {
-            if (_map.TryGetValue(segmentId, out var set))
+            if (_map.TryGetValue(segmentId, out var bucket))
             {
-                set.Remove(walKey);
-                if (set.Count == 0)
+                bucket.Remove(walKey);
+                if (bucket.Count == 0)
+                {
+                    bucket.Return();
                     _map.Remove(segmentId);
+                }
             }
         }
         finally { _lock.ExitWriteLock(); }
@@ -76,12 +88,10 @@ public sealed class WalSegmentIndex : IDisposable
         _lock.EnterReadLock();
         try
         {
-            if (_map.TryGetValue(segmentId, out var set))
+            if (_map.TryGetValue(segmentId, out var bucket) && bucket.Count > 0)
             {
-                keys = new ulong[set.Count];
-                int i = 0;
-                foreach (ulong k in set)
-                    keys[i++] = k;
+                keys = new ulong[bucket.Count];
+                bucket.CopyTo(keys);
             }
             else
             {
@@ -97,8 +107,8 @@ public sealed class WalSegmentIndex : IDisposable
         _lock.EnterReadLock();
         try
         {
-            if (_map.TryGetValue(segmentId, out var set))
-                return set.Count;
+            if (_map.TryGetValue(segmentId, out var bucket))
+                return bucket.Count;
             return 0;
         }
         finally { _lock.ExitReadLock(); }
@@ -107,6 +117,71 @@ public sealed class WalSegmentIndex : IDisposable
     /// <inheritdoc/>
     public void Dispose()
     {
+        foreach (var bucket in _map.Values)
+            bucket.Return();
+        _map.Clear();
         _lock.Dispose();
+    }
+
+    /// <summary>
+    /// Contiguous pooled array of WAL keys for a single segment.
+    /// Uses swap-remove for O(1) deletion, ArrayPool for zero-alloc growth.
+    /// </summary>
+    private sealed class KeyBucket
+    {
+        private ulong[] _keys;
+        private int _count;
+
+        public int Count => _count;
+
+        public KeyBucket(int capacity)
+        {
+            _keys = ArrayPool<ulong>.Shared.Rent(capacity);
+            _count = 0;
+        }
+
+        public void Add(ulong key)
+        {
+            if (_count == _keys.Length)
+                Grow();
+            _keys[_count++] = key;
+        }
+
+        /// <summary>Swap-remove: O(n) scan + O(1) removal. Order is not preserved.</summary>
+        public void Remove(ulong key)
+        {
+            for (int i = 0; i < _count; i++)
+            {
+                if (_keys[i] == key)
+                {
+                    _keys[i] = _keys[--_count];
+                    return;
+                }
+            }
+        }
+
+        public void CopyTo(ulong[] dest)
+        {
+            Array.Copy(_keys, dest, _count);
+        }
+
+        public void Return()
+        {
+            if (_keys.Length > 0)
+            {
+                ArrayPool<ulong>.Shared.Return(_keys);
+                _keys = Array.Empty<ulong>();
+                _count = 0;
+            }
+        }
+
+        private void Grow()
+        {
+            int newCap = _keys.Length * 2;
+            var newArr = ArrayPool<ulong>.Shared.Rent(newCap);
+            Array.Copy(_keys, newArr, _count);
+            ArrayPool<ulong>.Shared.Return(_keys);
+            _keys = newArr;
+        }
     }
 }


### PR DESCRIPTION
## Pooled Array Segment Index

Replaces `HashSet<ulong>` per segment with `ArrayPool<ulong>`-backed contiguous arrays and swap-remove semantics.

### Changes

**`WalSegmentIndex.cs`** — internal `KeyBucket` class:
- Rents from `ArrayPool<ulong>.Shared` (initial capacity 64, doubles on grow)
- `Add`: append at tail — O(1) amortised
- `Remove`: linear scan + swap-with-last — O(n) scan, O(1) removal, no shifting
- `CopyTo`: `Array.Copy` from contiguous backing array
- `Return`: returns array to pool on empty bucket or dispose
- `Dispose`: returns all pooled arrays, clears map

### Why

- `HashSet<ulong>` allocates per-entry nodes on the managed heap
- Pooled arrays: zero per-key allocations during steady-state (Add/Move/Remove)
- Contiguous memory: better cache locality for `GetKeys` snapshot copies
- `ArrayPool` reuse: old segment arrays get recycled for new segments

### API unchanged

Same public surface: `Add`, `Move`, `Remove`, `GetKeys`, `GetCount`, `Dispose`. Drop-in replacement.

Fixes #932