### PR TITLE
feat: SIMD-accelerated byte scanner with AVX2/SSE2/NEON paths (fixes #908)

### DIFF
--- a/BareMetalWeb.Data.Tests/SimdAccelerationTests.cs
+++ b/BareMetalWeb.Data.Tests/SimdAccelerationTests.cs
@@ -668,6 +668,189 @@ public sealed class BloomFilterDataTests
         Assert.True(falsePositives > 0,
             "Zero false positives is statistically implausible — possible test bug.");
     }
+
+    // ── SimdByteScanner ────────────────────────────────────────────────────
+
+    [Fact]
+    public void SimdByteScanner_FindByte_ReturnsFirstMatch()
+    {
+        var data = new byte[1024];
+        data[512] = 0xAA;
+        data[700] = 0xAA;
+
+        Assert.Equal(512, SimdByteScanner.FindByte(data, 0xAA));
+    }
+
+    [Fact]
+    public void SimdByteScanner_FindByte_ReturnsMinusOneWhenAbsent()
+    {
+        var data = new byte[256];
+        for (int i = 0; i < data.Length; i++) data[i] = 0x42;
+
+        Assert.Equal(-1, SimdByteScanner.FindByte(data, 0xFF));
+    }
+
+    [Fact]
+    public void SimdByteScanner_FindByte_EmptySpan()
+    {
+        Assert.Equal(-1, SimdByteScanner.FindByte(ReadOnlySpan<byte>.Empty, 0x00));
+    }
+
+    [Fact]
+    public void SimdByteScanner_FindByte_FirstByte()
+    {
+        var data = new byte[] { 0xBB, 0x00, 0x00, 0x00 };
+        Assert.Equal(0, SimdByteScanner.FindByte(data, 0xBB));
+    }
+
+    [Fact]
+    public void SimdByteScanner_FindByte_LastByte()
+    {
+        var data = new byte[65];
+        data[64] = 0xCC; // past any 32-byte or 16-byte aligned block
+        Assert.Equal(64, SimdByteScanner.FindByte(data, 0xCC));
+    }
+
+    [Fact]
+    public void SimdByteScanner_FindByte_LargeBuffer_EveryPosition()
+    {
+        for (int size = 0; size <= 128; size++)
+        {
+            var data = new byte[size];
+            for (int pos = 0; pos < size; pos++)
+            {
+                Array.Clear(data);
+                data[pos] = 0xFE;
+                int found = SimdByteScanner.FindByte(data, 0xFE);
+                Assert.Equal(pos, found);
+            }
+        }
+    }
+
+    [Fact]
+    public void SimdByteScanner_FindAnyOfTwo_FindsBothTargets()
+    {
+        var data = new byte[256];
+        data[100] = 0x0A;
+        data[50]  = 0x7C;
+
+        Assert.Equal(50, SimdByteScanner.FindAnyOfTwo(data, 0x0A, 0x7C));
+        Assert.Equal(50, SimdByteScanner.FindAnyOfTwo(data, 0x7C, 0x0A));
+    }
+
+    [Fact]
+    public void SimdByteScanner_FindAnyOfTwo_ReturnsMinusOneWhenAbsent()
+    {
+        var data = new byte[128];
+        for (int i = 0; i < data.Length; i++) data[i] = 0x42;
+
+        Assert.Equal(-1, SimdByteScanner.FindAnyOfTwo(data, 0x0A, 0x0D));
+    }
+
+    [Fact]
+    public void SimdByteScanner_CountByte_CorrectCount()
+    {
+        var data = new byte[1024];
+        int expected = 0;
+        for (int i = 0; i < data.Length; i++)
+        {
+            if (i % 7 == 0) { data[i] = 0xDD; expected++; }
+        }
+
+        Assert.Equal(expected, SimdByteScanner.CountByte(data, 0xDD));
+    }
+
+    [Fact]
+    public void SimdByteScanner_CountByte_AllMatch()
+    {
+        var data = new byte[200];
+        Array.Fill(data, (byte)0x99);
+        Assert.Equal(200, SimdByteScanner.CountByte(data, 0x99));
+    }
+
+    [Fact]
+    public void SimdByteScanner_CountByte_NoneMatch()
+    {
+        var data = new byte[200];
+        Assert.Equal(0, SimdByteScanner.CountByte(data, 0xFF));
+    }
+
+    [Fact]
+    public void SimdByteScanner_CountByte_Empty()
+    {
+        Assert.Equal(0, SimdByteScanner.CountByte(ReadOnlySpan<byte>.Empty, 0x00));
+    }
+
+    [Fact]
+    public void SimdByteScanner_FindByte_MatchesSpanIndexOf()
+    {
+        var rng = new Random(42);
+        for (int trial = 0; trial < 200; trial++)
+        {
+            int len = rng.Next(0, 2048);
+            var data = new byte[len];
+            rng.NextBytes(data);
+            byte target = (byte)rng.Next(256);
+
+            int expected = ((ReadOnlySpan<byte>)data).IndexOf(target);
+            int actual = SimdByteScanner.FindByte(data, target);
+            Assert.Equal(expected, actual);
+        }
+    }
+
+    [Fact]
+    public void SimdByteScanner_CountByte_MatchesLinqCount()
+    {
+        var rng = new Random(123);
+        for (int trial = 0; trial < 100; trial++)
+        {
+            int len = rng.Next(0, 2048);
+            var data = new byte[len];
+            rng.NextBytes(data);
+            byte target = (byte)rng.Next(256);
+
+            int expected = data.Count(b => b == target);
+            int actual = SimdByteScanner.CountByte(data, target);
+            Assert.Equal(expected, actual);
+        }
+    }
+
+    [Fact]
+    public void SimdByteScanner_FindNextRecordMagic_Integration()
+    {
+        var data = new byte[4096];
+        var rng = new Random(99);
+        rng.NextBytes(data);
+
+        System.Buffers.Binary.BinaryPrimitives.WriteUInt32LittleEndian(
+            data.AsSpan(1000), 0x52454331u);
+
+        int found = WalSegmentReader.FindNextRecordMagic(data);
+        Assert.True(found >= 0 && found <= 1000,
+            $"Expected magic at or before 1000, found at {found}");
+    }
+
+    [Fact]
+    public void SimdByteScanner_Throughput_LargeBuffer()
+    {
+        const int size = 4 * 1024 * 1024;
+        var data = new byte[size];
+        data[size - 1] = 0xFF;
+
+        SimdByteScanner.FindByte(data, 0xFF); // warm up
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        const int iterations = 50;
+        for (int i = 0; i < iterations; i++)
+            SimdByteScanner.FindByte(data, 0xFF);
+        sw.Stop();
+
+        long totalBytes = (long)size * iterations;
+        double gbPerSec = totalBytes / (sw.Elapsed.TotalSeconds * 1024 * 1024 * 1024);
+
+        Assert.True(gbPerSec > 0.5,
+            $"Throughput {gbPerSec:F2} GB/s is suspiciously low — SIMD path may not be active");
+    }
 }
 
 /// <summary>Simple POCO used to verify XxHash64 schema hash stability.</summary>

--- a/BareMetalWeb.Data/BareMetalWeb.Data.csproj
+++ b/BareMetalWeb.Data/BareMetalWeb.Data.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAotCompatible>true</IsAotCompatible>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/BareMetalWeb.Data/SimdByteScanner.cs
+++ b/BareMetalWeb.Data/SimdByteScanner.cs
@@ -1,0 +1,414 @@
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+#if NET7_0_OR_GREATER
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.X86;
+#endif
+
+namespace BareMetalWeb.Data;
+
+/// <summary>
+/// SIMD-accelerated byte scanner for high-throughput buffer searching.
+/// Dispatch order: AVX2 (32 bytes/cycle) → SSE2 (16 bytes/cycle) → AdvSimd/NEON (16 bytes/cycle) → Scalar.
+/// All paths return identical results.
+/// </summary>
+public static class SimdByteScanner
+{
+    /// <summary>
+    /// Returns the index of the first occurrence of <paramref name="target"/> in <paramref name="data"/>,
+    /// or -1 if not found. Uses AVX2/SSE2/NEON when available.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int FindByte(ReadOnlySpan<byte> data, byte target)
+    {
+#if NET7_0_OR_GREATER
+        if (Avx2.IsSupported)
+            return FindByteAvx2(data, target);
+        if (Sse2.IsSupported)
+            return FindByteSse2(data, target);
+        if (AdvSimd.IsSupported)
+            return FindByteAdvSimd(data, target);
+#endif
+        return FindByteScalar(data, target);
+    }
+
+    /// <summary>
+    /// Returns the index of the first occurrence of either <paramref name="a"/> or <paramref name="b"/>
+    /// in <paramref name="data"/>, or -1 if neither is found.
+    /// Useful for delimiter scanning (e.g. searching for '|' or '\n' simultaneously).
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int FindAnyOfTwo(ReadOnlySpan<byte> data, byte a, byte b)
+    {
+#if NET7_0_OR_GREATER
+        if (Avx2.IsSupported)
+            return FindAnyOfTwoAvx2(data, a, b);
+        if (Sse2.IsSupported)
+            return FindAnyOfTwoSse2(data, a, b);
+        if (AdvSimd.IsSupported)
+            return FindAnyOfTwoAdvSimd(data, a, b);
+#endif
+        return FindAnyOfTwoScalar(data, a, b);
+    }
+
+    /// <summary>
+    /// Counts occurrences of <paramref name="target"/> in <paramref name="data"/> using SIMD.
+    /// Processes 32 bytes per iteration on AVX2 with POPCNT for mask counting.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int CountByte(ReadOnlySpan<byte> data, byte target)
+    {
+#if NET7_0_OR_GREATER
+        if (Avx2.IsSupported)
+            return CountByteAvx2(data, target);
+        if (Sse2.IsSupported)
+            return CountByteSse2(data, target);
+        if (AdvSimd.IsSupported)
+            return CountByteAdvSimd(data, target);
+#endif
+        return CountByteScalar(data, target);
+    }
+
+    // ── Scalar fallbacks ────────────────────────────────────────────────────
+
+    private static int FindByteScalar(ReadOnlySpan<byte> data, byte target)
+    {
+        for (int i = 0; i < data.Length; i++)
+        {
+            if (data[i] == target) return i;
+        }
+        return -1;
+    }
+
+    private static int FindAnyOfTwoScalar(ReadOnlySpan<byte> data, byte a, byte b)
+    {
+        for (int i = 0; i < data.Length; i++)
+        {
+            byte v = data[i];
+            if (v == a || v == b) return i;
+        }
+        return -1;
+    }
+
+    private static int CountByteScalar(ReadOnlySpan<byte> data, byte target)
+    {
+        int count = 0;
+        for (int i = 0; i < data.Length; i++)
+        {
+            if (data[i] == target) count++;
+        }
+        return count;
+    }
+
+#if NET7_0_OR_GREATER
+
+    // ── AVX2 paths (32 bytes per iteration) ─────────────────────────────────
+
+    private static unsafe int FindByteAvx2(ReadOnlySpan<byte> data, byte target)
+    {
+        int length = data.Length;
+        if (length == 0) return -1;
+
+        fixed (byte* ptr = &MemoryMarshal.GetReference(data))
+        {
+            // Broadcast target byte to all 32 lanes of a 256-bit vector
+            Vector256<byte> needle = Vector256.Create(target);
+            int i = 0;
+
+            // Process 32 bytes per iteration
+            int vectorEnd = length - 31;
+            for (; i < vectorEnd; i += 32)
+            {
+                // Load 32 bytes from the buffer
+                Vector256<byte> chunk = Avx.LoadVector256(ptr + i);
+
+                // Compare each byte lane: 0xFF where equal, 0x00 where not
+                Vector256<byte> cmp = Avx2.CompareEqual(chunk, needle);
+
+                // Collapse comparison to a 32-bit mask (one bit per byte lane)
+                int mask = Avx2.MoveMask(cmp);
+
+                if (mask != 0)
+                {
+                    // TrailingZeroCount gives the index of the first set bit
+                    return i + BitOperations.TrailingZeroCount((uint)mask);
+                }
+            }
+
+            // Handle remaining bytes with scalar fallback
+            for (; i < length; i++)
+            {
+                if (ptr[i] == target) return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private static unsafe int FindAnyOfTwoAvx2(ReadOnlySpan<byte> data, byte a, byte b)
+    {
+        int length = data.Length;
+        if (length == 0) return -1;
+
+        fixed (byte* ptr = &MemoryMarshal.GetReference(data))
+        {
+            Vector256<byte> needleA = Vector256.Create(a);
+            Vector256<byte> needleB = Vector256.Create(b);
+            int i = 0;
+
+            int vectorEnd = length - 31;
+            for (; i < vectorEnd; i += 32)
+            {
+                Vector256<byte> chunk = Avx.LoadVector256(ptr + i);
+
+                // Compare against both targets, OR the results
+                Vector256<byte> cmpA = Avx2.CompareEqual(chunk, needleA);
+                Vector256<byte> cmpB = Avx2.CompareEqual(chunk, needleB);
+                Vector256<byte> combined = Avx2.Or(cmpA, cmpB);
+
+                int mask = Avx2.MoveMask(combined);
+                if (mask != 0)
+                    return i + BitOperations.TrailingZeroCount((uint)mask);
+            }
+
+            for (; i < length; i++)
+            {
+                byte v = ptr[i];
+                if (v == a || v == b) return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private static unsafe int CountByteAvx2(ReadOnlySpan<byte> data, byte target)
+    {
+        int length = data.Length;
+        if (length == 0) return 0;
+
+        int count = 0;
+        fixed (byte* ptr = &MemoryMarshal.GetReference(data))
+        {
+            Vector256<byte> needle = Vector256.Create(target);
+            int i = 0;
+
+            int vectorEnd = length - 31;
+            for (; i < vectorEnd; i += 32)
+            {
+                Vector256<byte> chunk = Avx.LoadVector256(ptr + i);
+                Vector256<byte> cmp = Avx2.CompareEqual(chunk, needle);
+                int mask = Avx2.MoveMask(cmp);
+
+                // POPCNT counts the number of set bits = number of matching bytes
+                count += BitOperations.PopCount((uint)mask);
+            }
+
+            for (; i < length; i++)
+            {
+                if (ptr[i] == target) count++;
+            }
+        }
+
+        return count;
+    }
+
+    // ── SSE2 paths (16 bytes per iteration) ─────────────────────────────────
+
+    private static unsafe int FindByteSse2(ReadOnlySpan<byte> data, byte target)
+    {
+        int length = data.Length;
+        if (length == 0) return -1;
+
+        fixed (byte* ptr = &MemoryMarshal.GetReference(data))
+        {
+            Vector128<byte> needle = Vector128.Create(target);
+            int i = 0;
+
+            int vectorEnd = length - 15;
+            for (; i < vectorEnd; i += 16)
+            {
+                Vector128<byte> chunk = Sse2.LoadVector128(ptr + i);
+                Vector128<byte> cmp = Sse2.CompareEqual(chunk, needle);
+                int mask = Sse2.MoveMask(cmp);
+
+                if (mask != 0)
+                    return i + BitOperations.TrailingZeroCount((uint)mask);
+            }
+
+            for (; i < length; i++)
+            {
+                if (ptr[i] == target) return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private static unsafe int FindAnyOfTwoSse2(ReadOnlySpan<byte> data, byte a, byte b)
+    {
+        int length = data.Length;
+        if (length == 0) return -1;
+
+        fixed (byte* ptr = &MemoryMarshal.GetReference(data))
+        {
+            Vector128<byte> needleA = Vector128.Create(a);
+            Vector128<byte> needleB = Vector128.Create(b);
+            int i = 0;
+
+            int vectorEnd = length - 15;
+            for (; i < vectorEnd; i += 16)
+            {
+                Vector128<byte> chunk = Sse2.LoadVector128(ptr + i);
+                Vector128<byte> cmpA = Sse2.CompareEqual(chunk, needleA);
+                Vector128<byte> cmpB = Sse2.CompareEqual(chunk, needleB);
+                Vector128<byte> combined = Sse2.Or(cmpA, cmpB);
+
+                int mask = Sse2.MoveMask(combined);
+                if (mask != 0)
+                    return i + BitOperations.TrailingZeroCount((uint)mask);
+            }
+
+            for (; i < length; i++)
+            {
+                byte v = ptr[i];
+                if (v == a || v == b) return i;
+            }
+        }
+
+        return -1;
+    }
+
+    private static unsafe int CountByteSse2(ReadOnlySpan<byte> data, byte target)
+    {
+        int length = data.Length;
+        if (length == 0) return 0;
+
+        int count = 0;
+        fixed (byte* ptr = &MemoryMarshal.GetReference(data))
+        {
+            Vector128<byte> needle = Vector128.Create(target);
+            int i = 0;
+
+            int vectorEnd = length - 15;
+            for (; i < vectorEnd; i += 16)
+            {
+                Vector128<byte> chunk = Sse2.LoadVector128(ptr + i);
+                Vector128<byte> cmp = Sse2.CompareEqual(chunk, needle);
+                int mask = Sse2.MoveMask(cmp);
+                count += BitOperations.PopCount((uint)mask);
+            }
+
+            for (; i < length; i++)
+            {
+                if (ptr[i] == target) count++;
+            }
+        }
+
+        return count;
+    }
+
+    // ── ARM AdvSimd/NEON paths (16 bytes per iteration) ─────────────────────
+
+    private static int FindByteAdvSimd(ReadOnlySpan<byte> data, byte target)
+    {
+        int length = data.Length;
+        if (length == 0) return -1;
+
+        var vecs = MemoryMarshal.Cast<byte, Vector128<byte>>(data);
+        Vector128<byte> needle = Vector128.Create(target);
+
+        for (int k = 0; k < vecs.Length; k++)
+        {
+            Vector128<byte> cmp = AdvSimd.CompareEqual(vecs[k], needle);
+
+            // MaxAcross reduces all 16 lanes to a single max; non-zero means a hit
+            if (AdvSimd.Arm64.MaxAcross(cmp).ToScalar() != 0)
+            {
+                int baseIdx = k * 16;
+                for (int j = 0; j < 16 && baseIdx + j < length; j++)
+                {
+                    if (data[baseIdx + j] == target)
+                        return baseIdx + j;
+                }
+            }
+        }
+
+        for (int i = vecs.Length * 16; i < length; i++)
+        {
+            if (data[i] == target) return i;
+        }
+
+        return -1;
+    }
+
+    private static int FindAnyOfTwoAdvSimd(ReadOnlySpan<byte> data, byte a, byte b)
+    {
+        int length = data.Length;
+        if (length == 0) return -1;
+
+        var vecs = MemoryMarshal.Cast<byte, Vector128<byte>>(data);
+        Vector128<byte> needleA = Vector128.Create(a);
+        Vector128<byte> needleB = Vector128.Create(b);
+
+        for (int k = 0; k < vecs.Length; k++)
+        {
+            Vector128<byte> cmpA = AdvSimd.CompareEqual(vecs[k], needleA);
+            Vector128<byte> cmpB = AdvSimd.CompareEqual(vecs[k], needleB);
+            Vector128<byte> combined = AdvSimd.Or(cmpA, cmpB);
+
+            if (AdvSimd.Arm64.MaxAcross(combined).ToScalar() != 0)
+            {
+                int baseIdx = k * 16;
+                for (int j = 0; j < 16 && baseIdx + j < length; j++)
+                {
+                    byte v = data[baseIdx + j];
+                    if (v == a || v == b)
+                        return baseIdx + j;
+                }
+            }
+        }
+
+        for (int i = vecs.Length * 16; i < length; i++)
+        {
+            byte v = data[i];
+            if (v == a || v == b) return i;
+        }
+
+        return -1;
+    }
+
+    private static int CountByteAdvSimd(ReadOnlySpan<byte> data, byte target)
+    {
+        int length = data.Length;
+        if (length == 0) return 0;
+
+        int count = 0;
+        var vecs = MemoryMarshal.Cast<byte, Vector128<byte>>(data);
+        Vector128<byte> needle = Vector128.Create(target);
+        // Each matching lane is 0xFF. We use subtraction from a zero accumulator:
+        // 0 - 0xFF = wraps, so instead we just sum each chunk's scalar count.
+        // Simple and correct: extract the match count via AddAcross.
+
+        for (int k = 0; k < vecs.Length; k++)
+        {
+            Vector128<byte> cmp = AdvSimd.CompareEqual(vecs[k], needle);
+            // Each matching lane = 0xFF. Negate (0-0xFF wraps to 1 in signed)
+            // is tricky; simpler: horizontally add all bytes then divide by 255.
+            // AddAcross sums all 16 byte lanes into one ushort.
+            ushort laneSum = AdvSimd.Arm64.AddAcross(cmp).ToScalar();
+            // Each match contributes 0xFF=255, so matches = laneSum / 255
+            count += laneSum / 255;
+        }
+
+        for (int i = vecs.Length * 16; i < length; i++)
+        {
+            if (data[i] == target) count++;
+        }
+
+        return count;
+    }
+
+#endif
+}

--- a/BareMetalWeb.Data/WalSegmentReader.cs
+++ b/BareMetalWeb.Data/WalSegmentReader.cs
@@ -210,4 +210,37 @@ internal static class WalSegmentReader
 
         return computed == storedHeaderCrc;
     }
+
+    /// <summary>
+    /// Scans a raw byte buffer for the next occurrence of a WAL record magic marker
+    /// using SIMD-accelerated byte scanning. Used during crash recovery to skip past
+    /// corrupt data and find the next valid record boundary.
+    /// Returns the offset within <paramref name="data"/> of the first byte of a
+    /// valid 4-byte RecordMagic, or -1 if not found.
+    /// </summary>
+    internal static int FindNextRecordMagic(ReadOnlySpan<byte> data)
+    {
+        // RecordMagic = 0x52454331 → bytes: 0x31, 0x43, 0x45, 0x52 (little-endian)
+        byte firstByte = (byte)(WalConstants.RecordMagic & 0xFF); // 0x31
+
+        int offset = 0;
+        while (offset + 3 < data.Length)
+        {
+            // SIMD-accelerated scan for the first byte of the magic marker
+            int hit = SimdByteScanner.FindByte(data.Slice(offset), firstByte);
+            if (hit < 0 || offset + hit + 3 >= data.Length)
+                return -1;
+
+            int candidate = offset + hit;
+
+            // Verify remaining 3 bytes of the 4-byte magic
+            if (BinaryPrimitives.ReadUInt32LittleEndian(data.Slice(candidate)) == WalConstants.RecordMagic)
+                return candidate;
+
+            // False positive — advance past this byte and keep scanning
+            offset = candidate + 1;
+        }
+
+        return -1;
+    }
 }


### PR DESCRIPTION
## Summary
Implements a high-performance SIMD byte scanner per #908.

### New: `SimdByteScanner` (`BareMetalWeb.Data/SimdByteScanner.cs`)
- **`FindByte(ReadOnlySpan<byte>, byte)`** — first occurrence, AVX2 32B/cycle
- **`FindAnyOfTwo(ReadOnlySpan<byte>, byte, byte)`** — dual-target scan (e.g. pipe + newline)
- **`CountByte(ReadOnlySpan<byte>, byte)`** — occurrence count with POPCNT on x86

### Dispatch hierarchy (highest performance first)
| Path | Width | Notes |
|------|-------|-------|
| AVX2 | 32 bytes/cycle | `LoadVector256` + `CompareEqual` + `MoveMask` |
| SSE2 | 16 bytes/cycle | `LoadVector128` + `CompareEqual` + `MoveMask` |
| AdvSimd/NEON | 16 bytes/cycle | `CompareEqual` + `MaxAcross` |
| Scalar | 1 byte/cycle | Fallback for WASM/older CPUs |

### Integration
- **`WalSegmentReader.FindNextRecordMagic`** — SIMD-accelerated WAL record boundary scanning for crash recovery (scans for `RecordMagic` 0x52454331 in corrupt segments)

### Tests (16 new)
- Boundary position correctness (every offset 0-128)
- Randomised equivalence vs `Span.IndexOf` (200 trials) and `LINQ.Count` (100 trials)
- FindAnyOfTwo dual-target correctness
- WAL magic integration test
- Throughput micro-benchmark (asserts >0.5 GB/s)

### Build
- `AllowUnsafeBlocks` enabled in `BareMetalWeb.Data.csproj` for pointer-based AVX2/SSE2 paths

Closes #908