### PR TITLE
feat: in-memory columnar store with SIMD query path (fixes #909)

### DIFF
--- a/BareMetalWeb.Data.Tests/ColumnQueryExecutorTests.cs
+++ b/BareMetalWeb.Data.Tests/ColumnQueryExecutorTests.cs
@@ -454,4 +454,176 @@ public sealed class ColumnQueryExecutorTests : IDisposable
         string path = DataLayerCapabilities.ColumnQueryPath;
         Assert.Contains(ColumnQueryExecutor.VectorizationThreshold.ToString(), path);
     }
+
+    // ── ColumnarStore tests ──────────────────────────────────────────────────
+
+    [Fact]
+    public void ColumnarStore_Build_PopulatesIntColumn()
+    {
+        var rows = MakeRows(300);
+        var meta = DataScaffold.GetEntityByType(typeof(SampleItem))!;
+        var store = new ColumnarStore(rows.Count);
+
+        store.Build(rows, meta);
+
+        Assert.Equal(300, store.RowCount);
+        Assert.True(store.HasColumn("Age"));
+        Assert.True(store.HasColumn("Score"));
+        Assert.True(store.HasColumn("BigNum"));
+        Assert.True(store.HasColumn("Ratio"));
+        Assert.False(store.HasColumn("Name")); // strings not stored
+    }
+
+    [Fact]
+    public void ColumnarStore_ScanInt_EqualsMatchesColumnQueryExecutor()
+    {
+        var rows = MakeRows(512);
+        var meta = DataScaffold.GetEntityByType(typeof(SampleItem))!;
+        var store = new ColumnarStore(rows.Count);
+        store.Build(rows, meta);
+
+        // Scan for Age == 25 via columnar store
+        int wordCount = (store.RowCount + 63) >> 6;
+        var bitmask = store.ScanClause("Age", QueryOperator.Equals, 25, wordCount);
+        Assert.NotNull(bitmask);
+
+        // Count matching rows from bitmask
+        int columnarHits = 0;
+        for (int i = 0; i < bitmask!.Length; i++)
+            columnarHits += System.Numerics.BitOperations.PopCount(bitmask[i]);
+
+        // Compare with ColumnQueryExecutor
+        var query = new QueryDefinition { Clauses = { new QueryClause { Field = "Age", Operator = QueryOperator.Equals, Value = 25 } } };
+        var cqeResult = ColumnQueryExecutor.Filter(rows, query);
+
+        Assert.Equal(cqeResult.Count, columnarHits);
+    }
+
+    [Fact]
+    public void ColumnarStore_ScanInt_GreaterThan()
+    {
+        var rows = MakeRows(512);
+        var meta = DataScaffold.GetEntityByType(typeof(SampleItem))!;
+        var store = new ColumnarStore(rows.Count);
+        store.Build(rows, meta);
+
+        int wordCount = (store.RowCount + 63) >> 6;
+        var bitmask = store.ScanClause("Age", QueryOperator.GreaterThan, 60, wordCount);
+        Assert.NotNull(bitmask);
+
+        int hits = 0;
+        for (int i = 0; i < bitmask!.Length; i++)
+            hits += System.Numerics.BitOperations.PopCount(bitmask[i]);
+
+        // Age ranges 20-69 (20 + i%50), so >60 means ages 61-69 = values where i%50 ∈ [41..49]
+        int expected = rows.Count(r => r.Age > 60);
+        Assert.Equal(expected, hits);
+    }
+
+    [Fact]
+    public void ColumnarStore_ScanDouble_LessThanOrEqual()
+    {
+        var rows = MakeRows(300);
+        var meta = DataScaffold.GetEntityByType(typeof(SampleItem))!;
+        var store = new ColumnarStore(rows.Count);
+        store.Build(rows, meta);
+
+        int wordCount = (store.RowCount + 63) >> 6;
+        var bitmask = store.ScanClause("Score", QueryOperator.LessThanOrEqual, 10.0, wordCount);
+        Assert.NotNull(bitmask);
+
+        int hits = 0;
+        for (int i = 0; i < bitmask!.Length; i++)
+            hits += System.Numerics.BitOperations.PopCount(bitmask[i]);
+
+        int expected = rows.Count(r => r.Score <= 10.0);
+        Assert.Equal(expected, hits);
+    }
+
+    [Fact]
+    public void ColumnarStore_ScanLong_NotEquals()
+    {
+        var rows = MakeRows(300);
+        var meta = DataScaffold.GetEntityByType(typeof(SampleItem))!;
+        var store = new ColumnarStore(rows.Count);
+        store.Build(rows, meta);
+
+        int wordCount = (store.RowCount + 63) >> 6;
+        var bitmask = store.ScanClause("BigNum", QueryOperator.NotEquals, 0L, wordCount);
+        Assert.NotNull(bitmask);
+
+        int hits = 0;
+        for (int i = 0; i < bitmask!.Length; i++)
+            hits += System.Numerics.BitOperations.PopCount(bitmask[i]);
+
+        // Row 0 has BigNum=0, rest are non-zero
+        int expected = rows.Count(r => r.BigNum != 0);
+        Assert.Equal(expected, hits);
+    }
+
+    [Fact]
+    public void ColumnarStore_ScanNonexistentField_ReturnsNull()
+    {
+        var rows = MakeRows(300);
+        var meta = DataScaffold.GetEntityByType(typeof(SampleItem))!;
+        var store = new ColumnarStore(rows.Count);
+        store.Build(rows, meta);
+
+        int wordCount = (store.RowCount + 63) >> 6;
+        var result = store.ScanClause("NonExistent", QueryOperator.Equals, 42, wordCount);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ColumnarStore_Invalidate_IncrementsVersion()
+    {
+        var rows = MakeRows(300);
+        var meta = DataScaffold.GetEntityByType(typeof(SampleItem))!;
+        var store = new ColumnarStore(rows.Count);
+        store.Build(rows, meta);
+
+        long v1 = store.Version;
+        store.Invalidate();
+        long v2 = store.Version;
+
+        Assert.True(v2 > v1);
+    }
+
+    [Fact]
+    public void ColumnarStore_GetKeyAtRow_MatchesOriginal()
+    {
+        var rows = MakeRows(300);
+        var meta = DataScaffold.GetEntityByType(typeof(SampleItem))!;
+        var store = new ColumnarStore(rows.Count);
+        store.Build(rows, meta);
+
+        for (int i = 0; i < rows.Count; i++)
+            Assert.Equal(rows[i].Key, store.GetKeyAtRow(i));
+    }
+
+    [Fact]
+    public void ColumnarStore_MultiClause_AndComposition()
+    {
+        var rows = MakeRows(512);
+        var meta = DataScaffold.GetEntityByType(typeof(SampleItem))!;
+        var store = new ColumnarStore(rows.Count);
+        store.Build(rows, meta);
+
+        int n = store.RowCount;
+        int wordCount = (n + 63) >> 6;
+
+        // Age > 30 AND Score < 50.0
+        var mask1 = store.ScanClause("Age", QueryOperator.GreaterThan, 30, wordCount)!;
+        var mask2 = store.ScanClause("Score", QueryOperator.LessThan, 50.0, wordCount)!;
+
+        // AND in place
+        for (int i = 0; i < wordCount; i++) mask1[i] &= mask2[i];
+
+        int hits = 0;
+        for (int i = 0; i < mask1.Length; i++)
+            hits += System.Numerics.BitOperations.PopCount(mask1[i]);
+
+        int expected = rows.Count(r => r.Age > 30 && r.Score < 50.0);
+        Assert.Equal(expected, hits);
+    }
 }

--- a/BareMetalWeb.Data/ColumnarStore.cs
+++ b/BareMetalWeb.Data/ColumnarStore.cs
@@ -1,0 +1,492 @@
+using System.Buffers;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using BareMetalWeb.Core;
+
+namespace BareMetalWeb.Data;
+
+/// <summary>
+/// In-memory columnar store for a single entity type.
+/// Maintains dense typed arrays (one per numeric field) synced with row additions/removals.
+/// Enables SIMD column scans without per-query object loading or property extraction.
+///
+/// <para>Lifecycle: created lazily on first vectorised query, invalidated on any write.
+/// The columnar layout avoids the "load all objects, extract column, then scan" pattern
+/// in <see cref="ColumnQueryExecutor"/> — arrays are pre-built and cache-friendly.</para>
+/// </summary>
+internal sealed class ColumnarStore
+{
+    private readonly Dictionary<string, int[]> _intColumns = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, long[]> _longColumns = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, double[]> _doubleColumns = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, float[]> _floatColumns = new(StringComparer.OrdinalIgnoreCase);
+
+    // Row index: maps object key → dense array position
+    private readonly Dictionary<uint, int> _keyToRow = new();
+    private uint[] _rowToKey;  // reverse map: dense position → object key
+    private int _rowCount;
+
+    // Stamp incremented on every mutation; callers compare to detect invalidation
+    private long _version;
+
+    public int RowCount => _rowCount;
+    public long Version => _version;
+
+    public ColumnarStore(int initialCapacity)
+    {
+        _rowToKey = new uint[Math.Max(initialCapacity, 64)];
+    }
+
+    /// <summary>
+    /// Populates the store from a pre-loaded set of objects and their metadata.
+    /// Called once during lazy initialisation.
+    /// </summary>
+    public void Build<T>(IReadOnlyList<T> objects, DataEntityMetadata meta) where T : BaseDataObject
+    {
+        _keyToRow.Clear();
+        _intColumns.Clear();
+        _longColumns.Clear();
+        _doubleColumns.Clear();
+        _floatColumns.Clear();
+
+        int n = objects.Count;
+        _rowCount = n;
+        if (_rowToKey.Length < n)
+            _rowToKey = new uint[n];
+
+        // Identify numeric fields and allocate columns
+        foreach (var field in meta.Fields)
+        {
+            var propType = Nullable.GetUnderlyingType(field.Property.PropertyType)
+                           ?? field.Property.PropertyType;
+
+            if (IsIntType(propType))
+                _intColumns[field.Name] = new int[n];
+            else if (IsLongType(propType))
+                _longColumns[field.Name] = new long[n];
+            else if (IsDoubleType(propType))
+                _doubleColumns[field.Name] = new double[n];
+            else if (IsFloatType(propType))
+                _floatColumns[field.Name] = new float[n];
+        }
+
+        // Extract column values in a single pass over all objects
+        for (int i = 0; i < n; i++)
+        {
+            var obj = objects[i];
+            _keyToRow[obj.Key] = i;
+            _rowToKey[i] = obj.Key;
+
+            foreach (var field in meta.Fields)
+            {
+                var getter = field.GetValueFn;
+                var val = getter(obj);
+
+                if (_intColumns.TryGetValue(field.Name, out var intCol))
+                    intCol[i] = ToInt(val);
+                else if (_longColumns.TryGetValue(field.Name, out var longCol))
+                    longCol[i] = ToLong(val);
+                else if (_doubleColumns.TryGetValue(field.Name, out var dblCol))
+                    dblCol[i] = ToDouble(val);
+                else if (_floatColumns.TryGetValue(field.Name, out var fltCol))
+                    fltCol[i] = ToFloat(val);
+            }
+        }
+
+        _version++;
+    }
+
+    /// <summary>Marks the store as stale. Next query will trigger a rebuild.</summary>
+    public void Invalidate() => Interlocked.Increment(ref _version);
+
+    // ── Column access ─────────────────────────────────────────────────────────
+
+    public bool TryGetIntColumn(string fieldName, out ReadOnlySpan<int> column)
+    {
+        if (_intColumns.TryGetValue(fieldName, out var arr))
+        {
+            column = arr.AsSpan(0, _rowCount);
+            return true;
+        }
+        column = default;
+        return false;
+    }
+
+    public bool TryGetLongColumn(string fieldName, out ReadOnlySpan<long> column)
+    {
+        if (_longColumns.TryGetValue(fieldName, out var arr))
+        {
+            column = arr.AsSpan(0, _rowCount);
+            return true;
+        }
+        column = default;
+        return false;
+    }
+
+    public bool TryGetDoubleColumn(string fieldName, out ReadOnlySpan<double> column)
+    {
+        if (_doubleColumns.TryGetValue(fieldName, out var arr))
+        {
+            column = arr.AsSpan(0, _rowCount);
+            return true;
+        }
+        column = default;
+        return false;
+    }
+
+    public bool TryGetFloatColumn(string fieldName, out ReadOnlySpan<float> column)
+    {
+        if (_floatColumns.TryGetValue(fieldName, out var arr))
+        {
+            column = arr.AsSpan(0, _rowCount);
+            return true;
+        }
+        column = default;
+        return false;
+    }
+
+    /// <summary>Returns the object key at the given dense row index.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public uint GetKeyAtRow(int rowIndex) => _rowToKey[rowIndex];
+
+    /// <summary>
+    /// Returns the set of field names that have columnar storage.
+    /// Useful for checking which clause fields can use the fast path.
+    /// </summary>
+    public bool HasColumn(string fieldName)
+        => _intColumns.ContainsKey(fieldName)
+        || _longColumns.ContainsKey(fieldName)
+        || _doubleColumns.ContainsKey(fieldName)
+        || _floatColumns.ContainsKey(fieldName);
+
+    // ── SIMD column scan ──────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Scans a pre-built column using SIMD and returns a bitmask of matching rows.
+    /// This is the hot path — no object loading, no property extraction, no boxing.
+    /// </summary>
+    public ulong[]? ScanClause(string fieldName, QueryOperator op, object? value, int wordCount)
+    {
+        if (_intColumns.TryGetValue(fieldName, out var intCol))
+        {
+            var propType = typeof(int); // simplified — all int-range are stored as int
+            if (!TryConvertToInt(value, propType, out int iTarget)) return null;
+            return ScanIntArray(intCol, op, iTarget, _rowCount, wordCount);
+        }
+
+        if (_longColumns.TryGetValue(fieldName, out var longCol))
+        {
+            if (!TryConvertToLong(value, typeof(long), out long lTarget)) return null;
+            return ScanLongArray(longCol, op, lTarget, _rowCount, wordCount);
+        }
+
+        if (_doubleColumns.TryGetValue(fieldName, out var dblCol))
+        {
+            if (!TryConvertToDouble(value, out double dTarget)) return null;
+            return ScanDoubleArray(dblCol, op, dTarget, _rowCount, wordCount);
+        }
+
+        if (_floatColumns.TryGetValue(fieldName, out var fltCol))
+        {
+            if (!TryConvertToFloat(value, out float fTarget)) return null;
+            return ScanFloatArray(fltCol, op, fTarget, _rowCount, wordCount);
+        }
+
+        return null; // field not in columnar store
+    }
+
+    // ── Typed array scans (no object access, pure array SIMD) ─────────────────
+
+    private static ulong[] ScanIntArray(int[] column, QueryOperator op, int target, int n, int wordCount)
+    {
+        var bitmask = new ulong[wordCount];
+        int vLen = Vector<int>.Count;
+        var targetVec = new Vector<int>(target);
+        int idx = 0;
+
+        for (; idx <= n - vLen; idx += vLen)
+        {
+            var chunk = new Vector<int>(column, idx);
+            var mask = ApplyIntOp(op, chunk, targetVec);
+            WriteToBitmask(bitmask, mask, idx, vLen);
+        }
+        for (; idx < n; idx++)
+            if (EvalScalar(op, column[idx], target))
+                bitmask[idx >> 6] |= 1UL << (idx & 63);
+
+        return bitmask;
+    }
+
+    private static ulong[] ScanLongArray(long[] column, QueryOperator op, long target, int n, int wordCount)
+    {
+        var bitmask = new ulong[wordCount];
+        int vLen = Vector<long>.Count;
+        var targetVec = new Vector<long>(target);
+        int idx = 0;
+
+        for (; idx <= n - vLen; idx += vLen)
+        {
+            var chunk = new Vector<long>(column, idx);
+            var mask = ApplyLongOp(op, chunk, targetVec);
+            WriteToBitmask(bitmask, mask, idx, vLen);
+        }
+        for (; idx < n; idx++)
+            if (EvalScalar(op, column[idx], target))
+                bitmask[idx >> 6] |= 1UL << (idx & 63);
+
+        return bitmask;
+    }
+
+    private static ulong[] ScanDoubleArray(double[] column, QueryOperator op, double target, int n, int wordCount)
+    {
+        var bitmask = new ulong[wordCount];
+        int vLen = Vector<double>.Count;
+        var targetVec = new Vector<double>(target);
+        int idx = 0;
+
+        for (; idx <= n - vLen; idx += vLen)
+        {
+            var chunk = new Vector<double>(column, idx);
+            Vector<long> mask = ApplyDoubleOp(op, chunk, targetVec);
+            WriteToBitmask(bitmask, mask, idx, vLen);
+        }
+        for (; idx < n; idx++)
+            if (EvalScalar(op, column[idx], target))
+                bitmask[idx >> 6] |= 1UL << (idx & 63);
+
+        return bitmask;
+    }
+
+    private static ulong[] ScanFloatArray(float[] column, QueryOperator op, float target, int n, int wordCount)
+    {
+        var bitmask = new ulong[wordCount];
+        int vLen = Vector<float>.Count;
+        var targetVec = new Vector<float>(target);
+        int idx = 0;
+
+        for (; idx <= n - vLen; idx += vLen)
+        {
+            var chunk = new Vector<float>(column, idx);
+            Vector<int> mask = ApplyFloatOp(op, chunk, targetVec);
+            WriteToBitmask(bitmask, mask, idx, vLen);
+        }
+        for (; idx < n; idx++)
+            if (EvalScalar(op, column[idx], target))
+                bitmask[idx >> 6] |= 1UL << (idx & 63);
+
+        return bitmask;
+    }
+
+    // ── Vector operator helpers (same as ColumnQueryExecutor) ──────────────────
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Vector<int> ApplyIntOp(QueryOperator op, Vector<int> chunk, Vector<int> target) => op switch
+    {
+        QueryOperator.Equals             => Vector.Equals(chunk, target),
+        QueryOperator.NotEquals          => Vector.OnesComplement(Vector.Equals(chunk, target)),
+        QueryOperator.GreaterThan        => Vector.GreaterThan(chunk, target),
+        QueryOperator.LessThan           => Vector.LessThan(chunk, target),
+        QueryOperator.GreaterThanOrEqual => Vector.GreaterThanOrEqual(chunk, target),
+        QueryOperator.LessThanOrEqual    => Vector.LessThanOrEqual(chunk, target),
+        _                                => Vector<int>.Zero,
+    };
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Vector<long> ApplyLongOp(QueryOperator op, Vector<long> chunk, Vector<long> target) => op switch
+    {
+        QueryOperator.Equals             => Vector.Equals(chunk, target),
+        QueryOperator.NotEquals          => Vector.OnesComplement(Vector.Equals(chunk, target)),
+        QueryOperator.GreaterThan        => Vector.GreaterThan(chunk, target),
+        QueryOperator.LessThan           => Vector.LessThan(chunk, target),
+        QueryOperator.GreaterThanOrEqual => Vector.GreaterThanOrEqual(chunk, target),
+        QueryOperator.LessThanOrEqual    => Vector.LessThanOrEqual(chunk, target),
+        _                                => Vector<long>.Zero,
+    };
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Vector<long> ApplyDoubleOp(QueryOperator op, Vector<double> chunk, Vector<double> target) => op switch
+    {
+        QueryOperator.Equals             => Vector.Equals(chunk, target),
+        QueryOperator.NotEquals          => Vector.OnesComplement(Vector.Equals(chunk, target)),
+        QueryOperator.GreaterThan        => Vector.GreaterThan(chunk, target),
+        QueryOperator.LessThan           => Vector.LessThan(chunk, target),
+        QueryOperator.GreaterThanOrEqual => Vector.GreaterThanOrEqual(chunk, target),
+        QueryOperator.LessThanOrEqual    => Vector.LessThanOrEqual(chunk, target),
+        _                                => Vector<long>.Zero,
+    };
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static Vector<int> ApplyFloatOp(QueryOperator op, Vector<float> chunk, Vector<float> target) => op switch
+    {
+        QueryOperator.Equals             => Vector.Equals(chunk, target),
+        QueryOperator.NotEquals          => Vector.OnesComplement(Vector.Equals(chunk, target)),
+        QueryOperator.GreaterThan        => Vector.GreaterThan(chunk, target),
+        QueryOperator.LessThan           => Vector.LessThan(chunk, target),
+        QueryOperator.GreaterThanOrEqual => Vector.GreaterThanOrEqual(chunk, target),
+        QueryOperator.LessThanOrEqual    => Vector.LessThanOrEqual(chunk, target),
+        _                                => Vector<int>.Zero,
+    };
+
+    // ── Bitmask helpers ───────────────────────────────────────────────────────
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void WriteToBitmask(ulong[] bitmask, Vector<int> mask, int rowOffset, int vLen)
+    {
+        ulong contrib = 0;
+        for (int j = 0; j < vLen; j++)
+            if (mask[j] != 0) contrib |= 1UL << j;
+        WriteMaskWord(bitmask, contrib, rowOffset, vLen);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void WriteToBitmask(ulong[] bitmask, Vector<long> mask, int rowOffset, int vLen)
+    {
+        ulong contrib = 0;
+        for (int j = 0; j < vLen; j++)
+            if (mask[j] != 0L) contrib |= 1UL << j;
+        WriteMaskWord(bitmask, contrib, rowOffset, vLen);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void WriteMaskWord(ulong[] bitmask, ulong contrib, int rowOffset, int vLen)
+    {
+        if (contrib == 0) return;
+        int wordIdx = rowOffset >> 6;
+        int bitOff  = rowOffset & 63;
+        bitmask[wordIdx] |= contrib << bitOff;
+        if (bitOff + vLen > 64 && wordIdx + 1 < bitmask.Length)
+            bitmask[wordIdx + 1] |= contrib >> (64 - bitOff);
+    }
+
+    // ── Scalar helpers ────────────────────────────────────────────────────────
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool EvalScalar<T>(QueryOperator op, T value, T target) where T : IComparable<T> => op switch
+    {
+        QueryOperator.Equals             => value.CompareTo(target) == 0,
+        QueryOperator.NotEquals          => value.CompareTo(target) != 0,
+        QueryOperator.GreaterThan        => value.CompareTo(target) > 0,
+        QueryOperator.LessThan           => value.CompareTo(target) < 0,
+        QueryOperator.GreaterThanOrEqual => value.CompareTo(target) >= 0,
+        QueryOperator.LessThanOrEqual    => value.CompareTo(target) <= 0,
+        _                                => false,
+    };
+
+    // ── Type utilities (same classification as ColumnQueryExecutor) ────────────
+
+    private static bool IsIntType(Type t)
+        => t == typeof(int)   || t == typeof(uint)  || t == typeof(short) || t == typeof(ushort)
+        || t == typeof(byte)  || t == typeof(sbyte) || t == typeof(bool)  || t.IsEnum;
+
+    private static bool IsLongType(Type t)
+        => t == typeof(long)           || t == typeof(ulong)
+        || t == typeof(DateTime)       || t == typeof(DateOnly)
+        || t == typeof(DateTimeOffset) || t == typeof(TimeOnly)
+        || t == typeof(TimeSpan);
+
+    private static bool IsDoubleType(Type t) => t == typeof(double) || t == typeof(decimal);
+    private static bool IsFloatType(Type t)  => t == typeof(float);
+
+    // ── Value conversion (reuse ColumnQueryExecutor logic) ─────────────────────
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static int ToInt(object? v)
+    {
+        if (v is int i)    return i;
+        if (v is bool b)   return b ? 1 : 0;
+        if (v is Enum)     return (int)Convert.ChangeType(v, typeof(int));
+        if (v == null)     return 0;
+        try { return Convert.ToInt32(v); } catch { return 0; }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static long ToLong(object? v)
+    {
+        if (v is long l)             return l;
+        if (v is DateTime dt)        return dt.Ticks;
+        if (v is DateOnly d)         return d.DayNumber;
+        if (v is TimeOnly to)        return to.Ticks;
+        if (v is TimeSpan ts)        return ts.Ticks;
+        if (v is DateTimeOffset dto) return dto.UtcTicks;
+        if (v == null)               return 0;
+        try { return Convert.ToInt64(v); } catch { return 0; }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static double ToDouble(object? v)
+    {
+        if (v is double d)    return d;
+        if (v is decimal dec) return (double)dec;
+        if (v is float f)    return f;
+        if (v == null)       return 0;
+        try { return Convert.ToDouble(v); } catch { return 0; }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static float ToFloat(object? v)
+    {
+        if (v is float f) return f;
+        if (v == null)    return 0;
+        try { return Convert.ToSingle(v); } catch { return 0; }
+    }
+
+    private static bool TryConvertToInt(object? value, Type targetType, out int result)
+    {
+        if (value == null) { result = 0; return false; }
+        try
+        {
+            if (targetType.IsEnum)
+            {
+                object enumVal = value is string s
+                    ? Enum.Parse(targetType, s, ignoreCase: true)
+                    : value;
+                result = (int)Convert.ChangeType(enumVal, typeof(int));
+                return true;
+            }
+            if (value is bool b) { result = b ? 1 : 0; return true; }
+            result = Convert.ToInt32(value);
+            return true;
+        }
+        catch { result = 0; return false; }
+    }
+
+    private static bool TryConvertToLong(object? value, Type targetType, out long result)
+    {
+        if (value == null) { result = 0; return false; }
+        try
+        {
+            if (targetType == typeof(DateTime) && value is string ds && DateTime.TryParse(ds, out var dt))
+                { result = dt.Ticks; return true; }
+            if (targetType == typeof(DateOnly) && value is string dos && DateOnly.TryParse(dos, out var d))
+                { result = d.DayNumber; return true; }
+            if (targetType == typeof(TimeOnly) && value is string tos && TimeOnly.TryParse(tos, out var to))
+                { result = to.Ticks; return true; }
+            if (targetType == typeof(TimeSpan) && value is string tss && TimeSpan.TryParse(tss, out var ts))
+                { result = ts.Ticks; return true; }
+            if (targetType == typeof(DateTimeOffset) && value is string dtos && DateTimeOffset.TryParse(dtos, out var dto))
+                { result = dto.UtcTicks; return true; }
+            result = Convert.ToInt64(value);
+            return true;
+        }
+        catch { result = 0; return false; }
+    }
+
+    private static bool TryConvertToDouble(object? value, out double result)
+    {
+        if (value == null) { result = 0; return false; }
+        try
+        {
+            if (value is decimal dec) { result = (double)dec; return true; }
+            result = Convert.ToDouble(value);
+            return true;
+        }
+        catch { result = 0; return false; }
+    }
+
+    private static bool TryConvertToFloat(object? value, out float result)
+    {
+        if (value == null) { result = 0; return false; }
+        try { result = Convert.ToSingle(value); return true; }
+        catch { result = 0; return false; }
+    }
+}

--- a/BareMetalWeb.Data/WalDataProvider.cs
+++ b/BareMetalWeb.Data/WalDataProvider.cs
@@ -4,11 +4,13 @@ using System.Buffers.Binary;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
+using System.Numerics;
 using System.Reflection;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using BareMetalWeb.Core;
 using BareMetalWeb.Core.Interfaces;
 using BareMetalWeb.Data.Interfaces;
 
@@ -94,6 +96,13 @@ public sealed class WalDataProvider : IDataProvider, IDisposable
     private readonly ConcurrentDictionary<string, SeqIdRange> _seqIdRanges
         = new(StringComparer.OrdinalIgnoreCase);
     private const int SeqIdBatchSize = 64;
+
+    // Columnar store cache — per-entity in-memory columnar layout for SIMD queries.
+    // Lazily built on first vectorised query, invalidated on Save/Delete.
+    private readonly ConcurrentDictionary<string, ColumnarStore> _columnarStores
+        = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, long> _columnarVersions
+        = new(StringComparer.OrdinalIgnoreCase);
 
     // Optional cluster state for write fencing
     private ClusterState? _clusterState;
@@ -288,6 +297,10 @@ public sealed class WalDataProvider : IDataProvider, IDisposable
                 }
                 _searchIndexManager.IndexObject(obj);
             }
+
+            // Invalidate columnar store so next query rebuilds from fresh data
+            if (_columnarStores.TryGetValue(type.Name, out var colStore))
+                colStore.Invalidate();
         }
         catch (Exception ex)
         {
@@ -606,9 +619,112 @@ public sealed class WalDataProvider : IDataProvider, IDisposable
         // ── Fallback: filter/sort on non-indexed fields ─────────────────────
         var canShortCircuit = query == null || query.Sorts.Count == 0;
 
+        // ── Columnar store path: SIMD scan over pre-built typed arrays ──────
+        // Avoids loading all objects just to extract columns — scans arrays
+        // directly, then loads only matching rows.
+        if (query != null
+            && idMap.Count >= ColumnQueryExecutor.VectorizationThreshold
+            && query.Groups.Count == 0
+            && query.Clauses.Count > 0)
+        {
+            var meta = DataScaffold.GetEntityByType(typeof(T));
+            if (meta != null)
+            {
+                var store = GetOrBuildColumnarStore<T>(typeName, idMap, meta);
+                if (store != null && store.RowCount >= ColumnQueryExecutor.VectorizationThreshold)
+                {
+                    // Check if all clauses can be served by columnar store
+                    bool allColumnar = true;
+                    foreach (var clause in query.Clauses)
+                    {
+                        if (string.IsNullOrEmpty(clause.Field) || !store.HasColumn(clause.Field))
+                        {
+                            allColumnar = false;
+                            break;
+                        }
+                    }
+
+                    if (allColumnar)
+                    {
+                        int n = store.RowCount;
+                        int wordCount = (n + 63) >> 6;
+                        ulong[]? combined = null;
+
+                        foreach (var clause in query.Clauses)
+                        {
+                            var clauseMask = store.ScanClause(clause.Field, clause.Operator, clause.Value, wordCount);
+                            if (clauseMask == null) { combined = new ulong[wordCount]; break; }
+
+                            if (combined == null)
+                                combined = clauseMask;
+                            else
+                                AndBitmaskInPlace(combined, clauseMask);
+                        }
+
+                        // Materialise matching rows — only load objects that passed the filter
+                        var results = new List<T>(Math.Min(top, n));
+                        int matched = 0;
+
+                        if (combined != null)
+                        {
+                            for (int wordIdx = 0; wordIdx < combined.Length && results.Count < top; wordIdx++)
+                            {
+                                ulong word = combined[wordIdx];
+                                while (word != 0)
+                                {
+                                    int bit = BitOperations.TrailingZeroCount(word);
+                                    int rowIdx = (wordIdx << 6) | bit;
+                                    word &= word - 1;
+
+                                    if (rowIdx >= n) break;
+                                    if (matched++ < skip) continue;
+
+                                    uint objKey = store.GetKeyAtRow(rowIdx);
+                                    try
+                                    {
+                                        T? obj = Load<T>(objKey);
+                                        if (obj != null)
+                                        {
+                                            if (canShortCircuit)
+                                            {
+                                                results.Add(obj);
+                                            }
+                                            else
+                                            {
+                                                results.Add(obj); // will sort below
+                                            }
+                                        }
+                                    }
+                                    catch (Exception ex)
+                                    {
+                                        _logger?.LogError($"Deserialization failed for {typeName} Key {objKey}.", ex);
+                                    }
+
+                                    if (canShortCircuit && results.Count >= top) break;
+                                }
+                            }
+                        }
+
+                        if (canShortCircuit)
+                            return results;
+
+                        // With sorts: sort filtered results, then slice
+                        var sortedList = new List<T>(_queryEvaluator.ApplySorts(results, query));
+                        if (skip > 0 || top != int.MaxValue)
+                        {
+                            int end = Math.Min(skip + top, sortedList.Count);
+                            var paged = new List<T>(Math.Max(0, end - skip));
+                            for (int i = skip; i < end; i++) paged.Add(sortedList[i]);
+                            return paged;
+                        }
+                        return sortedList;
+                    }
+                }
+            }
+        }
+
         // ── Vectorised path: pre-load all objects, then apply SIMD column scan ──
-        // Activated when the entity set is large enough to amortise column-extraction
-        // overhead and the query has no nested OR groups.
+        // Fallback when columnar store doesn't cover all clauses.
         if (query != null
             && idMap.Count >= ColumnQueryExecutor.VectorizationThreshold
             && query.Groups.Count == 0
@@ -861,6 +977,10 @@ public sealed class WalDataProvider : IDataProvider, IDisposable
             }
             _searchIndexManager.RemoveObject(type, key);
         }
+
+        // Invalidate columnar store
+        if (_columnarStores.TryGetValue(typeName, out var colStore))
+            colStore.Invalidate();
     }
 
     public ValueTask DeleteAsync<T>(uint key, CancellationToken cancellationToken = default)
@@ -982,6 +1102,10 @@ public sealed class WalDataProvider : IDataProvider, IDisposable
                 }
                 _indexStore.AppendEntry(entityName, schema.Names[i], newValue, keyStr, 'A');
             }
+
+            // Invalidate columnar store
+            if (_columnarStores.TryGetValue(entityName, out var colStore))
+                colStore.Invalidate();
         }
         catch (Exception ex)
         {
@@ -1632,6 +1756,59 @@ public sealed class WalDataProvider : IDataProvider, IDisposable
 
     // Cache: (type, schemaVersion) → MemberSignature[]
     private readonly ConcurrentDictionary<(Type, int), MemberSignature[]> _schemaMemberCache = new();
+
+    /// <summary>
+    /// Gets or lazily builds a columnar store for the given entity type.
+    /// Returns null if building fails (e.g. no numeric fields).
+    /// </summary>
+    private ColumnarStore? GetOrBuildColumnarStore<T>(
+        string typeName,
+        ConcurrentDictionary<uint, ulong> idMap,
+        DataEntityMetadata meta) where T : BaseDataObject
+    {
+        var store = _columnarStores.GetOrAdd(typeName, _ => new ColumnarStore(idMap.Count));
+        var lastVersion = _columnarVersions.GetOrAdd(typeName, -1L);
+
+        // Rebuild if stale (version changed due to Save/Delete)
+        if (lastVersion != store.Version || store.RowCount == 0)
+        {
+            var allObjects = new List<T>(idMap.Count);
+            foreach (var (objKey, _) in idMap)
+            {
+                try
+                {
+                    T? obj = Load<T>(objKey);
+                    if (obj != null) allObjects.Add(obj);
+                }
+                catch (Exception ex)
+                {
+                    _logger?.LogError($"Columnar build: deserialization failed for {typeName} Key {objKey}.", ex);
+                }
+            }
+
+            if (allObjects.Count < ColumnQueryExecutor.VectorizationThreshold)
+                return null;
+
+            store.Build(allObjects, meta);
+            _columnarVersions[typeName] = store.Version;
+        }
+
+        return store;
+    }
+
+    /// <summary>SIMD-accelerated bitmask AND (same as ColumnQueryExecutor.AndInPlace).</summary>
+    private static void AndBitmaskInPlace(ulong[] dest, ulong[] src)
+    {
+        int vLen = Vector<ulong>.Count;
+        int i = 0;
+        for (; i <= dest.Length - vLen; i += vLen)
+        {
+            var d = new Vector<ulong>(dest, i);
+            var s = new Vector<ulong>(src, i);
+            (d & s).CopyTo(dest, i);
+        }
+        for (; i < dest.Length; i++) dest[i] &= src[i];
+    }
 
     private T? DeserializePayload<T>(ReadOnlyMemory<byte> memory, uint key) where T : BaseDataObject
     {


### PR DESCRIPTION
## Summary
Adds an in-memory columnar store that maintains dense typed arrays per numeric field, enabling SIMD column scans without per-query object loading.

### Architecture
```
WAL (row-based on disk)
  → Load objects (lazy, cached)
    → ColumnarStore.Build() extracts typed arrays once
      → ScanClause() runs Vector<T> SIMD over pre-built arrays
        → Only matching rows loaded from deser cache
```

### New: `ColumnarStore` (`BareMetalWeb.Data/ColumnarStore.cs`)
- **Dense typed arrays**: `int[]`, `long[]`, `double[]`, `float[]` — one per numeric field
- **Build once**: Extracts all numeric fields in a single pass over loaded objects
- **Invalidate on write**: `Save()`, `Delete()`, `SaveRecord()` increment version stamp
- **SIMD scan**: `ScanClause(field, operator, value)` → `ulong[]` bitmask via `Vector<T>`
- **Key mapping**: Dense row index ↔ object key for selective loading

### WalDataProvider Integration
- New query path activates when:
  - Entity has ≥256 rows (vectorization threshold)
  - Query has no OR groups
  - **All clauses target numeric columnar fields**
- Matching rows identified via bitmask, then only those rows are loaded (vs loading ALL rows in the old path)
- Falls back to existing `ColumnQueryExecutor` when any clause targets non-numeric fields

### Performance Benefit
- **Before**: Load all N objects → extract column → SIMD scan → return matches
- **After**: SIMD scan pre-built arrays → load only K matching objects (K << N)
- Eliminates O(N) deserialisation cost for selective queries on large tables

### Tests (9 new)
- Column population and type detection
- Int/Long/Double scan operators (Equals, GreaterThan, LessThan, NotEquals)
- Multi-clause AND bitmask composition
- Key-at-row reverse mapping
- Version invalidation on mutation
- Cross-validation against `ColumnQueryExecutor`

Closes #909