### PR TITLE
fix: Replace hardcoded sleeps with polling loops in flaky tests

### DIFF
--- a/BareMetalWeb.Host.Tests/BackgroundJobServiceTests.cs
+++ b/BareMetalWeb.Host.Tests/BackgroundJobServiceTests.cs
@@ -6,6 +6,14 @@ namespace BareMetalWeb.Host.Tests;
 
 public class BackgroundJobServiceTests
 {
+    private static async Task WaitUntilAsync(Func<bool> condition, int timeoutMs = 5000, int intervalMs = 25)
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (!condition() && sw.ElapsedMilliseconds < timeoutMs)
+            await Task.Delay(intervalMs);
+        Assert.True(condition(), $"Condition not met within {timeoutMs}ms");
+    }
+
     // ── StartJob / TryGetJob ──────────────────────────────────────
 
     [Fact]
@@ -71,8 +79,7 @@ public class BackgroundJobServiceTests
         });
 
         await tcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        // Give the task a moment to set Succeeded.
-        await Task.Delay(50);
+        await WaitUntilAsync(() => { svc.TryGetJob(jobId, out var s); return s?.Status == BackgroundJobStatus.Succeeded; });
 
         svc.TryGetJob(jobId, out var snapshot);
         Assert.Equal(BackgroundJobStatus.Succeeded, snapshot!.Status);
@@ -93,8 +100,7 @@ public class BackgroundJobServiceTests
         });
 
         await started.WaitAsync(TimeSpan.FromSeconds(5));
-        // Give the task time to transition to Failed after throwing.
-        await Task.Delay(100);
+        await WaitUntilAsync(() => { svc.TryGetJob(jobId, out var s); return s?.Status == BackgroundJobStatus.Failed; });
 
         svc.TryGetJob(jobId, out var snapshot);
         Assert.Equal(BackgroundJobStatus.Failed, snapshot!.Status);
@@ -193,7 +199,7 @@ public class BackgroundJobServiceTests
         });
 
         await done.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        await Task.Delay(50); // let the finally block run
+        await WaitUntilAsync(() => { svc.TryGetJob(jobId, out var s); return s?.CompletedAt != null; });
 
         svc.TryGetJob(jobId, out var snapshot);
         Assert.NotNull(snapshot!.CompletedAt);
@@ -214,7 +220,7 @@ public class BackgroundJobServiceTests
         });
 
         await done.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        await Task.Delay(50); // let Status become Succeeded
+        await WaitUntilAsync(() => { svc.TryGetJob(jobId, out var s); return s?.Status == BackgroundJobStatus.Succeeded; });
 
         // Retrieve the raw entry via the internal Jobs dictionary.
         var jobsField = typeof(BackgroundJobService).GetField("_jobs",

--- a/BareMetalWeb.Host.Tests/ClientRequestTrackerTests.cs
+++ b/BareMetalWeb.Host.Tests/ClientRequestTrackerTests.cs
@@ -8,6 +8,13 @@ namespace BareMetalWeb.Host.Tests;
 
 public class ClientRequestTrackerTests
 {
+    private static void WaitUntil(Func<bool> condition, int timeoutMs = 5000, int intervalMs = 25)
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (!condition() && sw.ElapsedMilliseconds < timeoutMs)
+            Thread.Sleep(intervalMs);
+    }
+
     private class MockLogger : IBufferedLogger
     {
         public void LogInfo(string message) { }
@@ -125,10 +132,13 @@ public class ClientRequestTrackerTests
         Assert.True(tracker.ShouldThrottle(clientIp, out var reason1, out _));
         Assert.Equal("blocked", reason1);
         
-        // Wait for block to expire
-        Thread.Sleep(100);
+        // Wait for block to expire by checking snapshot (not ShouldThrottle, which increments counters)
+        WaitUntil(() => {
+            var s = tracker.Snapshot();
+            return s.ContainsKey(clientIp) && s[clientIp].BlockedUntilUtc <= DateTime.UtcNow;
+        });
 
-        // After block expires, client should be marked suspicious
+        // After block expires, first call clears the block and marks suspicious
         tracker.ShouldThrottle(clientIp, out _, out _);
         var snapshot = tracker.Snapshot();
         
@@ -324,8 +334,9 @@ public class ClientRequestTrackerTests
             tracker.ShouldThrottle(clientIp, out _, out _);
         }
 
-        // Wait for window to reset
-        Thread.Sleep(1100);
+        // Wait for window to reset (1-second window; generous timeout for CI)
+        var windowStart = System.Diagnostics.Stopwatch.StartNew();
+        WaitUntil(() => windowStart.ElapsedMilliseconds >= 1200);
 
         // Make more requests in new window
         for (int i = 0; i < 5; i++)
@@ -403,8 +414,11 @@ public class ClientRequestTrackerTests
         // Should still be blocked
         Assert.True(tracker.ShouldThrottle(clientIp, out _, out _));
         
-        // Wait for block to expire
-        Thread.Sleep(250);
+        // Wait for block to expire by checking snapshot (not ShouldThrottle, which increments counters)
+        WaitUntil(() => {
+            var s = tracker.Snapshot();
+            return s.ContainsKey(clientIp) && s[clientIp].BlockedUntilUtc <= DateTime.UtcNow;
+        });
         
         // Should no longer be blocked
         var result = tracker.ShouldThrottle(clientIp, out _, out _);

--- a/BareMetalWeb.Host.Tests/DiskBufferedLoggerTests.cs
+++ b/BareMetalWeb.Host.Tests/DiskBufferedLoggerTests.cs
@@ -11,6 +11,14 @@ public class DiskBufferedLoggerTests : IDisposable
 {
     private readonly string _tempDir;
 
+    private static async Task WaitUntilAsync(Func<bool> condition, int timeoutMs = 5000, int intervalMs = 25)
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (!condition() && sw.ElapsedMilliseconds < timeoutMs)
+            await Task.Delay(intervalMs);
+        Assert.True(condition(), $"Condition not met within {timeoutMs}ms");
+    }
+
     public DiskBufferedLoggerTests()
     {
         _tempDir = Path.Combine(Path.GetTempPath(), $"bmw_log_{Guid.NewGuid().ToString("N")[..8]}");
@@ -86,8 +94,8 @@ public class DiskBufferedLoggerTests : IDisposable
         // Act
         logger.LogError("Something broke", new InvalidOperationException("boom"));
 
-        // Give fire-and-forget task time to complete
-        await Task.Delay(500);
+        // Wait for fire-and-forget task to write the error file
+        await WaitUntilAsync(() => Directory.GetFiles(_tempDir, "error_*.log", SearchOption.AllDirectories).Length > 0);
 
         // Assert
         var errorFiles = Directory.GetFiles(_tempDir, "error_*.log", SearchOption.AllDirectories);
@@ -136,7 +144,7 @@ public class DiskBufferedLoggerTests : IDisposable
         var logger = new DiskBufferedLogger(_tempDir);
         logger.LogError("err", new Exception("test"));
 
-        await Task.Delay(500);
+        await WaitUntilAsync(() => Directory.GetFiles(_tempDir, "error_*.log", SearchOption.AllDirectories).Length > 0);
 
         // Assert
         var errorFiles = Directory.GetFiles(_tempDir, "error_*.log", SearchOption.AllDirectories);
@@ -261,7 +269,7 @@ public class DiskBufferedLoggerTests : IDisposable
         var logger = new DiskBufferedLogger(_tempDir);
         logger.LogError("error only", new Exception("fail"));
 
-        await Task.Delay(500);
+        await WaitUntilAsync(() => Directory.GetFiles(_tempDir, "error_*.log", SearchOption.AllDirectories).Length > 0);
 
         // Assert
         var errorFiles = Directory.GetFiles(_tempDir, "error_*.log", SearchOption.AllDirectories);
@@ -280,7 +288,7 @@ public class DiskBufferedLoggerTests : IDisposable
 
         // Act
         logger.LogError("outer message", ex);
-        await Task.Delay(500);
+        await WaitUntilAsync(() => Directory.GetFiles(_tempDir, "error_*.log", SearchOption.AllDirectories).Length > 0);
 
         // Assert
         var errorFiles = Directory.GetFiles(_tempDir, "error_*.log", SearchOption.AllDirectories);
@@ -314,7 +322,7 @@ public class DiskBufferedLoggerTests : IDisposable
             Assert.Null(exception);
 
             // Wait for the fire-and-forget async task to complete
-            await Task.Delay(500);
+            await WaitUntilAsync(() => captured.ToString().Length > 0);
         }
         finally
         {
@@ -506,7 +514,7 @@ public class DiskBufferedLoggerTests : IDisposable
 
         // Act
         logger.LogError("format-err", ex);
-        await Task.Delay(500);
+        await WaitUntilAsync(() => Directory.GetFiles(_tempDir, "error_*.log", SearchOption.AllDirectories).Length > 0);
 
         // Assert
         var errorFiles = Directory.GetFiles(_tempDir, "error_*.log", SearchOption.AllDirectories);
@@ -533,8 +541,8 @@ public class DiskBufferedLoggerTests : IDisposable
                 logger.LogError($"concurrent-err-{i}", new Exception($"err-{i}"))));
         await Task.WhenAll(tasks);
 
-        // Give fire-and-forget tasks time to complete
-        await Task.Delay(1000);
+        // Wait for fire-and-forget tasks to complete
+        await WaitUntilAsync(() => Directory.GetFiles(_tempDir, "error_*.log", SearchOption.AllDirectories).Length > 0);
 
         // Assert – at least some error files exist and no exceptions thrown
         var errorFiles = Directory.GetFiles(_tempDir, "error_*.log", SearchOption.AllDirectories);

--- a/BareMetalWeb.Rendering.Tests/OutputCacheTests.cs
+++ b/BareMetalWeb.Rendering.Tests/OutputCacheTests.cs
@@ -8,6 +8,13 @@ namespace BareMetalWeb.Rendering.Tests;
 
 public class OutputCacheTests
 {
+    private static void WaitUntil(Func<bool> condition, int timeoutMs = 5000, int intervalMs = 25)
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (!condition() && sw.ElapsedMilliseconds < timeoutMs)
+            Thread.Sleep(intervalMs);
+    }
+
     [Fact]
     public void TryGet_EmptyCache_ReturnsFalse()
     {
@@ -69,7 +76,7 @@ public class OutputCacheTests
 
         // Act
         cache.Store(path, body, "text/html", 200, expiry: 1);
-        Thread.Sleep(1100); // Wait for expiry
+        WaitUntil(() => !cache.TryGet(path, out _));
         var result = cache.TryGet(path, out _);
 
         // Assert
@@ -135,7 +142,7 @@ public class OutputCacheTests
         Assert.True(cache.TryGet(path, out _));
         
         // Wait and check again
-        Thread.Sleep(2100);
+        WaitUntil(() => !cache.TryGet(path, out _));
         Assert.False(cache.TryGet(path, out _));
     }
 
@@ -152,7 +159,7 @@ public class OutputCacheTests
         
         // Even with 0 expiry, it might be retrievable for a very short time
         // But after any wait, it should be expired
-        Thread.Sleep(10);
+        WaitUntil(() => !cache.TryGet(path, out _));
         var result = cache.TryGet(path, out _);
 
         // Assert
@@ -313,7 +320,7 @@ public class OutputCacheTests
             cache.Store(p, body, "text/html", 200, expiry: 0);
 
         // Wait long enough for all entries to expire.
-        Thread.Sleep(50);
+        WaitUntil(() => !cache.TryGet("/expired1", out _));
 
         // Act: store a new entry – this triggers PruneExpired internally.
         cache.Store("/new", body, "text/html", 200, expiry: 30);

--- a/BareMetalWeb.Runtime.Tests/AggregateLockManagerTests.cs
+++ b/BareMetalWeb.Runtime.Tests/AggregateLockManagerTests.cs
@@ -10,6 +10,13 @@ namespace BareMetalWeb.Runtime.Tests;
 /// <summary>Tests for <see cref="AggregateLockManager"/>.</summary>
 public class AggregateLockManagerTests
 {
+    private static void WaitUntil(Func<bool> condition, int timeoutMs = 5000, int intervalMs = 25)
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (!condition() && sw.ElapsedMilliseconds < timeoutMs)
+            Thread.Sleep(intervalMs);
+    }
+
     private static AggregateLockManager MakeManager() => new();
 
     private static readonly TimeSpan ShortExpiry = TimeSpan.FromSeconds(10);
@@ -111,7 +118,7 @@ public class AggregateLockManagerTests
     {
         var mgr = MakeManager();
         mgr.TryAcquire("agg-1", "tx-1", TimeSpan.FromMilliseconds(1)); // expires almost immediately
-        Thread.Sleep(10); // let it expire
+        WaitUntil(() => mgr.TryAcquire("agg-1", "tx-2", ShortExpiry));
         var ok = mgr.TryAcquire("agg-1", "tx-2", ShortExpiry);
         Assert.True(ok, "Expired lock should be replaced by new owner");
     }


### PR DESCRIPTION
## Summary
Replace timing-dependent `Thread.Sleep` and `Task.Delay` calls with Stopwatch-based polling loops across 5 test files. Tests now wait for conditions to actually be met rather than assuming fixed delays are sufficient, eliminating flaky failures under CI load.

### Changes
| File | Fix |
|------|-----|
| `BackgroundJobServiceTests.cs` | Poll for job status transitions (Succeeded/Failed/CompletedAt) |
| `ClientRequestTrackerTests.cs` | Poll `Snapshot()` for block expiry (avoids ShouldThrottle counter increments) |
| `OutputCacheTests.cs` | Poll `TryGet` for cache expiry |
| `AggregateLockManagerTests.cs` | Poll `TryAcquire` for lock expiry |
| `DiskBufferedLoggerTests.cs` | Poll for log file existence |

Fixes #962
Fixes #963