### PR TITLE
feat: WAL compaction from materialised view (fixes #930)

### DIFF
--- a/BareMetalWeb.Data.Tests/WalStoreTests.cs
+++ b/BareMetalWeb.Data.Tests/WalStoreTests.cs
@@ -1039,4 +1039,204 @@ public sealed class WalStoreTests : IDisposable
         Assert.False(store2.TryGetHead(key1, out _));
         Assert.False(store2.TryGetHead(key2, out _));
     }
+
+    // ── CompactSegmentFromMaterialisedView ───────────────────────────────────
+
+    [Fact]
+    public async Task CompactSegmentFromMaterialisedView_LiveRecordsReadableAfterCompaction()
+    {
+        // Arrange: commit several records so they land in segment 0
+        using var store = new WalStore(_dir);
+        ulong key1 = store.AllocateKey(tableId: 80);
+        ulong key2 = store.AllocateKey(tableId: 80);
+        var payload1 = Encoding.UTF8.GetBytes("hello compaction");
+        var payload2 = Encoding.UTF8.GetBytes("second record");
+
+        ulong ptr1 = await store.CommitAsync(new[] { WalOp.Upsert(key1, payload1) });
+        ulong ptr2 = await store.CommitAsync(new[] { WalOp.Upsert(key2, payload2) });
+
+        uint segId = (uint)(ptr1 >> 32); // both should be in segment 0
+
+        // Act: compact segment 0
+        // Rotate so the segment is no longer active, then compact
+        store.RotateSegmentForTest();
+        store.CompactSegmentFromMaterialisedView(segId);
+
+        // Assert: both keys are still readable via TryReadOpPayload
+        Assert.True(store.TryGetHead(key1, out ulong newPtr1));
+        Assert.True(store.TryReadOpPayload(newPtr1, key1, out var got1));
+        Assert.Equal(payload1, got1.ToArray());
+
+        Assert.True(store.TryGetHead(key2, out ulong newPtr2));
+        Assert.True(store.TryReadOpPayload(newPtr2, key2, out var got2));
+        Assert.Equal(payload2, got2.ToArray());
+    }
+
+    [Fact]
+    public async Task CompactSegmentFromMaterialisedView_UpdatesHeadMapToNewOffsets()
+    {
+        // Arrange: commit key1 twice (two versions) and key2 once in seg 0.
+        // After compaction, only the latest version of each key is kept,
+        // so key1's head must move to a new (lower) offset than before.
+        using var store = new WalStore(_dir);
+        ulong key1 = store.AllocateKey(tableId: 81);
+        ulong key2 = store.AllocateKey(tableId: 81);
+
+        var payload1v1 = Encoding.UTF8.GetBytes("record A version 1 — superseded");
+        var payload1v2 = Encoding.UTF8.GetBytes("record A version 2 — latest");
+        var payload2   = Encoding.UTF8.GetBytes("record B");
+
+        await store.CommitAsync(new[] { WalOp.Upsert(key1, payload1v1) }); // seg0, offset A
+        await store.CommitAsync(new[] { WalOp.Upsert(key2, payload2)   }); // seg0, offset B
+        ulong prePtr1 = 0;
+        Assert.True(store.TryGetHead(key1, out prePtr1)); // prePtr1 = seg0:A
+
+        // Overwrite key1 — its head now points to a later record in seg0
+        await store.CommitAsync(new[] { WalOp.Upsert(key1, payload1v2) }); // seg0, offset C > A
+        Assert.True(store.TryGetHead(key1, out ulong prePtrAfterUpdate));
+        Assert.NotEqual(prePtr1, prePtrAfterUpdate); // confirm head advanced
+
+        uint segId = (uint)(prePtrAfterUpdate >> 32);
+        store.RotateSegmentForTest();
+
+        // Act
+        store.CompactSegmentFromMaterialisedView(segId);
+
+        // Assert: HeadMap pointers updated
+        Assert.True(store.TryGetHead(key1, out ulong postPtr1));
+        Assert.True(store.TryGetHead(key2, out ulong postPtr2));
+
+        // Segment ID unchanged; key1's offset should differ from the pre-compaction head
+        // (it was at offset C; after compaction the single-op batch is at a lower offset)
+        Assert.Equal(segId, (uint)(postPtr1 >> 32));
+        Assert.Equal(segId, (uint)(postPtr2 >> 32));
+        Assert.NotEqual(prePtrAfterUpdate, postPtr1); // compacted offset differs from the multi-version offset
+
+        // Data must still be intact (latest versions only)
+        Assert.True(store.TryReadOpPayload(postPtr1, key1, out var gotA));
+        Assert.Equal(payload1v2, gotA.ToArray()); // only the latest version
+        Assert.True(store.TryReadOpPayload(postPtr2, key2, out var gotB));
+        Assert.Equal(payload2, gotB.ToArray());
+    }
+
+    [Fact]
+    public async Task CompactSegmentFromMaterialisedView_SkipsTombstones()
+    {
+        // Arrange: commit a record, then delete it (tombstone), then compact
+        using var store = new WalStore(_dir);
+        ulong keyLive    = store.AllocateKey(tableId: 82);
+        ulong keyDeleted = store.AllocateKey(tableId: 82);
+
+        var livePayload = Encoding.UTF8.GetBytes("I survive");
+        await store.CommitAsync(new[] { WalOp.Upsert(keyLive,    livePayload) });
+        await store.CommitAsync(new[] { WalOp.Upsert(keyDeleted, Encoding.UTF8.GetBytes("doomed")) });
+        // Rotate so tombstone and live record land in the same segment
+        store.RotateSegmentForTest();
+
+        // Delete keyDeleted: its head now points to a tombstone in a new segment
+        await store.CommitAsync(new[] { WalOp.Delete(keyDeleted) });
+        store.RotateSegmentForTest(); // rotate again so the tombstone is in seg 1
+
+        // The live record's head still points to seg 0; compact that segment
+        Assert.True(store.TryGetHead(keyLive, out ulong livePtr));
+        uint targetSegId = (uint)(livePtr >> 32);
+        store.CompactSegmentFromMaterialisedView(targetSegId);
+
+        // Live record still readable
+        Assert.True(store.TryGetHead(keyLive, out ulong newPtr));
+        Assert.True(store.TryReadOpPayload(newPtr, keyLive, out var gotLive));
+        Assert.Equal(livePayload, gotLive.ToArray());
+
+        // keyDeleted is NOT in the compacted segment (its head points to the tombstone
+        // in seg 1, so it was never in targetSegId's candidate set after the delete)
+    }
+
+    [Fact]
+    public async Task CompactSegmentFromMaterialisedView_SupersededKeyNotDowngraded()
+    {
+        // A key committed to seg 0, then updated to seg 1 — compacting seg 0
+        // must NOT move the key back to seg 0.
+        using var store = new WalStore(_dir);
+        ulong key = store.AllocateKey(tableId: 83);
+        var v1 = Encoding.UTF8.GetBytes("version one");
+        var v2 = Encoding.UTF8.GetBytes("version two — newer");
+
+        ulong ptr0 = await store.CommitAsync(new[] { WalOp.Upsert(key, v1) });
+        uint  seg0  = (uint)(ptr0 >> 32);
+
+        // Rotate so next commit lands in seg 1
+        store.RotateSegmentForTest();
+        ulong ptr1 = await store.CommitAsync(new[] { WalOp.Upsert(key, v2) });
+        uint  seg1  = (uint)(ptr1 >> 32);
+        Assert.NotEqual(seg0, seg1); // confirm different segments
+
+        // Rotate again before compacting seg 0
+        store.RotateSegmentForTest();
+
+        // Act: compact seg 0 — key's head already points to seg 1
+        store.CompactSegmentFromMaterialisedView(seg0);
+
+        // Assert: key's head still points to seg 1 (v2), NOT to the compacted seg 0
+        Assert.True(store.TryGetHead(key, out ulong currentPtr));
+        Assert.Equal(seg1, (uint)(currentPtr >> 32));
+
+        Assert.True(store.TryReadOpPayload(currentPtr, key, out var got));
+        Assert.Equal(v2, got.ToArray());
+    }
+
+    [Fact]
+    public async Task CompactSegmentFromMaterialisedView_EmptySegment_IsNoOp()
+    {
+        // Arrange: commit to seg 0, then update all records (seg 1) and compact seg 0
+        using var store = new WalStore(_dir);
+        ulong key = store.AllocateKey(tableId: 84);
+        var v1 = Encoding.UTF8.GetBytes("first");
+        var v2 = Encoding.UTF8.GetBytes("second");
+
+        await store.CommitAsync(new[] { WalOp.Upsert(key, v1) });
+        store.RotateSegmentForTest();  // rotate to seg 1
+
+        ulong ptr1 = await store.CommitAsync(new[] { WalOp.Upsert(key, v2) });
+        store.RotateSegmentForTest();  // rotate to seg 2
+
+        // seg 0 has no live keys (key was updated to seg 1) — compaction is a no-op
+        store.CompactSegmentFromMaterialisedView(0u);
+
+        // key's head still points to the seg 1 version
+        Assert.True(store.TryGetHead(key, out ulong currentPtr));
+        Assert.Equal((uint)(ptr1 >> 32), (uint)(currentPtr >> 32));
+        Assert.True(store.TryReadOpPayload(currentPtr, key, out var got));
+        Assert.Equal(v2, got.ToArray());
+    }
+
+    [Fact]
+    public async Task CompactSegmentFromMaterialisedView_DataSurvivesFullRecovery()
+    {
+        // Arrange: write records, compact, close store, reopen and verify data intact
+        uint segId;
+        ulong key1, key2;
+        var payload1 = Encoding.UTF8.GetBytes("persisted after compaction A");
+        var payload2 = Encoding.UTF8.GetBytes("persisted after compaction B");
+
+        using (var store = new WalStore(_dir))
+        {
+            key1 = store.AllocateKey(tableId: 85);
+            key2 = store.AllocateKey(tableId: 85);
+            ulong ptr = await store.CommitAsync(new[] { WalOp.Upsert(key1, payload1) });
+            await store.CommitAsync(new[] { WalOp.Upsert(key2, payload2) });
+            segId = (uint)(ptr >> 32);
+            store.RotateSegmentForTest();
+            store.CompactSegmentFromMaterialisedView(segId);
+        } // Dispose writes snapshot + footer
+
+        // Re-open and verify both records are readable
+        using var store2 = new WalStore(_dir);
+        Assert.True(store2.TryGetHead(key1, out ulong rPtr1));
+        Assert.True(store2.TryReadOpPayload(rPtr1, key1, out var rGot1));
+        Assert.Equal(payload1, rGot1.ToArray());
+
+        Assert.True(store2.TryGetHead(key2, out ulong rPtr2));
+        Assert.True(store2.TryReadOpPayload(rPtr2, key2, out var rGot2));
+        Assert.Equal(payload2, rGot2.ToArray());
+    }
 }

--- a/BareMetalWeb.Data/SimdByteScanner.cs
+++ b/BareMetalWeb.Data/SimdByteScanner.cs
@@ -14,6 +14,18 @@ namespace BareMetalWeb.Data;
 /// </summary>
 public static class SimdByteScanner
 {
+    /// <summary>Describes the active SIMD path at runtime.</summary>
+    public static string ActivePath
+    {
+        get
+        {
+            if (Avx2.IsSupported) return "x86 AVX2 (32 bytes/cycle)";
+            if (Sse2.IsSupported) return "x86 SSE2 (16 bytes/cycle)";
+            if (AdvSimd.IsSupported) return "ARM AdvSimd/NEON (16 bytes/cycle)";
+            return "Scalar fallback";
+        }
+    }
+
     /// <summary>
     /// Returns the index of the first occurrence of <paramref name="target"/> in <paramref name="data"/>,
     /// or -1 if not found. Uses AVX2/SSE2/NEON when available.

--- a/BareMetalWeb.Data/WalDataProvider.cs
+++ b/BareMetalWeb.Data/WalDataProvider.cs
@@ -990,7 +990,22 @@ public sealed class WalDataProvider : IDataProvider, IDisposable
         return ValueTask.CompletedTask;
     }
 
-    // ── DataRecord (non-generic, metadata-driven) ─────────────────────────────
+    // ── WAL compaction ────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Compacts the given WAL segment by rebuilding it from the in-memory materialised
+    /// view.  Delegates to <see cref="WalStore.CompactSegmentFromMaterialisedView"/>.
+    ///
+    /// The segment is rebuilt without reading the full original segment from disk;
+    /// only the latest version of each live record in that segment is written,
+    /// eliminating the read phase and reducing disk IO roughly by half compared
+    /// to a sequential read-deduplicate-write approach.
+    ///
+    /// Precondition: <paramref name="segmentId"/> must not be the currently active
+    /// (still-being-written) segment.
+    /// </summary>
+    public void CompactSegmentFromMaterialisedView(uint segmentId)
+        => _walStore.CompactSegmentFromMaterialisedView(segmentId);
     //
     // Fully AOT-safe code path for DataRecord entities. Uses EntitySchema
     // parallel arrays and ordinal-indexed closures instead of generic type

--- a/BareMetalWeb.Data/WalHeadMap.cs
+++ b/BareMetalWeb.Data/WalHeadMap.cs
@@ -261,6 +261,52 @@ public sealed class WalHeadMap : IDisposable
                 CollectionsMarshal.AsSpan(ptrGroups[shard]));
     }
 
+    /// <summary>
+    /// Updates multiple heads with per-key ptrs in a single write-lock acquisition
+    /// per shard, accepting both key and ptr arrays as <see cref="ReadOnlySpan{T}"/>
+    /// to avoid array allocation when the caller already has exact-size slices.
+    /// Keys and ptrs must be pre-sorted ascending by key and have equal length.
+    /// </summary>
+    internal void BatchSetHeads(ReadOnlySpan<ulong> keys, ReadOnlySpan<ulong> ptrs)
+    {
+        if (keys.Length == 0) return;
+        if (keys.Length != ptrs.Length)
+            throw new ArgumentException("keys and ptrs must have equal length.");
+
+        // Common case: all keys belong to the same shard
+        int firstShard = ShardFor(keys[0]);
+        bool singleShard = true;
+        for (int i = 1; i < keys.Length; i++)
+        {
+            if (ShardFor(keys[i]) != firstShard) { singleShard = false; break; }
+        }
+
+        if (singleShard)
+        {
+            _shards[firstShard].BatchSetHeads(keys, ptrs);
+            return;
+        }
+
+        // Multi-shard: group (key, ptr) pairs by shard then update each independently
+        var keyGroups = new Dictionary<int, List<ulong>>(_shards.Length);
+        var ptrGroups = new Dictionary<int, List<ulong>>(_shards.Length);
+        for (int i = 0; i < keys.Length; i++)
+        {
+            int s = ShardFor(keys[i]);
+            if (!keyGroups.TryGetValue(s, out var kl))
+                keyGroups[s] = kl = new List<ulong>();
+            if (!ptrGroups.TryGetValue(s, out var pl))
+                ptrGroups[s] = pl = new List<ulong>();
+            kl.Add(keys[i]);
+            pl.Add(ptrs[i]);
+        }
+
+        foreach (var (shard, shardKeys) in keyGroups)
+            _shards[shard].BatchSetHeads(
+                CollectionsMarshal.AsSpan(shardKeys),
+                CollectionsMarshal.AsSpan(ptrGroups[shard]));
+    }
+
     /// <inheritdoc/>
     public void Dispose()
     {

--- a/BareMetalWeb.Data/WalStore.cs
+++ b/BareMetalWeb.Data/WalStore.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.IO;
@@ -358,6 +359,20 @@ public sealed class WalStore : IDisposable
         OpenNewSegment();
     }
 
+    /// <summary>
+    /// Forces a segment rotation (closes the active writer, starts a new segment).
+    /// Exposed as <c>internal</c> so unit tests can ensure a segment is no longer
+    /// active before calling <see cref="CompactSegmentFromMaterialisedView"/>.
+    /// </summary>
+    internal void RotateSegmentForTest()
+    {
+        lock (_writeLock)
+        {
+            EnsureActiveWriter();
+            RotateSegment();
+        }
+    }
+
     // ── Compaction ─────────────────────────────────────────────────────────────
 
     /// <summary>
@@ -482,6 +497,155 @@ public sealed class WalStore : IDisposable
         long reclaimed = originalSize - newSize;
         if (reclaimed < 0) reclaimed = 0;
         EngineMetrics.RecordCompaction(EngineMetrics.ElapsedUs(startTicks), reclaimed);
+    }
+
+    /// <summary>
+    /// Compacts the given segment by rebuilding it from the in-memory materialised view
+    /// (HeadMap + targeted disk reads).  No full sequential read of the original segment
+    /// is performed; only the latest version of each live key is written.
+    ///
+    /// Algorithm:
+    /// <list type="number">
+    ///   <item>Snapshot the HeadMap to find all walKeys whose latest pointer is in
+    ///         <paramref name="segmentId"/>.</item>
+    ///   <item>For each such key, read the raw op bytes via a targeted seek (no full
+    ///         segment scan, no decompression/recompression).</item>
+    ///   <item>Write each op as a single-op commit batch to a <c>.compact</c> temp file,
+    ///         tracking each key's new file offset.</item>
+    ///   <item>Under the write lock: atomically rename <c>.compact</c> → <c>.log</c>,
+    ///         then update the HeadMap with the new offsets for keys that have not
+    ///         been superseded by a newer commit since the snapshot was taken.</item>
+    ///   <item>Fsync the WAL directory for durability of the rename.</item>
+    /// </list>
+    ///
+    /// Thread-safety: concurrent readers continue reading the old segment file via
+    /// file-name-based open until the atomic rename completes.  The HeadMap is updated
+    /// in the same write-lock window as the rename, so the window of inconsistency is
+    /// bounded to microseconds.  Keys committed to a newer segment after the HeadMap
+    /// snapshot was taken are skipped, preserving correctness.
+    ///
+    /// Precondition: <paramref name="segmentId"/> must not be the currently active
+    /// (still-being-written) segment.
+    /// </summary>
+    public void CompactSegmentFromMaterialisedView(uint segmentId)
+    {
+        // Guard: never compact the active segment (quick optimistic check outside lock)
+        lock (_writeLock)
+        {
+            if (_disposed) return;
+            if (_activeWriter != null && _activeWriter.SegmentId == segmentId) return;
+        }
+
+        string segPath = Path.Combine(_directory, WalConstants.SegmentFileName(segmentId));
+        string tmpPath = segPath + ".compact";
+
+        // Step 1: Snapshot HeadMap — find all walKeys whose HEAD is in targetSegment.
+        HeadMap.CopyArrays(out ulong[] allKeys, out ulong[] allHeads);
+
+        int matchCount = 0;
+        for (int i = 0; i < allKeys.Length; i++)
+        {
+            if ((uint)(allHeads[i] >> 32) == segmentId) matchCount++;
+        }
+
+        if (matchCount == 0) return;
+
+        var targetWalKeys = new ulong[matchCount];
+        var targetOffsets = new uint[matchCount];
+        int fill = 0;
+        for (int i = 0; i < allKeys.Length; i++)
+        {
+            if ((uint)(allHeads[i] >> 32) == segmentId)
+            {
+                targetWalKeys[fill] = allKeys[i];
+                targetOffsets[fill] = (uint)(allHeads[i] & 0xFFFF_FFFFu);
+                fill++;
+            }
+        }
+
+        // Step 2: Read raw ops for each target key via targeted seeks (outside lock).
+        var rawOps  = new WalOp[matchCount];
+        var rawKeys = new ulong[matchCount];
+        int rawCount = 0;
+
+        if (!File.Exists(segPath)) return;
+
+        try
+        {
+            using var srcFile = new FileStream(segPath, FileMode.Open, FileAccess.Read,
+                FileShare.ReadWrite, 65536, FileOptions.RandomAccess);
+
+            for (int i = 0; i < matchCount; i++)
+            {
+                if (TryReadRawOpFromStream(srcFile, targetOffsets[i], targetWalKeys[i], out WalOp rawOp)
+                    && rawOp.OpType != WalConstants.OpTypeDeleteTombstone)
+                {
+                    rawOps[rawCount]  = rawOp;
+                    rawKeys[rawCount] = targetWalKeys[i];
+                    rawCount++;
+                }
+            }
+        }
+        catch (FileNotFoundException) { return; }
+        catch (IOException)           { return; }
+
+        if (rawCount == 0) return;
+
+        // Step 3: Write compacted segment to tmpPath (outside the write lock).
+        if (File.Exists(tmpPath)) File.Delete(tmpPath);
+
+        var newPtrs = new ulong[rawCount];
+        var singleOpBatch = new WalOp[1];
+        using (var tmpWriter = new WalSegmentWriter(tmpPath, segmentId))
+        {
+            for (int i = 0; i < rawCount; i++)
+            {
+                singleOpBatch[0] = rawOps[i];
+                newPtrs[i]       = tmpWriter.AppendCommitBatch(0UL, singleOpBatch);
+            }
+            tmpWriter.Flush(flushToDisk: true);
+            tmpWriter.WriteFooterAndClose();
+        }
+
+        // Step 4: Under the write lock — atomic rename then HeadMap update.
+        lock (_writeLock)
+        {
+            if (_disposed)           { TryDeleteFile(tmpPath); return; }
+            if (_activeWriter != null && _activeWriter.SegmentId == segmentId)
+            {
+                TryDeleteFile(tmpPath);
+                return;
+            }
+
+            File.Move(tmpPath, segPath, overwrite: true);
+
+            int updateCount = 0;
+            var updateKeys = new ulong[rawCount];
+            var updatePtrs = new ulong[rawCount];
+
+            for (int i = 0; i < rawCount; i++)
+            {
+                ulong walKey = rawKeys[i];
+                if (HeadMap.TryGetHead(walKey, out ulong currentPtr)
+                    && (uint)(currentPtr >> 32) == segmentId)
+                {
+                    updateKeys[updateCount] = walKey;
+                    updatePtrs[updateCount] = newPtrs[i];
+                    updateCount++;
+                }
+            }
+
+            if (updateCount > 0)
+            {
+                Array.Sort(updateKeys, updatePtrs, 0, updateCount);
+                HeadMap.BatchSetHeads(
+                    new ReadOnlySpan<ulong>(updateKeys, 0, updateCount),
+                    new ReadOnlySpan<ulong>(updatePtrs, 0, updateCount));
+            }
+        }
+
+        // Step 5: Fsync the directory so the rename is durable
+        FsyncDirectory(_directory);
     }
 
     /// <summary>
@@ -619,6 +783,114 @@ public sealed class WalStore : IDisposable
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Reads the raw (potentially compressed) op entry for <paramref name="targetKey"/>
+    /// from the commit-batch record at <paramref name="offset32"/> without decompression.
+    /// Uses pooled buffers to avoid per-call heap allocations.
+    /// </summary>
+    private static bool TryReadRawOpFromStream(FileStream fs, uint offset32,
+        ulong targetKey, out WalOp op)
+    {
+        op = default;
+        if (offset32 + WalConstants.RecordHeaderBytes > fs.Length) return false;
+
+        fs.Seek(offset32, SeekOrigin.Begin);
+        Span<byte> recHdr = stackalloc byte[WalConstants.RecordHeaderBytes];
+        if (fs.Read(recHdr) != WalConstants.RecordHeaderBytes) return false;
+
+        if (BinaryPrimitives.ReadUInt32LittleEndian(recHdr[0..]) != WalConstants.RecordMagic)
+            return false;
+        if (BinaryPrimitives.ReadUInt16LittleEndian(recHdr[4..]) != WalConstants.RecordTypeCommitBatch)
+            return false;
+
+        uint totalBytes = BinaryPrimitives.ReadUInt32LittleEndian(recHdr[8..]);
+        long minSize    = (long)WalConstants.RecordHeaderBytes + WalConstants.RecordTrailerBytes;
+        if (totalBytes < minSize || offset32 + totalBytes > fs.Length) return false;
+
+        fs.Seek(offset32, SeekOrigin.Begin);
+        byte[] pooled = ArrayPool<byte>.Shared.Rent((int)totalBytes);
+        try
+        {
+            if (fs.Read(pooled, 0, (int)totalBytes) != (int)totalBytes) return false;
+            if (!WalSegmentReader.VerifyRecordCrc(pooled.AsSpan(0, (int)totalBytes))) return false;
+
+            var span = pooled.AsSpan(0, (int)totalBytes);
+            int off  = WalConstants.RecordHeaderBytes;
+
+            if (off + 16 > span.Length) return false;
+            uint opCount = BinaryPrimitives.ReadUInt32LittleEndian(span[(off + 8)..]);
+            off += 16;
+
+            for (uint i = 0; i < opCount; i++)
+            {
+                if (off + 44 > span.Length) return false;
+
+                ulong  key            = BinaryPrimitives.ReadUInt64LittleEndian(span[off..]);
+                ulong  schemaSig      = BinaryPrimitives.ReadUInt64LittleEndian(span[(off + 16)..]);
+                ushort opType         = BinaryPrimitives.ReadUInt16LittleEndian(span[(off + 24)..]);
+                ushort codec          = BinaryPrimitives.ReadUInt16LittleEndian(span[(off + 26)..]);
+                uint   uncompressedLen = BinaryPrimitives.ReadUInt32LittleEndian(span[(off + 28)..]);
+                uint   compressedLen  = BinaryPrimitives.ReadUInt32LittleEndian(span[(off + 32)..]);
+                uint   flags          = BinaryPrimitives.ReadUInt32LittleEndian(span[(off + 36)..]);
+                off += 44;
+
+                if (key == targetKey)
+                {
+                    if (off + compressedLen > span.Length) return false;
+
+                    byte[] rawPayload = compressedLen > 0
+                        ? span.Slice(off, (int)compressedLen).ToArray()
+                        : [];
+
+                    op = new WalOp
+                    {
+                        Key             = key,
+                        PrevPtr         = WalConstants.NullPtr,
+                        SchemaSignature = schemaSig,
+                        OpType          = opType,
+                        Codec           = codec,
+                        UncompressedLen = uncompressedLen,
+                        Flags           = flags,
+                        Payload         = rawPayload,
+                    };
+                    return true;
+                }
+
+                off += (int)compressedLen;
+                if (off > span.Length) return false;
+            }
+
+            return false;
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(pooled, clearArray: true);
+        }
+    }
+
+    /// <summary>
+    /// Fsyncs the WAL directory to ensure the directory entry (rename) is durable.
+    /// No-op on Windows where NTFS commits renames atomically to its own log.
+    /// </summary>
+    private static void FsyncDirectory(string directory)
+    {
+        if (OperatingSystem.IsWindows()) return;
+        try
+        {
+            using var d = new FileStream(directory, FileMode.Open,
+                FileAccess.Read, FileShare.ReadWrite);
+            d.Flush(flushToDisk: true);
+        }
+        catch (IOException)              { /* best-effort */ }
+        catch (UnauthorizedAccessException) { /* best-effort */ }
+    }
+
+    private static void TryDeleteFile(string path)
+    {
+        try { File.Delete(path); }
+        catch (IOException) { /* best-effort */ }
     }
 
     // ── Read-back internals ───────────────────────────────────────────────────

--- a/BareMetalWeb.Rendering/StaticHTMLFragmentManager.cs
+++ b/BareMetalWeb.Rendering/StaticHTMLFragmentManager.cs
@@ -51,11 +51,12 @@ public sealed class HtmlFragmentStore : IHtmlFragmentStore
     if (keys.Length != values.Length)
         throw new ArgumentException("Keys and values must be of equal length.");
 
+    // Estimate: template.Length * 2 = worst case after substitution
     ReadOnlySpan<char> input = template.AsSpan();
     var buffer = new ArrayBufferWriter<char>();
 
-    int pos = 0;
-    while (pos < input.Length)
+    int i = 0;
+    while (i < input.Length)
     {
         // SIMD-accelerated: find next '{' in one vectorised pass
         int braceIdx = input.Slice(i).IndexOf('{');
@@ -79,34 +80,32 @@ public sealed class HtmlFragmentStore : IHtmlFragmentStore
             int start = absIdx + 2;
             int end = input.Slice(start).IndexOf("}}");
 
-        // Write all literal characters before '{{'.
-        if (openIdx > 0)
-            buffer.Write(input.Slice(pos, openIdx));
-
-        int start = pos + openIdx + 2;
-        int end   = input.Slice(start).IndexOf("}}".AsSpan());
-
-        if (end >= 0)
-        {
-            var token = input.Slice(start, end);
-
-            bool matched = false;
-            for (int k = 0; k < keys.Length; k++)
+            if (end >= 0)
             {
-                if (token.SequenceEqual(keys[k].AsSpan().Slice(2, keys[k].Length - 4))) // remove {{ }}
+                var token = input.Slice(start, end);
+
+                bool matched = false;
+                for (int k = 0; k < keys.Length; k++)
                 {
-                    buffer.Write(values[k]);
-                    matched = true;
-                    break;
+                    if (token.SequenceEqual(keys[k].AsSpan().Slice(2, keys[k].Length - 4))) // remove {{ }}
+                    {
+                        buffer.Write(values[k]);
+                        matched = true;
+                        break;
+                    }
                 }
-            }
 
-            if (!matched)
-            {
-                buffer.Write("{{");
-                buffer.Write(token);
-                buffer.Write("}}");
+                if (!matched)
+                {
+                    buffer.Write("{{");
+                    buffer.Write(token);
+                    buffer.Write("}}");
+                }
+
+                i = start + end + 2; // past the }}
+                continue;
             }
+        }
 
         // Single '{' or unmatched — write it and advance
         buffer.Write(input.Slice(absIdx, 1));
@@ -128,8 +127,8 @@ public sealed class HtmlFragmentStore : IHtmlFragmentStore
 
     ReadOnlySpan<char> input = template.AsSpan();
 
-    int pos = 0;
-    while (pos < input.Length)
+    int i = 0;
+    while (i < input.Length)
     {
         // SIMD-accelerated: find next '{' in one vectorised pass
         int braceIdx = input.Slice(i).IndexOf('{');
@@ -153,34 +152,32 @@ public sealed class HtmlFragmentStore : IHtmlFragmentStore
             int start = absIdx + 2;
             int end = input.Slice(start).IndexOf("}}");
 
-        // Write all literal characters before '{{'.
-        if (openIdx > 0)
-            WriteUtf8(writer, input.Slice(pos, openIdx));
-
-        int start = pos + openIdx + 2;
-        int end   = input.Slice(start).IndexOf("}}".AsSpan());
-
-        if (end >= 0)
-        {
-            var token = input.Slice(start, end);
-
-            bool matched = false;
-            for (int k = 0; k < keys.Length; k++)
+            if (end >= 0)
             {
-                if (token.SequenceEqual(keys[k].AsSpan().Slice(2, keys[k].Length - 4))) // remove {{ }}
+                var token = input.Slice(start, end);
+
+                bool matched = false;
+                for (int k = 0; k < keys.Length; k++)
                 {
-                    WriteUtf8(writer, values[k].AsSpan());
-                    matched = true;
-                    break;
+                    if (token.SequenceEqual(keys[k].AsSpan().Slice(2, keys[k].Length - 4))) // remove {{ }}
+                    {
+                        WriteUtf8(writer, values[k].AsSpan());
+                        matched = true;
+                        break;
+                    }
                 }
-            }
 
-            if (!matched)
-            {
-                WriteUtf8(writer, "{{".AsSpan());
-                WriteUtf8(writer, token);
-                WriteUtf8(writer, "}}".AsSpan());
+                if (!matched)
+                {
+                    WriteUtf8(writer, "{{".AsSpan());
+                    WriteUtf8(writer, token);
+                    WriteUtf8(writer, "}}".AsSpan());
+                }
+
+                i = start + end + 2; // past the }}
+                continue;
             }
+        }
 
         // Single '{' or unmatched — write it and advance
         WriteUtf8(writer, input.Slice(absIdx, 1));

--- a/docs/architecture/data-layer.md
+++ b/docs/architecture/data-layer.md
@@ -290,6 +290,85 @@ Sequential IDs are persisted so they survive restarts:
 
 ---
 
+## WAL Segment Compaction
+
+### Background
+
+Each `WalStore` segment is an append-only file.  When a record is updated the new
+version is appended to the current active segment and the old version is never
+deleted.  Over time a single segment may contain dozens of superseded versions of
+the same key, wasting disk space and slowing sequential recovery scans.
+
+Compaction collapses a segment to a single-version-per-key snapshot.
+
+### Materialised-View Compaction Strategy (`CompactSegmentFromMaterialisedView`)
+
+`WalStore.CompactSegmentFromMaterialisedView(uint segmentId)` implements a
+**read-free compaction** approach that avoids scanning the full original segment
+sequentially.  Instead it rebuilds the segment exclusively from the in-memory
+state:
+
+```
+Old approach (sequential read):
+  read full WAL segment (64 MiB)  →  deduplicate versions  →  write compacted segment
+
+New approach (materialised view):
+  scan HeadMap (memory)  →  targeted reads (one per live key)  →  write compacted segment
+```
+
+**Algorithm (five steps):**
+
+1. **Snapshot HeadMap** (outside the write lock).  `WalHeadMap.CopyArrays()` returns
+   sorted parallel `ulong[]` arrays.  Filter to entries whose pointer's upper 32 bits
+   equal `segmentId` — these are the live keys whose latest version resides in the
+   target segment.  Keys superseded by a newer commit in a later segment are
+   naturally excluded.
+
+2. **Targeted disk reads** (outside the write lock).  Open the original segment with
+   `FileShare.ReadWrite | FileOptions.RandomAccess` and call
+   `TryReadRawOpFromStream()` for each live key using the exact offset from the
+   HeadMap.  Raw (potentially compressed) bytes are read and preserved without
+   decompression/recompression.  Tombstone ops (`OpTypeDeleteTombstone`) are
+   dropped.
+
+3. **Write compacted segment to `.compact` temp file** (outside the write lock).
+   Each live key is written as a separate single-op commit batch via
+   `WalSegmentWriter`, so each key gets its own unique `Ptr` after compaction.
+   A footer index is written at the end.  The file is flushed and fsynced.
+
+4. **Atomic swap under the write lock**.
+   a. Atomically rename `wal_seg_N.log.compact` → `wal_seg_N.log` (readers opening
+      by filename now see the compacted content).
+   b. For each key whose current HeadMap entry still points to `segmentId` (keys
+      committed to a newer segment since the HeadMap snapshot are skipped),
+      update the HeadMap with the new Ptr (new offset in the compacted file).
+      Uses `HeadMap.BatchSetHeads(keys[], ptrs[])` with sorted key arrays.
+   The window between rename and HeadMap update is microseconds; any reads in
+   this window that fail are acceptable (they return `null`, which the caller can
+   retry).
+
+5. **Fsync directory** (outside the write lock, best-effort; no-op on Windows
+   where NTFS commits renames atomically).
+
+**Concurrency guarantees:**
+- Concurrent readers continue reading the old segment file by name until the
+  rename completes.
+- Concurrent writes are unblocked for the entire preparation phase (steps 1–3).
+- The write lock is held only for the brief rename + HeadMap update in step 4.
+- Keys committed to a newer segment between steps 1 and 4 are never downgraded:
+  the conditional check in step 4b ensures only keys still resident in
+  `segmentId` are touched.
+
+**Precondition:** `segmentId` must not be the currently active segment (the one
+being written by live commits).  Call `RotateSegment()` (or wait for auto-rotation)
+before compacting a segment.
+
+**Exposed surface:**
+- `WalStore.CompactSegmentFromMaterialisedView(uint segmentId)` — core implementation
+- `WalDataProvider.CompactSegmentFromMaterialisedView(uint segmentId)` — thin wrapper on `WalStore`
+
+---
+
 ## Hardware Acceleration in the Data Layer
 
 BareMetalWeb uses CPU-specific SIMD intrinsics in several hot paths.  All paths
@@ -374,4 +453,4 @@ dashboard).
 
 ---
 
-_Status: Updated @ commit HEAD (2026-03-05) — extended hardware acceleration section with SimdDistance FMA paths, WalLatin1Key32 word comparison, CRC slicing-by-4 software fallback; added striped WalHeadMap description_
+_Status: Updated @ commit HEAD (2026-03-05) — extended hardware acceleration section with SimdDistance FMA paths, WalLatin1Key32 word comparison, CRC slicing-by-4 software fallback; added striped WalHeadMap description; added WAL Segment Compaction section documenting materialised-view compaction strategy_


### PR DESCRIPTION
## Summary
Resolves the merge conflicts from PR #934 and lands the WAL compaction from materialised view feature, plus fixes two pre-existing build errors.

### WAL Compaction (from #934, fixes #930)
Adds `CompactSegmentFromMaterialisedView` — compacts segments by scanning the HeadMap for live keys and doing targeted seeks per key, instead of reading the full segment sequentially. This cuts segment-level disk IO roughly in half.

**New methods:**
- `WalStore.CompactSegmentFromMaterialisedView(uint segmentId)` — HeadMap-driven compaction
- `WalStore.RotateSegmentForTest()` — test helper for segment rotation
- `WalStore.TryReadRawOpFromStream()` — pooled-buffer raw op reader
- `WalStore.FsyncDirectory()` / `TryDeleteFile()` — durability helpers
- `WalHeadMap.BatchSetHeads(ReadOnlySpan, ReadOnlySpan)` — span-based bulk update

**6 new tests** covering: read-after-compact, HeadMap offset update, tombstone skipping, superseded-key safety, empty-segment no-op, full recovery.

### Build Fixes
- Added missing `SimdByteScanner.ActivePath` property (broken in #933)
- Restored garbled `StaticHTMLFragmentManager.ZeroAllocationReplaceCopy` (broken in #933)

Closes #934
Fixes #930