### PR TITLE
infra: add upgrade, canary, and cireset web apps to Bicep

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -1,0 +1,33 @@
+name: Deploy Infrastructure
+
+run-name: "Deploy Infrastructure"
+
+on:
+  workflow_dispatch:
+    inputs:
+      resource_group:
+        description: 'Azure Resource Group name'
+        required: true
+        default: 'baremetalweb-rg'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Login to Azure
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Deploy Bicep
+        uses: azure/arm-deploy@v2
+        with:
+          resourceGroupName: ${{ inputs.resource_group }}
+          template: infra/main.bicep
+          failOnStdErr: false

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -10,7 +10,16 @@ param webAppName string = 'baremetalweb'
 @description('Name of the production Web App.')
 param webAppProdName string = 'baremetalweb-prod'
 
-// App Service Plan: P0V3 (Premium v3) - updated from F1 (Free)
+@description('Name of the CI reset Web App (L1.1 fresh-deploy tests).')
+param webAppCiResetName string = 'baremetalweb-cireset'
+
+@description('Name of the upgrade-path CI Web App (L1.1-upgrade / L1.2).')
+param webAppUpgradeName string = 'baremetalweb-upgrade'
+
+@description('Name of the canary ring-0 Web App (L2.1 staging).')
+param webAppCanaryName string = 'baremetalweb-canary'
+
+// App Service Plan: P0V3 (Premium v3)
 resource appServicePlan 'Microsoft.Web/serverfarms@2023-01-01' = {
   name: appServicePlanName
   location: location
@@ -43,6 +52,51 @@ resource webApp 'Microsoft.Web/sites@2023-01-01' = {
 // Production Web App
 resource webAppProd 'Microsoft.Web/sites@2023-01-01' = {
   name: webAppProdName
+  location: location
+  properties: {
+    serverFarmId: appServicePlan.id
+    httpsOnly: true
+    siteConfig: {
+      alwaysOn: true
+      netFrameworkVersion: 'v9.0'
+      use32BitWorkerProcess: false
+    }
+  }
+}
+
+// CI Reset Web App — blown away and redeployed with empty data on each CI run
+resource webAppCiReset 'Microsoft.Web/sites@2023-01-01' = {
+  name: webAppCiResetName
+  location: location
+  properties: {
+    serverFarmId: appServicePlan.id
+    httpsOnly: true
+    siteConfig: {
+      alwaysOn: false
+      netFrameworkVersion: 'v9.0'
+      use32BitWorkerProcess: false
+    }
+  }
+}
+
+// Upgrade CI Web App — runs with a standard data set from a previous version
+resource webAppUpgrade 'Microsoft.Web/sites@2023-01-01' = {
+  name: webAppUpgradeName
+  location: location
+  properties: {
+    serverFarmId: appServicePlan.id
+    httpsOnly: true
+    siteConfig: {
+      alwaysOn: false
+      netFrameworkVersion: 'v9.0'
+      use32BitWorkerProcess: false
+    }
+  }
+}
+
+// Canary Ring-0 Web App — release candidate deployed here for soak testing
+resource webAppCanary 'Microsoft.Web/sites@2023-01-01' = {
+  name: webAppCanaryName
   location: location
   properties: {
     serverFarmId: appServicePlan.id


### PR DESCRIPTION
## Summary
Adds the 3 missing Azure Web Apps to `infra/main.bicep` that the CI/CD pipeline (`ci-cd-pipeline.yml`) expects:

| Web App | Pipeline Stage | AlwaysOn |
|---------|---------------|----------|
| `baremetalweb-cireset` | L1.1 fresh-deploy smoke tests | No |
| `baremetalweb-upgrade` | L1.1-upgrade / L1.2 integration | No |
| `baremetalweb-canary` | L2.1 canary ring-0 staging | Yes |

Also adds `deploy-infra.yml` — a manual workflow to deploy the Bicep template.

### To provision
After merging, run the **Deploy Infrastructure** workflow from the Actions tab with the target resource group name.

### Secrets status ✅
All required secrets are already configured:
- `AZURE_CREDENTIALS` / `_UPGRADE` / `_CANARY` / `_TENANTS`
- `CIMIGRATE_TEST_USERNAME` / `_DISPLAYNAME` / `_PASSWORD`

Fixes #985