### PR TITLE
ci: replace webapps-deploy with az webapp up

### DIFF
--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -189,10 +189,9 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Deploy to baremetalweb (Canary / CI base)
-        uses: azure/webapps-deploy@v3
-        with:
-          app-name: baremetalweb
-          package: ./publish
+        run: |
+          cd ./publish
+          az webapp up --name baremetalweb --os-type Linux --runtime "DOTNETCORE:10.0"
 
       - name: Wait for deployment to stabilise
         run: |
@@ -268,10 +267,9 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS_UPGRADE }}
 
       - name: Deploy to baremetalweb-upgrade (no data reset)
-        uses: azure/webapps-deploy@v3
-        with:
-          app-name: baremetalweb-upgrade
-          package: ./publish
+        run: |
+          cd ./publish
+          az webapp up --name baremetalweb-upgrade --os-type Linux --runtime "DOTNETCORE:10.0"
 
       - name: Wait for deployment to stabilise
         run: |
@@ -666,10 +664,9 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS_CANARY }}
 
       - name: Deploy to baremetalweb-canary (Ring 0)
-        uses: azure/webapps-deploy@v3
-        with:
-          app-name: baremetalweb-canary
-          package: ./publish
+        run: |
+          cd ./publish
+          az webapp up --name baremetalweb-canary --os-type Linux --runtime "DOTNETCORE:10.0"
 
       - name: Wait for deployment to stabilise
         run: |

--- a/.github/workflows/deploy-cimigrate.yml
+++ b/.github/workflows/deploy-cimigrate.yml
@@ -56,10 +56,9 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS_CIMIGRATE }}
 
       - name: Deploy to Azure Web App
-        uses: azure/webapps-deploy@v3
-        with:
-          app-name: baremetalweb-cimigrate
-          package: ./publish
+        run: |
+          cd ./publish
+          az webapp up --name baremetalweb-cimigrate --os-type Linux --runtime "DOTNETCORE:10.0"
 
   integration-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-cireset.yml
+++ b/.github/workflows/deploy-cireset.yml
@@ -58,10 +58,9 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS_CIRESET }}
 
       - name: Deploy to Azure Web App (CI Reset)
-        uses: azure/webapps-deploy@v3
-        with:
-          app-name: baremetalweb-cireset
-          package: ./publish
+        run: |
+          cd ./publish
+          az webapp up --name baremetalweb-cireset --os-type Linux --runtime "DOTNETCORE:10.0"
 
       - name: Wait for deployment to stabilize
         run: |

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -66,7 +66,6 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS_PROD }}
 
       - name: Deploy to Azure Web App
-        uses: azure/webapps-deploy@v3
-        with:
-          app-name: baremetalweb-prod
-          package: ./publish
+        run: |
+          cd ./publish
+          az webapp up --name baremetalweb-prod --os-type Linux --runtime "DOTNETCORE:10.0"

--- a/.github/workflows/deploy-tenant.yml
+++ b/.github/workflows/deploy-tenant.yml
@@ -59,10 +59,9 @@ jobs:
           creds: ${{ secrets.azure-credentials }}
 
       - name: Deploy to ${{ inputs.app-name }}
-        uses: azure/webapps-deploy@v3
-        with:
-          app-name: ${{ inputs.app-name }}
-          package: ./publish
+        run: |
+          cd ./publish
+          az webapp up --name ${{ inputs.app-name }} --os-type Linux --runtime "DOTNETCORE:10.0"
 
       - name: Wait for deployment to stabilise
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -185,10 +185,9 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Deploy to Azure Web App
-        uses: azure/webapps-deploy@v3
-        with:
-          app-name: baremetalweb
-          package: ./publish
+        run: |
+          cd ./publish
+          az webapp up --name baremetalweb --os-type Linux --runtime "DOTNETCORE:10.0"
 
       - name: Wait for deployment to stabilize
         run: |

--- a/.github/workflows/reset-data-staging.yml
+++ b/.github/workflows/reset-data-staging.yml
@@ -55,7 +55,6 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Deploy to Azure Web App
-        uses: azure/webapps-deploy@v3
-        with:
-          app-name: baremetalweb
-          package: ./publish
+        run: |
+          cd ./publish
+          az webapp up --name baremetalweb --os-type Linux --runtime "DOTNETCORE:10.0"


### PR DESCRIPTION
## Summary
Replaces all `azure/webapps-deploy@v3` GitHub Action steps with `az webapp up` CLI commands across 7 workflow files. Simpler, more portable, fewer moving parts.

### Before
```yaml
- uses: azure/webapps-deploy@v3
  with:
    app-name: baremetalweb
    package: ./publish
```

### After
```yaml
- run: |
    cd ./publish
    az webapp up --name baremetalweb --os-type Linux --runtime "DOTNETCORE:10.0"
```

### Files changed
| Workflow | Target |
|----------|--------|
| deploy.yml | baremetalweb |
| deploy-prod.yml | baremetalweb-prod |
| deploy-cireset.yml | baremetalweb-cireset |
| deploy-cimigrate.yml | baremetalweb-cimigrate |
| reset-data-staging.yml | baremetalweb |
| deploy-tenant.yml | ${{ inputs.app-name }} |
| ci-cd-pipeline.yml | baremetalweb, -upgrade, -canary |

`azure/login@v2` is retained — `az` CLI needs it. Zero `azure/webapps-deploy` references remain.

Fixes #987