### PR TITLE
feat: add real tenants to deploy-list and Bicep

### DIFF
--- a/deploy-list.json
+++ b/deploy-list.json
@@ -24,16 +24,21 @@
   ],
   "early_access": [
     {
-      "id": "tenant-example-ea",
-      "name": "Example Early-Access Tenant",
-      "app_name": "baremetalweb-tenant-example-ea"
+      "id": "memoryforaitodo",
+      "name": "Memory for AI Todo",
+      "app_name": "memoryforaitodo"
+    },
+    {
+      "id": "metalsamples",
+      "name": "Metal Samples",
+      "app_name": "metalsamples"
     }
   ],
   "main_rollout": [
     {
-      "id": "tenant-example-prod",
-      "name": "Example Production Tenant",
-      "app_name": "baremetalweb-tenant-example-prod"
+      "id": "oldoaklaboratoryschool",
+      "name": "Old Oak Laboratory School",
+      "app_name": "oldoaklaboratoryschool"
     }
   ]
 }

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -108,3 +108,50 @@ resource webAppCanary 'Microsoft.Web/sites@2023-01-01' = {
     }
   }
 }
+
+// ── Tenant Web Apps ──────────────────────────────────────────────────────────
+
+// P1 Early-access: Memory for AI Todo
+resource webAppMemoryForAiTodo 'Microsoft.Web/sites@2023-01-01' = {
+  name: 'memoryforaitodo'
+  location: location
+  properties: {
+    serverFarmId: appServicePlan.id
+    httpsOnly: true
+    siteConfig: {
+      alwaysOn: true
+      netFrameworkVersion: 'v9.0'
+      use32BitWorkerProcess: false
+    }
+  }
+}
+
+// P1 Early-access: Metal Samples
+resource webAppMetalSamples 'Microsoft.Web/sites@2023-01-01' = {
+  name: 'metalsamples'
+  location: location
+  properties: {
+    serverFarmId: appServicePlan.id
+    httpsOnly: true
+    siteConfig: {
+      alwaysOn: true
+      netFrameworkVersion: 'v9.0'
+      use32BitWorkerProcess: false
+    }
+  }
+}
+
+// P2 Standard rollout: Old Oak Laboratory School
+resource webAppOldOakLaboratorySchool 'Microsoft.Web/sites@2023-01-01' = {
+  name: 'oldoaklaboratoryschool'
+  location: location
+  properties: {
+    serverFarmId: appServicePlan.id
+    httpsOnly: true
+    siteConfig: {
+      alwaysOn: true
+      netFrameworkVersion: 'v9.0'
+      use32BitWorkerProcess: false
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Replace example placeholder tenants with real ones and add their Web App definitions to Bicep.

### P1 Early-access (L2.2)
| Tenant | App Name |
|--------|----------|
| Memory for AI Todo | `memoryforaitodo` |
| Metal Samples | `metalsamples` |

### P2 Standard rollout (L2.3)
| Tenant | App Name |
|--------|----------|
| Old Oak Laboratory School | `oldoaklaboratoryschool` |

### To provision
After merging, run the **Deploy Infrastructure** workflow to create the Web Apps in Azure.

Fixes #991