### PR TITLE
fix: version not updating on footer

### DIFF
--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -81,7 +81,7 @@ jobs:
           MAJOR="${{ vars.MAJOR_VERSION || '1' }}"
           DATE="$(date +%Y%m%d)"
           BUILD="${{ github.run_number }}"
-          echo "info_version=V${MAJOR}.${DATE}.${BUILD}"   >> $GITHUB_OUTPUT
+          echo "info_version=${MAJOR}.${DATE}.${BUILD}+${GITHUB_SHA:0:7}"   >> $GITHUB_OUTPUT
           echo "assembly_version=${MAJOR}.0.0.${BUILD}"    >> $GITHUB_OUTPUT
           echo "tag=v${MAJOR}.${DATE}.${BUILD}"            >> $GITHUB_OUTPUT
 
@@ -190,7 +190,7 @@ jobs:
 
       - name: Deploy to baremetalweb (Canary / CI base)
         run: |
-          cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name baremetalweb --resource-group baremetalweb-rg --src-path ../deploy.zip --type zip --async true
+          cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name baremetalweb --resource-group baremetalweb-rg --src-path ../deploy.zip --type zip
 
       - name: Wait for deployment to stabilise
         run: |
@@ -267,7 +267,7 @@ jobs:
 
       - name: Deploy to baremetalweb-upgrade (no data reset)
         run: |
-          cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name baremetalweb-upgrade --resource-group baremetalweb-rg --src-path ../deploy.zip --type zip --async true
+          cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name baremetalweb-upgrade --resource-group baremetalweb-rg --src-path ../deploy.zip --type zip
 
       - name: Wait for deployment to stabilise
         run: |
@@ -663,7 +663,7 @@ jobs:
 
       - name: Deploy to baremetalweb-canary (Ring 0)
         run: |
-          cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name baremetalweb-canary --resource-group baremetalweb-rg --src-path ../deploy.zip --type zip --async true
+          cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name baremetalweb-canary --resource-group baremetalweb-rg --src-path ../deploy.zip --type zip
 
       - name: Wait for deployment to stabilise
         run: |

--- a/.github/workflows/deploy-cimigrate.yml
+++ b/.github/workflows/deploy-cimigrate.yml
@@ -30,7 +30,7 @@ jobs:
           MAJOR="${{ vars.MAJOR_VERSION || '1' }}"
           DATE="$(date +%Y%m%d)"
           BUILD="${{ github.run_number }}"
-          echo "info_version=V${MAJOR}.${DATE}.${BUILD}" >> $GITHUB_OUTPUT
+          echo "info_version=${MAJOR}.${DATE}.${BUILD}+${GITHUB_SHA:0:7}" >> $GITHUB_OUTPUT
           echo "assembly_version=${MAJOR}.0.0.${BUILD}" >> $GITHUB_OUTPUT
 
       - name: Setup .NET
@@ -57,7 +57,7 @@ jobs:
 
       - name: Deploy to Azure Web App
         run: |
-          cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name baremetalweb-cimigrate --resource-group baremetalweb-rg --src-path ../deploy.zip --type zip --async true
+          cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name baremetalweb-cimigrate --resource-group baremetalweb-rg --src-path ../deploy.zip --type zip
 
   integration-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-cireset.yml
+++ b/.github/workflows/deploy-cireset.yml
@@ -29,7 +29,7 @@ jobs:
           MAJOR="${{ vars.MAJOR_VERSION || '1' }}"
           DATE="$(date +%Y%m%d)"
           BUILD="${{ github.run_number }}"
-          echo "info_version=V${MAJOR}.${DATE}.${BUILD}" >> $GITHUB_OUTPUT
+          echo "info_version=${MAJOR}.${DATE}.${BUILD}+${GITHUB_SHA:0:7}" >> $GITHUB_OUTPUT
           echo "assembly_version=${MAJOR}.0.0.${BUILD}" >> $GITHUB_OUTPUT
 
       - name: Setup .NET
@@ -59,7 +59,7 @@ jobs:
 
       - name: Deploy to Azure Web App (CI Reset)
         run: |
-          cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name baremetalweb-cireset --resource-group baremetalweb-rg --src-path ../deploy.zip --type zip --async true
+          cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name baremetalweb-cireset --resource-group baremetalweb-rg --src-path ../deploy.zip --type zip
 
       - name: Wait for deployment to stabilize
         run: |

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -27,7 +27,7 @@ jobs:
           MAJOR="${{ vars.MAJOR_VERSION || '1' }}"
           DATE="$(date +%Y%m%d)"
           BUILD="${{ github.run_number }}"
-          echo "info_version=V${MAJOR}.${DATE}.${BUILD}" >> $GITHUB_OUTPUT
+          echo "info_version=${MAJOR}.${DATE}.${BUILD}+${GITHUB_SHA:0:7}" >> $GITHUB_OUTPUT
           echo "assembly_version=${MAJOR}.0.0.${BUILD}" >> $GITHUB_OUTPUT
 
       - name: Setup .NET
@@ -67,4 +67,4 @@ jobs:
 
       - name: Deploy to Azure Web App
         run: |
-          cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name baremetalweb-prod --resource-group baremetalweb-rg --src-path ../deploy.zip --type zip --async true
+          cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name baremetalweb-prod --resource-group baremetalweb-rg --src-path ../deploy.zip --type zip

--- a/.github/workflows/deploy-tenant.yml
+++ b/.github/workflows/deploy-tenant.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Deploy to ${{ inputs.app-name }}
         run: |
-          cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name ${{ inputs.app-name }} --resource-group ${{ inputs.resource-group }} --src-path ../deploy.zip --type zip --async true
+          cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name ${{ inputs.app-name }} --resource-group ${{ inputs.resource-group }} --src-path ../deploy.zip --type zip
 
       - name: Wait for deployment to stabilise
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,6 +52,8 @@ jobs:
   # ── Stage 1b: Publish Release AOT+trimmed (for deploy) ─────────────────
   build-release:
     runs-on: ubuntu-latest
+    outputs:
+      info_version: ${{ steps.version.outputs.info_version }}
     steps:
       - uses: actions/checkout@v4
 
@@ -61,7 +63,7 @@ jobs:
           MAJOR="${{ vars.MAJOR_VERSION || '1' }}"
           DATE="$(date +%Y%m%d)"
           BUILD="${{ github.run_number }}"
-          echo "info_version=V${MAJOR}.${DATE}.${BUILD}" >> $GITHUB_OUTPUT
+          echo "info_version=${MAJOR}.${DATE}.${BUILD}+${GITHUB_SHA:0:7}" >> $GITHUB_OUTPUT
           echo "assembly_version=${MAJOR}.0.0.${BUILD}" >> $GITHUB_OUTPUT
 
       - name: Setup .NET
@@ -203,12 +205,28 @@ jobs:
 
       - name: Deploy to Azure Web App
         run: |
-          cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name baremetalweb --resource-group baremetalweb-rg --src-path ../deploy.zip --type zip --async true
+          cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name baremetalweb --resource-group baremetalweb-rg --src-path ../deploy.zip --type zip
 
       - name: Wait for deployment to stabilize
         run: |
-          echo "Waiting 30 seconds for deployment to complete and app to start..."
+          echo "Waiting 30 seconds for app to restart..."
           sleep 30
+
+      - name: Verify deployed version
+        run: |
+          EXPECTED="${{ needs.build-release.outputs.info_version }}"
+          echo "Expected version: ${EXPECTED}"
+          BODY=$(curl -sf https://baremetalweb.azurewebsites.net/ || true)
+          FOUND=$(echo "$BODY" | grep -oP 'v\K[0-9]+\.[0-9]+\.[0-9]+\+[a-f0-9]+' | head -1)
+          echo "Found version: ${FOUND}"
+          if [ -z "$FOUND" ]; then
+            echo "⚠️ Could not extract version from footer — skipping check"
+          elif [ "$FOUND" = "$EXPECTED" ]; then
+            echo "✅ Version verified: v${FOUND}"
+          else
+            echo "❌ Version mismatch: expected ${EXPECTED}, got ${FOUND}"
+            exit 1
+          fi
 
   # ── Stage 4: Playwright E2E (after deploy) ─────────────────────────────
   e2e:

--- a/.github/workflows/reset-data-staging.yml
+++ b/.github/workflows/reset-data-staging.yml
@@ -26,7 +26,7 @@ jobs:
           MAJOR="${{ vars.MAJOR_VERSION || '1' }}"
           DATE="$(date +%Y%m%d)"
           BUILD="${{ github.run_number }}"
-          echo "info_version=V${MAJOR}.${DATE}.${BUILD}" >> $GITHUB_OUTPUT
+          echo "info_version=${MAJOR}.${DATE}.${BUILD}+${GITHUB_SHA:0:7}" >> $GITHUB_OUTPUT
           echo "assembly_version=${MAJOR}.0.0.${BUILD}" >> $GITHUB_OUTPUT
 
       - name: Setup .NET
@@ -56,4 +56,4 @@ jobs:
 
       - name: Deploy to Azure Web App
         run: |
-          cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name baremetalweb --resource-group baremetalweb-rg --src-path ../deploy.zip --type zip --async true
+          cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name baremetalweb --resource-group baremetalweb-rg --src-path ../deploy.zip --type zip

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -62,7 +62,7 @@ jobs:
           MAJOR="${{ vars.MAJOR_VERSION || '1' }}"
           DATE="$(date +%Y%m%d)"
           BUILD="${{ github.run_number }}"
-          echo "info_version=V${MAJOR}.${DATE}.${BUILD}" >> $GITHUB_OUTPUT
+          echo "info_version=${MAJOR}.${DATE}.${BUILD}+${GITHUB_SHA:0:7}" >> $GITHUB_OUTPUT
           echo "assembly_version=${MAJOR}.0.0.${BUILD}" >> $GITHUB_OUTPUT
 
       - name: Setup .NET

--- a/BareMetalWeb.Host/BareMetalWeb.Host.csproj
+++ b/BareMetalWeb.Host/BareMetalWeb.Host.csproj
@@ -5,6 +5,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Version>1.0.0</Version>
+    <!-- Prevent SDK from appending +SourceRevisionId — CI stamps the full
+         InformationalVersion (including short SHA) via -p:InformationalVersion -->
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <!-- AOT: produce a single native binary with no JIT dependency -->
     <PublishAot>true</PublishAot>
     <!-- Trimming: full mode trims all assemblies (not just opt-in ones), aggressively


### PR DESCRIPTION
Fixes #1019

## Root cause
`az webapp deploy --async true` returns immediately — if Azure fails to apply the zip, CI shows green but the old binary stays live. The version stamp also relied on .NET SDK auto-appending SourceRevisionId, which is fragile.

## Changes
- **Remove `--async true`** from all 9 deploy commands across 7 workflow files — deploys now wait for Azure confirmation
- **Explicit version format**: `{major}.{date}.{build}+{sha7}` (was `V{major}.{date}.{build}` + SDK auto-SHA)
- **`IncludeSourceRevisionInInformationalVersion=false`** in Host.csproj — prevents SDK from double-appending the commit hash
- **Post-deploy version check** in deploy.yml — curls the app after deploy and verifies the footer shows the expected version