### PR TITLE
fix: deploy not applying new builds to Azure

### DIFF
--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -188,12 +188,18 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
+      - name: Ensure app runs from deployed files
+        run: |
+          az webapp config appsettings set --name baremetalweb --resource-group baremetalweb-rg \
+            --settings WEBSITE_RUN_FROM_PACKAGE=0 --output none
+
       - name: Deploy to baremetalweb (Canary / CI base)
         run: |
-          cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name baremetalweb --resource-group baremetalweb-rg --src-path ../deploy.zip --type zip
+          cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name baremetalweb --resource-group baremetalweb-rg --src-path ../deploy.zip --type zip --clean true
 
-      - name: Wait for deployment to stabilise
+      - name: Restart app
         run: |
+          az webapp restart --name baremetalweb --resource-group baremetalweb-rg
           echo "Waiting 30 s for app to start..."
           sleep 30
 
@@ -265,12 +271,18 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS_UPGRADE }}
 
+      - name: Ensure app runs from deployed files
+        run: |
+          az webapp config appsettings set --name baremetalweb-upgrade --resource-group baremetalweb-rg \
+            --settings WEBSITE_RUN_FROM_PACKAGE=0 --output none
+
       - name: Deploy to baremetalweb-upgrade (no data reset)
         run: |
-          cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name baremetalweb-upgrade --resource-group baremetalweb-rg --src-path ../deploy.zip --type zip
+          cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name baremetalweb-upgrade --resource-group baremetalweb-rg --src-path ../deploy.zip --type zip --clean true
 
-      - name: Wait for deployment to stabilise
+      - name: Restart app
         run: |
+          az webapp restart --name baremetalweb-upgrade --resource-group baremetalweb-rg
           echo "Waiting 30 s for app to start..."
           sleep 30
 
@@ -661,12 +673,18 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS_CANARY }}
 
+      - name: Ensure app runs from deployed files
+        run: |
+          az webapp config appsettings set --name baremetalweb-canary --resource-group baremetalweb-rg \
+            --settings WEBSITE_RUN_FROM_PACKAGE=0 --output none
+
       - name: Deploy to baremetalweb-canary (Ring 0)
         run: |
-          cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name baremetalweb-canary --resource-group baremetalweb-rg --src-path ../deploy.zip --type zip
+          cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name baremetalweb-canary --resource-group baremetalweb-rg --src-path ../deploy.zip --type zip --clean true
 
-      - name: Wait for deployment to stabilise
+      - name: Restart app
         run: |
+          az webapp restart --name baremetalweb-canary --resource-group baremetalweb-rg
           echo "Waiting 60 s for app to start..."
           sleep 60
 

--- a/.github/workflows/deploy-cimigrate.yml
+++ b/.github/workflows/deploy-cimigrate.yml
@@ -55,9 +55,17 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS_CIMIGRATE }}
 
+      - name: Ensure app runs from deployed files
+        run: |
+          az webapp config appsettings set --name baremetalweb-cimigrate --resource-group baremetalweb-rg \
+            --settings WEBSITE_RUN_FROM_PACKAGE=0 --output none
+
       - name: Deploy to Azure Web App
         run: |
-          cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name baremetalweb-cimigrate --resource-group baremetalweb-rg --src-path ../deploy.zip --type zip
+          cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name baremetalweb-cimigrate --resource-group baremetalweb-rg --src-path ../deploy.zip --type zip --clean true
+
+      - name: Restart app
+        run: az webapp restart --name baremetalweb-cimigrate --resource-group baremetalweb-rg
 
   integration-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-cireset.yml
+++ b/.github/workflows/deploy-cireset.yml
@@ -57,13 +57,19 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS_CIRESET }}
 
+      - name: Ensure app runs from deployed files
+        run: |
+          az webapp config appsettings set --name baremetalweb-cireset --resource-group baremetalweb-rg \
+            --settings WEBSITE_RUN_FROM_PACKAGE=0 --output none
+
       - name: Deploy to Azure Web App (CI Reset)
         run: |
-          cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name baremetalweb-cireset --resource-group baremetalweb-rg --src-path ../deploy.zip --type zip
+          cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name baremetalweb-cireset --resource-group baremetalweb-rg --src-path ../deploy.zip --type zip --clean true
 
-      - name: Wait for deployment to stabilize
+      - name: Restart app
         run: |
-          echo "Waiting 30 seconds for deployment to complete and app to start..."
+          az webapp restart --name baremetalweb-cireset --resource-group baremetalweb-rg
+          echo "Waiting 30 seconds for app to restart..."
           sleep 30
 
       - name: Setup Node.js

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -65,6 +65,14 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS_PROD }}
 
+      - name: Ensure app runs from deployed files
+        run: |
+          az webapp config appsettings set --name baremetalweb-prod --resource-group baremetalweb-rg \
+            --settings WEBSITE_RUN_FROM_PACKAGE=0 --output none
+
       - name: Deploy to Azure Web App
         run: |
-          cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name baremetalweb-prod --resource-group baremetalweb-rg --src-path ../deploy.zip --type zip
+          cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name baremetalweb-prod --resource-group baremetalweb-rg --src-path ../deploy.zip --type zip --clean true
+
+      - name: Restart app
+        run: az webapp restart --name baremetalweb-prod --resource-group baremetalweb-rg

--- a/.github/workflows/deploy-tenant.yml
+++ b/.github/workflows/deploy-tenant.yml
@@ -67,12 +67,18 @@ jobs:
         with:
           creds: ${{ secrets.azure-credentials }}
 
+      - name: Ensure app runs from deployed files
+        run: |
+          az webapp config appsettings set --name ${{ inputs.app-name }} --resource-group ${{ inputs.resource-group }} \
+            --settings WEBSITE_RUN_FROM_PACKAGE=0 --output none
+
       - name: Deploy to ${{ inputs.app-name }}
         run: |
-          cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name ${{ inputs.app-name }} --resource-group ${{ inputs.resource-group }} --src-path ../deploy.zip --type zip
+          cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name ${{ inputs.app-name }} --resource-group ${{ inputs.resource-group }} --src-path ../deploy.zip --type zip --clean true
 
-      - name: Wait for deployment to stabilise
+      - name: Restart app
         run: |
+          az webapp restart --name ${{ inputs.app-name }} --resource-group ${{ inputs.resource-group }}
           echo "Waiting 30 s for app to start..."
           sleep 30
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -203,12 +203,19 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
+      - name: Ensure app runs from deployed files (not cached package)
+        run: |
+          az webapp config appsettings set --name baremetalweb --resource-group baremetalweb-rg \
+            --settings WEBSITE_RUN_FROM_PACKAGE=0 --output none
+          echo "✓ WEBSITE_RUN_FROM_PACKAGE=0"
+
       - name: Deploy to Azure Web App
         run: |
-          cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name baremetalweb --resource-group baremetalweb-rg --src-path ../deploy.zip --type zip
+          cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name baremetalweb --resource-group baremetalweb-rg --src-path ../deploy.zip --type zip --clean true
 
-      - name: Wait for deployment to stabilize
+      - name: Restart app
         run: |
+          az webapp restart --name baremetalweb --resource-group baremetalweb-rg
           echo "Waiting 30 seconds for app to restart..."
           sleep 30
 

--- a/.github/workflows/reset-data-staging.yml
+++ b/.github/workflows/reset-data-staging.yml
@@ -54,6 +54,14 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
+      - name: Ensure app runs from deployed files
+        run: |
+          az webapp config appsettings set --name baremetalweb --resource-group baremetalweb-rg \
+            --settings WEBSITE_RUN_FROM_PACKAGE=0 --output none
+
       - name: Deploy to Azure Web App
         run: |
-          cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name baremetalweb --resource-group baremetalweb-rg --src-path ../deploy.zip --type zip
+          cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name baremetalweb --resource-group baremetalweb-rg --src-path ../deploy.zip --type zip --clean true
+
+      - name: Restart app
+        run: az webapp restart --name baremetalweb --resource-group baremetalweb-rg


### PR DESCRIPTION
Fixes #1019 (continued)

## Root cause
`az webapp up` (the old deploy command) sets `WEBSITE_RUN_FROM_PACKAGE=1`, which makes Azure App Service run from a cached read-only package mount. When we switched to `az webapp deploy --type zip` in PR #1000, the zip was extracted to `/home/site/wwwroot` but the app continued running from the old cached package — explaining why version `1.20260303.443` was stuck even after 100+ successful deploys.

## Fix (all 7 deploy workflows, 9 deploy sites)
1. **`WEBSITE_RUN_FROM_PACKAGE=0`** — clears the package-run mode before each deploy
2. **`--clean true`** — purges stale files from the target directory before extraction
3. **`az webapp restart`** — explicit restart after deploy to ensure the new binary loads

## Affected workflows
- deploy.yml (staging)
- deploy-prod.yml (production)
- deploy-cimigrate.yml (CI migrate)
- deploy-cireset.yml (CI reset)
- reset-data-staging.yml (staging reset)
- deploy-tenant.yml (reusable tenant deploy)
- ci-cd-pipeline.yml (L1.1-base, L1.1-upgrade, L2.1 canary)