### PR TITLE
fix: stop app before deploy to avoid Kudu 502

### DIFF
--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -188,18 +188,20 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-      - name: Ensure app runs from deployed files
+      - name: Stop app and clear package-run mode
         run: |
+          az webapp stop --name baremetalweb --resource-group baremetalweb-rg
           az webapp config appsettings set --name baremetalweb --resource-group baremetalweb-rg \
             --settings WEBSITE_RUN_FROM_PACKAGE=0 --output none
+          echo "✓ App stopped, WEBSITE_RUN_FROM_PACKAGE=0"
 
       - name: Deploy to baremetalweb (Canary / CI base)
         run: |
           cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name baremetalweb --resource-group baremetalweb-rg --src-path ../deploy.zip --type zip --clean true
 
-      - name: Restart app
+      - name: Start app
         run: |
-          az webapp restart --name baremetalweb --resource-group baremetalweb-rg
+          az webapp start --name baremetalweb --resource-group baremetalweb-rg
           echo "Waiting 30 s for app to start..."
           sleep 30
 
@@ -271,18 +273,20 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS_UPGRADE }}
 
-      - name: Ensure app runs from deployed files
+      - name: Stop app and clear package-run mode
         run: |
+          az webapp stop --name baremetalweb-upgrade --resource-group baremetalweb-rg
           az webapp config appsettings set --name baremetalweb-upgrade --resource-group baremetalweb-rg \
             --settings WEBSITE_RUN_FROM_PACKAGE=0 --output none
+          echo "✓ App stopped, WEBSITE_RUN_FROM_PACKAGE=0"
 
       - name: Deploy to baremetalweb-upgrade (no data reset)
         run: |
           cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name baremetalweb-upgrade --resource-group baremetalweb-rg --src-path ../deploy.zip --type zip --clean true
 
-      - name: Restart app
+      - name: Start app
         run: |
-          az webapp restart --name baremetalweb-upgrade --resource-group baremetalweb-rg
+          az webapp start --name baremetalweb-upgrade --resource-group baremetalweb-rg
           echo "Waiting 30 s for app to start..."
           sleep 30
 
@@ -673,18 +677,20 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS_CANARY }}
 
-      - name: Ensure app runs from deployed files
+      - name: Stop app and clear package-run mode
         run: |
+          az webapp stop --name baremetalweb-canary --resource-group baremetalweb-rg
           az webapp config appsettings set --name baremetalweb-canary --resource-group baremetalweb-rg \
             --settings WEBSITE_RUN_FROM_PACKAGE=0 --output none
+          echo "✓ App stopped, WEBSITE_RUN_FROM_PACKAGE=0"
 
       - name: Deploy to baremetalweb-canary (Ring 0)
         run: |
           cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name baremetalweb-canary --resource-group baremetalweb-rg --src-path ../deploy.zip --type zip --clean true
 
-      - name: Restart app
+      - name: Start app
         run: |
-          az webapp restart --name baremetalweb-canary --resource-group baremetalweb-rg
+          az webapp start --name baremetalweb-canary --resource-group baremetalweb-rg
           echo "Waiting 60 s for app to start..."
           sleep 60
 

--- a/.github/workflows/deploy-cimigrate.yml
+++ b/.github/workflows/deploy-cimigrate.yml
@@ -55,17 +55,19 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS_CIMIGRATE }}
 
-      - name: Ensure app runs from deployed files
+      - name: Stop app and clear package-run mode
         run: |
+          az webapp stop --name baremetalweb-cimigrate --resource-group baremetalweb-rg
           az webapp config appsettings set --name baremetalweb-cimigrate --resource-group baremetalweb-rg \
             --settings WEBSITE_RUN_FROM_PACKAGE=0 --output none
+          echo "✓ App stopped, WEBSITE_RUN_FROM_PACKAGE=0"
 
       - name: Deploy to Azure Web App
         run: |
           cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name baremetalweb-cimigrate --resource-group baremetalweb-rg --src-path ../deploy.zip --type zip --clean true
 
-      - name: Restart app
-        run: az webapp restart --name baremetalweb-cimigrate --resource-group baremetalweb-rg
+      - name: Start app
+        run: az webapp start --name baremetalweb-cimigrate --resource-group baremetalweb-rg
 
   integration-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-cireset.yml
+++ b/.github/workflows/deploy-cireset.yml
@@ -57,18 +57,20 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS_CIRESET }}
 
-      - name: Ensure app runs from deployed files
+      - name: Stop app and clear package-run mode
         run: |
+          az webapp stop --name baremetalweb-cireset --resource-group baremetalweb-rg
           az webapp config appsettings set --name baremetalweb-cireset --resource-group baremetalweb-rg \
             --settings WEBSITE_RUN_FROM_PACKAGE=0 --output none
+          echo "✓ App stopped, WEBSITE_RUN_FROM_PACKAGE=0"
 
       - name: Deploy to Azure Web App (CI Reset)
         run: |
           cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name baremetalweb-cireset --resource-group baremetalweb-rg --src-path ../deploy.zip --type zip --clean true
 
-      - name: Restart app
+      - name: Start app
         run: |
-          az webapp restart --name baremetalweb-cireset --resource-group baremetalweb-rg
+          az webapp start --name baremetalweb-cireset --resource-group baremetalweb-rg
           echo "Waiting 30 seconds for app to restart..."
           sleep 30
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -65,14 +65,16 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS_PROD }}
 
-      - name: Ensure app runs from deployed files
+      - name: Stop app and clear package-run mode
         run: |
+          az webapp stop --name baremetalweb-prod --resource-group baremetalweb-rg
           az webapp config appsettings set --name baremetalweb-prod --resource-group baremetalweb-rg \
             --settings WEBSITE_RUN_FROM_PACKAGE=0 --output none
+          echo "✓ App stopped, WEBSITE_RUN_FROM_PACKAGE=0"
 
       - name: Deploy to Azure Web App
         run: |
           cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name baremetalweb-prod --resource-group baremetalweb-rg --src-path ../deploy.zip --type zip --clean true
 
-      - name: Restart app
-        run: az webapp restart --name baremetalweb-prod --resource-group baremetalweb-rg
+      - name: Start app
+        run: az webapp start --name baremetalweb-prod --resource-group baremetalweb-rg

--- a/.github/workflows/deploy-tenant.yml
+++ b/.github/workflows/deploy-tenant.yml
@@ -67,18 +67,20 @@ jobs:
         with:
           creds: ${{ secrets.azure-credentials }}
 
-      - name: Ensure app runs from deployed files
+      - name: Stop app and clear package-run mode
         run: |
+          az webapp stop --name ${{ inputs.app-name }} --resource-group ${{ inputs.resource-group }}
           az webapp config appsettings set --name ${{ inputs.app-name }} --resource-group ${{ inputs.resource-group }} \
             --settings WEBSITE_RUN_FROM_PACKAGE=0 --output none
+          echo "✓ App stopped, WEBSITE_RUN_FROM_PACKAGE=0"
 
       - name: Deploy to ${{ inputs.app-name }}
         run: |
           cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name ${{ inputs.app-name }} --resource-group ${{ inputs.resource-group }} --src-path ../deploy.zip --type zip --clean true
 
-      - name: Restart app
+      - name: Start app
         run: |
-          az webapp restart --name ${{ inputs.app-name }} --resource-group ${{ inputs.resource-group }}
+          az webapp start --name ${{ inputs.app-name }} --resource-group ${{ inputs.resource-group }}
           echo "Waiting 30 s for app to start..."
           sleep 30
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -203,20 +203,21 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-      - name: Ensure app runs from deployed files (not cached package)
+      - name: Stop app and clear package-run mode
         run: |
+          az webapp stop --name baremetalweb --resource-group baremetalweb-rg
           az webapp config appsettings set --name baremetalweb --resource-group baremetalweb-rg \
             --settings WEBSITE_RUN_FROM_PACKAGE=0 --output none
-          echo "✓ WEBSITE_RUN_FROM_PACKAGE=0"
+          echo "✓ App stopped, WEBSITE_RUN_FROM_PACKAGE=0"
 
       - name: Deploy to Azure Web App
         run: |
           cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name baremetalweb --resource-group baremetalweb-rg --src-path ../deploy.zip --type zip --clean true
 
-      - name: Restart app
+      - name: Start app
         run: |
-          az webapp restart --name baremetalweb --resource-group baremetalweb-rg
-          echo "Waiting 30 seconds for app to restart..."
+          az webapp start --name baremetalweb --resource-group baremetalweb-rg
+          echo "Waiting 30 seconds for app to start..."
           sleep 30
 
       - name: Verify deployed version

--- a/.github/workflows/reset-data-staging.yml
+++ b/.github/workflows/reset-data-staging.yml
@@ -54,14 +54,16 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-      - name: Ensure app runs from deployed files
+      - name: Stop app and clear package-run mode
         run: |
+          az webapp stop --name baremetalweb --resource-group baremetalweb-rg
           az webapp config appsettings set --name baremetalweb --resource-group baremetalweb-rg \
             --settings WEBSITE_RUN_FROM_PACKAGE=0 --output none
+          echo "✓ App stopped, WEBSITE_RUN_FROM_PACKAGE=0"
 
       - name: Deploy to Azure Web App
         run: |
           cd ./publish && zip -qr ../deploy.zip . && az webapp deploy --name baremetalweb --resource-group baremetalweb-rg --src-path ../deploy.zip --type zip --clean true
 
-      - name: Restart app
-        run: az webapp restart --name baremetalweb --resource-group baremetalweb-rg
+      - name: Start app
+        run: az webapp start --name baremetalweb --resource-group baremetalweb-rg


### PR DESCRIPTION
Follow-up to #1024

PR #1024 set `WEBSITE_RUN_FROM_PACKAGE=0` before deploying, but changing an app setting triggers an app restart which makes Kudu temporarily unavailable — causing `az webapp deploy` to fail with HTTP 502.

**Fix:** Stop → Config → Deploy → Start

All 7 deploy workflows now follow this sequence:
1. `az webapp stop` — cleanly stops the app
2. `az webapp config appsettings set WEBSITE_RUN_FROM_PACKAGE=0` — disables package-run mode
3. `az webapp deploy --type zip --clean true` — deploys fresh files
4. `az webapp start` — starts the app with the new binary