### PR TITLE
fix: configure startup command for AOT binary on Azure App Service

### DIFF
--- a/.github/workflows/deploy-cimigrate.yml
+++ b/.github/workflows/deploy-cimigrate.yml
@@ -55,12 +55,14 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS_CIMIGRATE }}
 
-      - name: Stop app and clear package-run mode
+      - name: Stop app and configure for AOT binary
         run: |
           az webapp stop --name baremetalweb-cimigrate --resource-group baremetalweb-rg
           az webapp config appsettings set --name baremetalweb-cimigrate --resource-group baremetalweb-rg \
             --settings WEBSITE_RUN_FROM_PACKAGE=0 --output none
-          echo "✓ App stopped, WEBSITE_RUN_FROM_PACKAGE=0"
+          az webapp config set --name baremetalweb-cimigrate --resource-group baremetalweb-rg \
+            --startup-file "./BareMetalWeb.Host" --output none
+          echo "✓ App stopped, WEBSITE_RUN_FROM_PACKAGE=0, startup-file set"
 
       - name: Deploy to Azure Web App
         run: |

--- a/.github/workflows/deploy-cireset.yml
+++ b/.github/workflows/deploy-cireset.yml
@@ -57,12 +57,14 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS_CIRESET }}
 
-      - name: Stop app and clear package-run mode
+      - name: Stop app and configure for AOT binary
         run: |
           az webapp stop --name baremetalweb-cireset --resource-group baremetalweb-rg
           az webapp config appsettings set --name baremetalweb-cireset --resource-group baremetalweb-rg \
             --settings WEBSITE_RUN_FROM_PACKAGE=0 --output none
-          echo "✓ App stopped, WEBSITE_RUN_FROM_PACKAGE=0"
+          az webapp config set --name baremetalweb-cireset --resource-group baremetalweb-rg \
+            --startup-file "./BareMetalWeb.Host" --output none
+          echo "✓ App stopped, WEBSITE_RUN_FROM_PACKAGE=0, startup-file set"
 
       - name: Deploy to Azure Web App (CI Reset)
         run: |

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -65,12 +65,14 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS_PROD }}
 
-      - name: Stop app and clear package-run mode
+      - name: Stop app and configure for AOT binary
         run: |
           az webapp stop --name baremetalweb-prod --resource-group baremetalweb-rg
           az webapp config appsettings set --name baremetalweb-prod --resource-group baremetalweb-rg \
             --settings WEBSITE_RUN_FROM_PACKAGE=0 --output none
-          echo "✓ App stopped, WEBSITE_RUN_FROM_PACKAGE=0"
+          az webapp config set --name baremetalweb-prod --resource-group baremetalweb-rg \
+            --startup-file "./BareMetalWeb.Host" --output none
+          echo "✓ App stopped, WEBSITE_RUN_FROM_PACKAGE=0, startup-file set"
 
       - name: Deploy to Azure Web App
         run: |

--- a/.github/workflows/deploy-tenant.yml
+++ b/.github/workflows/deploy-tenant.yml
@@ -67,12 +67,14 @@ jobs:
         with:
           creds: ${{ secrets.azure-credentials }}
 
-      - name: Stop app and clear package-run mode
+      - name: Stop app and configure for AOT binary
         run: |
           az webapp stop --name ${{ inputs.app-name }} --resource-group ${{ inputs.resource-group }}
           az webapp config appsettings set --name ${{ inputs.app-name }} --resource-group ${{ inputs.resource-group }} \
             --settings WEBSITE_RUN_FROM_PACKAGE=0 --output none
-          echo "✓ App stopped, WEBSITE_RUN_FROM_PACKAGE=0"
+          az webapp config set --name ${{ inputs.app-name }} --resource-group ${{ inputs.resource-group }} \
+            --startup-file "./BareMetalWeb.Host" --output none
+          echo "✓ App stopped, WEBSITE_RUN_FROM_PACKAGE=0, startup-file set"
 
       - name: Deploy to ${{ inputs.app-name }}
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -203,12 +203,14 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-      - name: Stop app and clear package-run mode
+      - name: Stop app and configure for AOT binary
         run: |
           az webapp stop --name baremetalweb --resource-group baremetalweb-rg
           az webapp config appsettings set --name baremetalweb --resource-group baremetalweb-rg \
             --settings WEBSITE_RUN_FROM_PACKAGE=0 --output none
-          echo "✓ App stopped, WEBSITE_RUN_FROM_PACKAGE=0"
+          az webapp config set --name baremetalweb --resource-group baremetalweb-rg \
+            --startup-file "./BareMetalWeb.Host" --output none
+          echo "✓ App stopped, WEBSITE_RUN_FROM_PACKAGE=0, startup-file set"
 
       - name: Deploy to Azure Web App
         run: |


### PR DESCRIPTION
## Problem

Oryx cannot auto-detect the startup DLL when `PublishAot=true` because no `.runtimeconfig.json` is produced. This causes Azure App Service to fall back to the default hosting page on restart.

## Fix

Added `az webapp config set --startup-file ./BareMetalWeb.Host` before the deploy step in all 5 deployment workflows so Azure runs the native AOT binary directly.

**Affected workflows:** deploy.yml, deploy-prod.yml, deploy-tenant.yml, deploy-cireset.yml, deploy-cimigrate.yml

Fixes #1026
