### PR TITLE
feat: dictionary encoding + SIMD filtering (#911, #912)

### DIFF
--- a/BareMetalWeb.Data.Tests/DictionaryEncodedColumnTests.cs
+++ b/BareMetalWeb.Data.Tests/DictionaryEncodedColumnTests.cs
@@ -1,0 +1,461 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using BareMetalWeb.Data;
+using Xunit;
+
+namespace BareMetalWeb.Data.Tests;
+
+/// <summary>
+/// Tests for <see cref="DictionaryEncodedColumn{T}"/> (issue #911) and
+/// <see cref="DictionaryColumnFilter"/> (issue #912).
+///
+/// Structured as:
+///   1. Encoding basics — round-trip, cardinality, compression tier selection.
+///   2. Compression tiers — byte, ushort, int paths exercised explicitly.
+///   3. Decode correctness — output matches original input.
+///   4. SIMD FilterEquals — correctness against scalar reference.
+///   5. SIMD FilterNotEquals — inverse filter correctness.
+///   6. Multi-value FilterIn — set membership filter.
+///   7. Edge cases — empty, single value, all-unique.
+///   8. Large dataset — performance sanity (no explicit timing, just correctness at scale).
+/// </summary>
+public sealed class DictionaryEncodedColumnTests
+{
+    // ── 1. Encoding basics ────────────────────────────────────────────────
+
+    [Fact]
+    public void Encode_StringColumn_BuildsCorrectDictionary()
+    {
+        var input = new[] { "active", "active", "disabled", "active", "pending" };
+        var encoded = DictionaryEncodedColumn<string>.Encode(input);
+
+        Assert.Equal(3, encoded.Cardinality);
+        Assert.Equal(5, encoded.RowCount);
+        Assert.Contains("active", encoded.DictionaryValues);
+        Assert.Contains("disabled", encoded.DictionaryValues);
+        Assert.Contains("pending", encoded.DictionaryValues);
+    }
+
+    [Fact]
+    public void Encode_IntColumn_BuildsCorrectDictionary()
+    {
+        var input = new[] { 10, 20, 10, 30, 20, 10 };
+        var encoded = DictionaryEncodedColumn<int>.Encode(input);
+
+        Assert.Equal(3, encoded.Cardinality);
+        Assert.Equal(6, encoded.RowCount);
+    }
+
+    [Fact]
+    public void Encode_Decode_RoundTrip_RecoversOriginal()
+    {
+        var input = new[] { "active", "active", "disabled", "active", "pending" };
+        var encoded = DictionaryEncodedColumn<string>.Encode(input);
+
+        var output = new string[input.Length];
+        encoded.Decode(output);
+
+        Assert.Equal(input, output);
+    }
+
+    [Fact]
+    public void Encode_Decode_IntRoundTrip_RecoversOriginal()
+    {
+        var rng = new Random(42);
+        var input = Enumerable.Range(0, 1000).Select(_ => rng.Next(0, 50)).ToArray();
+        var encoded = DictionaryEncodedColumn<int>.Encode(input);
+
+        var output = new int[input.Length];
+        encoded.Decode(output);
+
+        Assert.Equal(input, output);
+    }
+
+    // ── 2. Compression tier selection ─────────────────────────────────────
+
+    [Fact]
+    public void Encode_LowCardinality_UsesByteTier()
+    {
+        // 10 unique values → byte tier
+        var input = Enumerable.Range(0, 500).Select(i => i % 10).ToArray();
+        var encoded = DictionaryEncodedColumn<int>.Encode(input);
+
+        Assert.Equal(DictionaryEncodedColumn<int>.IndexTier.Byte, encoded.Tier);
+        Assert.Equal(10, encoded.Cardinality);
+    }
+
+    [Fact]
+    public void Encode_Cardinality256_StillByteTier()
+    {
+        var input = Enumerable.Range(0, 1024).Select(i => i % 256).ToArray();
+        var encoded = DictionaryEncodedColumn<int>.Encode(input);
+
+        Assert.Equal(DictionaryEncodedColumn<int>.IndexTier.Byte, encoded.Tier);
+        Assert.Equal(256, encoded.Cardinality);
+    }
+
+    [Fact]
+    public void Encode_Cardinality257_UsesUShortTier()
+    {
+        var input = Enumerable.Range(0, 1024).Select(i => i % 257).ToArray();
+        var encoded = DictionaryEncodedColumn<int>.Encode(input);
+
+        Assert.Equal(DictionaryEncodedColumn<int>.IndexTier.UShort, encoded.Tier);
+        Assert.Equal(257, encoded.Cardinality);
+    }
+
+    [Fact]
+    public void Encode_HighCardinality_UsesIntTier()
+    {
+        // 70,000 unique values → int tier
+        var input = Enumerable.Range(0, 70_000).ToArray();
+        var encoded = DictionaryEncodedColumn<int>.Encode(input);
+
+        Assert.Equal(DictionaryEncodedColumn<int>.IndexTier.Int, encoded.Tier);
+        Assert.Equal(70_000, encoded.Cardinality);
+    }
+
+    [Fact]
+    public void Encode_UShortTier_RoundTrip()
+    {
+        // 300 unique values → ushort tier
+        var input = Enumerable.Range(0, 2000).Select(i => i % 300).ToArray();
+        var encoded = DictionaryEncodedColumn<int>.Encode(input);
+
+        Assert.Equal(DictionaryEncodedColumn<int>.IndexTier.UShort, encoded.Tier);
+
+        var output = new int[input.Length];
+        encoded.Decode(output);
+        Assert.Equal(input, output);
+    }
+
+    // ── 3. GetEncodedIndexesAsInt ──────────────────────────────────────────
+
+    [Fact]
+    public void GetEncodedIndexesAsInt_ProducesConsistentCodes()
+    {
+        var input = new[] { "active", "active", "disabled", "active", "pending" };
+        var encoded = DictionaryEncodedColumn<string>.Encode(input);
+
+        var indexes = new int[input.Length];
+        encoded.GetEncodedIndexesAsInt(indexes);
+
+        // Same values should have same codes
+        Assert.Equal(indexes[0], indexes[1]); // both "active"
+        Assert.Equal(indexes[0], indexes[3]); // both "active"
+        Assert.NotEqual(indexes[0], indexes[2]); // "active" != "disabled"
+        Assert.NotEqual(indexes[2], indexes[4]); // "disabled" != "pending"
+    }
+
+    [Fact]
+    public void GetEncodedIndexesAsInt_AllTiers_DecodeToSameValues()
+    {
+        // Byte tier
+        var byteTier = DictionaryEncodedColumn<int>.Encode(new[] { 1, 2, 1, 3 });
+        var byteIdx = new int[4];
+        byteTier.GetEncodedIndexesAsInt(byteIdx);
+        for (int i = 0; i < 4; i++)
+            Assert.Equal(byteTier.DictionaryValues[byteIdx[i]], new[] { 1, 2, 1, 3 }[i]);
+    }
+
+    // ── 4. SIMD FilterEquals ──────────────────────────────────────────────
+
+    [Fact]
+    public void FilterEquals_MatchesScalarReference()
+    {
+        var input = Enumerable.Range(0, 1024).Select(i => i % 5).ToArray();
+        var encoded = DictionaryEncodedColumn<int>.Encode(input);
+
+        var indexes = new int[input.Length];
+        encoded.GetEncodedIndexesAsInt(indexes);
+
+        int targetValue = 3;
+        int targetCode = encoded.LookupCode(targetValue);
+        Assert.True(targetCode >= 0);
+
+        var simdOutput = new int[input.Length];
+        int simdCount = DictionaryColumnFilter.FilterEquals(indexes, targetCode, simdOutput);
+
+        // Scalar reference
+        var scalarMatches = new List<int>();
+        for (int i = 0; i < input.Length; i++)
+            if (input[i] == targetValue)
+                scalarMatches.Add(i);
+
+        Assert.Equal(scalarMatches.Count, simdCount);
+        for (int i = 0; i < simdCount; i++)
+            Assert.Equal(scalarMatches[i], simdOutput[i]);
+    }
+
+    [Fact]
+    public void FilterEquals_StringColumn_CorrectResults()
+    {
+        var statuses = new[] { "active", "disabled", "pending" };
+        var rng = new Random(99);
+        var input = Enumerable.Range(0, 2048).Select(_ => statuses[rng.Next(3)]).ToArray();
+
+        var encoded = DictionaryEncodedColumn<string>.Encode(input);
+        var indexes = new int[input.Length];
+        encoded.GetEncodedIndexesAsInt(indexes);
+
+        int activeCode = encoded.LookupCode("active");
+        var output = new int[input.Length];
+        int count = DictionaryColumnFilter.FilterEquals(indexes, activeCode, output);
+
+        int expected = input.Count(s => s == "active");
+        Assert.Equal(expected, count);
+        for (int i = 0; i < count; i++)
+            Assert.Equal("active", input[output[i]]);
+    }
+
+    [Fact]
+    public void FilterEquals_NoMatches_ReturnsZero()
+    {
+        var input = new[] { 1, 2, 3, 4, 5 };
+        var encoded = DictionaryEncodedColumn<int>.Encode(input);
+        var indexes = new int[input.Length];
+        encoded.GetEncodedIndexesAsInt(indexes);
+
+        int missingCode = encoded.LookupCode(99);
+        Assert.Equal(-1, missingCode);
+
+        // Filtering for code -1 should return nothing
+        var output = new int[input.Length];
+        int count = DictionaryColumnFilter.FilterEquals(indexes, -1, output);
+        Assert.Equal(0, count);
+    }
+
+    [Fact]
+    public void FilterEquals_AllMatch_ReturnsAllIndexes()
+    {
+        var input = Enumerable.Repeat(42, 512).ToArray();
+        var encoded = DictionaryEncodedColumn<int>.Encode(input);
+        var indexes = new int[input.Length];
+        encoded.GetEncodedIndexesAsInt(indexes);
+
+        int code = encoded.LookupCode(42);
+        var output = new int[input.Length];
+        int count = DictionaryColumnFilter.FilterEquals(indexes, code, output);
+
+        Assert.Equal(512, count);
+        for (int i = 0; i < count; i++)
+            Assert.Equal(i, output[i]);
+    }
+
+    // ── 5. SIMD FilterNotEquals ───────────────────────────────────────────
+
+    [Fact]
+    public void FilterNotEquals_MatchesScalarReference()
+    {
+        var input = Enumerable.Range(0, 1024).Select(i => i % 7).ToArray();
+        var encoded = DictionaryEncodedColumn<int>.Encode(input);
+        var indexes = new int[input.Length];
+        encoded.GetEncodedIndexesAsInt(indexes);
+
+        int excludeValue = 2;
+        int excludeCode = encoded.LookupCode(excludeValue);
+
+        var simdOutput = new int[input.Length];
+        int simdCount = DictionaryColumnFilter.FilterNotEquals(indexes, excludeCode, simdOutput);
+
+        var scalarMatches = new List<int>();
+        for (int i = 0; i < input.Length; i++)
+            if (input[i] != excludeValue)
+                scalarMatches.Add(i);
+
+        Assert.Equal(scalarMatches.Count, simdCount);
+        for (int i = 0; i < simdCount; i++)
+            Assert.Equal(scalarMatches[i], simdOutput[i]);
+    }
+
+    // ── 6. Multi-value FilterIn ───────────────────────────────────────────
+
+    [Fact]
+    public void FilterIn_MultipleValues_ReturnsUnion()
+    {
+        var input = Enumerable.Range(0, 1024).Select(i => i % 10).ToArray();
+        var encoded = DictionaryEncodedColumn<int>.Encode(input);
+        var indexes = new int[input.Length];
+        encoded.GetEncodedIndexesAsInt(indexes);
+
+        int code2 = encoded.LookupCode(2);
+        int code5 = encoded.LookupCode(5);
+        int code8 = encoded.LookupCode(8);
+
+        var output = new int[input.Length];
+        int count = DictionaryColumnFilter.FilterIn(indexes, new[] { code2, code5, code8 }, output);
+
+        int expected = input.Count(v => v == 2 || v == 5 || v == 8);
+        Assert.Equal(expected, count);
+        for (int i = 0; i < count; i++)
+        {
+            int val = input[output[i]];
+            Assert.True(val == 2 || val == 5 || val == 8);
+        }
+    }
+
+    // ── 7. Edge cases ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void Encode_Empty_ProducesEmptyColumn()
+    {
+        var encoded = DictionaryEncodedColumn<string>.Encode(ReadOnlySpan<string>.Empty);
+
+        Assert.Equal(0, encoded.Cardinality);
+        Assert.Equal(0, encoded.RowCount);
+        Assert.Equal(DictionaryEncodedColumn<string>.IndexTier.Byte, encoded.Tier);
+    }
+
+    [Fact]
+    public void Encode_SingleValue_CardinalityOne()
+    {
+        var input = Enumerable.Repeat("only", 100).ToArray();
+        var encoded = DictionaryEncodedColumn<string>.Encode(input);
+
+        Assert.Equal(1, encoded.Cardinality);
+        Assert.Equal(DictionaryEncodedColumn<string>.IndexTier.Byte, encoded.Tier);
+
+        var output = new string[100];
+        encoded.Decode(output);
+        Assert.All(output, v => Assert.Equal("only", v));
+    }
+
+    [Fact]
+    public void Encode_AllUnique_CardinalityEqualsRowCount()
+    {
+        var input = Enumerable.Range(0, 200).Select(i => $"val_{i}").ToArray();
+        var encoded = DictionaryEncodedColumn<string>.Encode(input);
+
+        Assert.Equal(200, encoded.Cardinality);
+        Assert.Equal(200, encoded.RowCount);
+    }
+
+    [Fact]
+    public void LookupCode_ExistingValue_ReturnsCode()
+    {
+        var input = new[] { "a", "b", "c" };
+        var encoded = DictionaryEncodedColumn<string>.Encode(input);
+
+        Assert.True(encoded.LookupCode("a") >= 0);
+        Assert.True(encoded.LookupCode("b") >= 0);
+        Assert.True(encoded.LookupCode("c") >= 0);
+    }
+
+    [Fact]
+    public void LookupCode_MissingValue_ReturnsNegativeOne()
+    {
+        var input = new[] { "a", "b", "c" };
+        var encoded = DictionaryEncodedColumn<string>.Encode(input);
+
+        Assert.Equal(-1, encoded.LookupCode("missing"));
+    }
+
+    [Fact]
+    public void Decode_OutputTooSmall_Throws()
+    {
+        var input = new[] { 1, 2, 3 };
+        var encoded = DictionaryEncodedColumn<int>.Encode(input);
+
+        Assert.Throws<ArgumentException>(() => encoded.Decode(new int[2]));
+    }
+
+    [Fact]
+    public void GetEncodedIndexesAsInt_OutputTooSmall_Throws()
+    {
+        var input = new[] { 1, 2, 3 };
+        var encoded = DictionaryEncodedColumn<int>.Encode(input);
+
+        Assert.Throws<ArgumentException>(() => encoded.GetEncodedIndexesAsInt(new int[2]));
+    }
+
+    // ── 8. Large dataset correctness ──────────────────────────────────────
+
+    [Fact]
+    public void FilterEquals_LargeDataset_CorrectResults()
+    {
+        // 1M rows with 20 unique values → exercises SIMD hot path extensively
+        int rowCount = 1_000_000;
+        var rng = new Random(123);
+        var input = new int[rowCount];
+        for (int i = 0; i < rowCount; i++) input[i] = rng.Next(0, 20);
+
+        var encoded = DictionaryEncodedColumn<int>.Encode(input);
+        Assert.Equal(20, encoded.Cardinality);
+        Assert.Equal(DictionaryEncodedColumn<int>.IndexTier.Byte, encoded.Tier);
+
+        var indexes = new int[rowCount];
+        encoded.GetEncodedIndexesAsInt(indexes);
+
+        int targetValue = 7;
+        int targetCode = encoded.LookupCode(targetValue);
+
+        var output = new int[rowCount];
+        int count = DictionaryColumnFilter.FilterEquals(indexes, targetCode, output);
+
+        int expected = input.Count(v => v == targetValue);
+        Assert.Equal(expected, count);
+
+        // Verify all matches are correct
+        for (int i = 0; i < count; i++)
+            Assert.Equal(targetValue, input[output[i]]);
+    }
+
+    [Fact]
+    public void FilterNotEquals_LargeDataset_CorrectResults()
+    {
+        int rowCount = 100_000;
+        var rng = new Random(456);
+        var input = new int[rowCount];
+        for (int i = 0; i < rowCount; i++) input[i] = rng.Next(0, 5);
+
+        var encoded = DictionaryEncodedColumn<int>.Encode(input);
+        var indexes = new int[rowCount];
+        encoded.GetEncodedIndexesAsInt(indexes);
+
+        int excludeCode = encoded.LookupCode(3);
+        var output = new int[rowCount];
+        int count = DictionaryColumnFilter.FilterNotEquals(indexes, excludeCode, output);
+
+        int expected = input.Count(v => v != 3);
+        Assert.Equal(expected, count);
+    }
+
+    [Fact]
+    public void Encode_Decode_LargeDataset_RoundTrip()
+    {
+        int rowCount = 500_000;
+        var rng = new Random(789);
+        var input = new string[rowCount];
+        var vals = new[] { "alpha", "beta", "gamma", "delta", "epsilon" };
+        for (int i = 0; i < rowCount; i++) input[i] = vals[rng.Next(vals.Length)];
+
+        var encoded = DictionaryEncodedColumn<string>.Encode(input);
+        Assert.Equal(5, encoded.Cardinality);
+
+        var output = new string[rowCount];
+        encoded.Decode(output);
+
+        for (int i = 0; i < rowCount; i++)
+            Assert.Equal(input[i], output[i]);
+    }
+
+    [Fact]
+    public void FilterEquals_NonAligned_CorrectResults()
+    {
+        // 1023 rows: not evenly divisible by 8 (AVX2 lane count)
+        var input = Enumerable.Range(0, 1023).Select(i => i % 3).ToArray();
+        var encoded = DictionaryEncodedColumn<int>.Encode(input);
+        var indexes = new int[input.Length];
+        encoded.GetEncodedIndexesAsInt(indexes);
+
+        int code1 = encoded.LookupCode(1);
+        var output = new int[input.Length];
+        int count = DictionaryColumnFilter.FilterEquals(indexes, code1, output);
+
+        int expected = input.Count(v => v == 1);
+        Assert.Equal(expected, count);
+        for (int i = 0; i < count; i++)
+            Assert.Equal(1, input[output[i]]);
+    }
+}

--- a/BareMetalWeb.Data/DictionaryColumnFilter.cs
+++ b/BareMetalWeb.Data/DictionaryColumnFilter.cs
@@ -1,0 +1,272 @@
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+
+namespace BareMetalWeb.Data;
+
+/// <summary>
+/// SIMD-accelerated filtering over dictionary-encoded integer index columns.
+///
+/// <para>Filters compare encoded dictionary indexes (small ints) instead of full values,
+/// enabling tens of millions of rows per second throughput.</para>
+///
+/// <para>Pipeline tiers:
+///   1. <b>AVX2</b> — 8 × int32 per cycle via <c>Avx2.CompareEqual</c> + <c>Avx2.MoveMask</c>
+///   2. <b>Portable SIMD</b> — <c>Vector&lt;int&gt;</c> fallback (width auto-detected)
+///   3. <b>Scalar</b> — branchless loop for platforms without hardware SIMD
+/// </para>
+/// </summary>
+public static class DictionaryColumnFilter
+{
+    /// <summary>
+    /// Scans <paramref name="encodedColumn"/> for entries equal to <paramref name="dictionaryIndex"/>
+    /// and writes matching row positions into <paramref name="outputIndexes"/>.
+    /// Returns the number of matches written.
+    ///
+    /// <para>Uses AVX2 when available (8 ints per cycle), then falls back to portable
+    /// <c>Vector&lt;int&gt;</c>, then scalar loop.</para>
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int FilterEquals(
+        ReadOnlySpan<int> encodedColumn,
+        int dictionaryIndex,
+        Span<int> outputIndexes)
+    {
+        if (Avx2.IsSupported)
+            return FilterEqualsAvx2(encodedColumn, dictionaryIndex, outputIndexes);
+
+        if (Vector.IsHardwareAccelerated && Vector<int>.Count >= 4)
+            return FilterEqualsVector(encodedColumn, dictionaryIndex, outputIndexes);
+
+        return FilterEqualsScalar(encodedColumn, dictionaryIndex, outputIndexes);
+    }
+
+    /// <summary>
+    /// Scans for entries NOT equal to <paramref name="dictionaryIndex"/>.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int FilterNotEquals(
+        ReadOnlySpan<int> encodedColumn,
+        int dictionaryIndex,
+        Span<int> outputIndexes)
+    {
+        if (Avx2.IsSupported)
+            return FilterNotEqualsAvx2(encodedColumn, dictionaryIndex, outputIndexes);
+
+        if (Vector.IsHardwareAccelerated && Vector<int>.Count >= 4)
+            return FilterNotEqualsVector(encodedColumn, dictionaryIndex, outputIndexes);
+
+        return FilterNotEqualsScalar(encodedColumn, dictionaryIndex, outputIndexes);
+    }
+
+    /// <summary>
+    /// Multi-value IN filter: matches rows whose encoded index is in <paramref name="dictionaryIndexes"/>.
+    /// </summary>
+    public static int FilterIn(
+        ReadOnlySpan<int> encodedColumn,
+        ReadOnlySpan<int> dictionaryIndexes,
+        Span<int> outputIndexes)
+    {
+        // Build a fast lookup set; for small cardinalities a bitmask is ideal.
+        int maxIdx = 0;
+        for (int i = 0; i < dictionaryIndexes.Length; i++)
+            if (dictionaryIndexes[i] > maxIdx) maxIdx = dictionaryIndexes[i];
+
+        // Use a bit-set for cardinalities that fit in a ulong or small ulong[].
+        int words = (maxIdx >> 6) + 1;
+        Span<ulong> bitSet = words <= 16 ? stackalloc ulong[words] : new ulong[words];
+        bitSet.Clear();
+        for (int i = 0; i < dictionaryIndexes.Length; i++)
+        {
+            int idx = dictionaryIndexes[i];
+            bitSet[idx >> 6] |= 1UL << (idx & 63);
+        }
+
+        int count = 0;
+        for (int i = 0; i < encodedColumn.Length; i++)
+        {
+            int code = encodedColumn[i];
+            int word = code >> 6;
+            if (word < bitSet.Length && (bitSet[word] & (1UL << (code & 63))) != 0)
+                outputIndexes[count++] = i;
+        }
+        return count;
+    }
+
+    // ── AVX2 path: 8 × int32 per iteration ─────────────────────────────────
+
+    private static unsafe int FilterEqualsAvx2(
+        ReadOnlySpan<int> encodedColumn,
+        int dictionaryIndex,
+        Span<int> outputIndexes)
+    {
+        int n = encodedColumn.Length;
+        int count = 0;
+
+        // Broadcast the target dictionary index into all 8 lanes of a 256-bit register.
+        Vector256<int> target = Vector256.Create(dictionaryIndex);
+
+        int i = 0;
+        fixed (int* pCol = encodedColumn)
+        {
+            // Process 8 ints per iteration using AVX2.
+            for (; i <= n - 8; i += 8)
+            {
+                // Load 8 encoded indexes from column.
+                Vector256<int> chunk = Avx.LoadVector256(pCol + i);
+
+                // Compare each lane: produces -1 (all bits set) on match, 0 otherwise.
+                Vector256<int> cmp = Avx2.CompareEqual(chunk, target);
+
+                // Extract the top bit of each 32-bit lane into an 8-bit mask.
+                int mask = Avx2.MoveMask(cmp.AsByte());
+
+                // Each matching 32-bit lane contributes 4 set bits (0xF) in the byte mask.
+                // Walk set bits in 4-bit strides.
+                while (mask != 0)
+                {
+                    int bit = BitOperations.TrailingZeroCount(mask);
+                    int lane = bit >> 2; // each lane is 4 bytes wide
+                    outputIndexes[count++] = i + lane;
+                    mask &= ~(0xF << (lane << 2)); // clear all 4 bits for this lane
+                }
+            }
+        }
+
+        // Scalar tail for remaining elements.
+        for (; i < n; i++)
+            if (encodedColumn[i] == dictionaryIndex)
+                outputIndexes[count++] = i;
+
+        return count;
+    }
+
+    private static unsafe int FilterNotEqualsAvx2(
+        ReadOnlySpan<int> encodedColumn,
+        int dictionaryIndex,
+        Span<int> outputIndexes)
+    {
+        int n = encodedColumn.Length;
+        int count = 0;
+        Vector256<int> target = Vector256.Create(dictionaryIndex);
+
+        int i = 0;
+        fixed (int* pCol = encodedColumn)
+        {
+            for (; i <= n - 8; i += 8)
+            {
+                Vector256<int> chunk = Avx.LoadVector256(pCol + i);
+                // Invert equals to get not-equals.
+                Vector256<int> cmp = Avx2.AndNot(
+                    Avx2.CompareEqual(chunk, target),
+                    Vector256.Create(-1));
+                int mask = Avx2.MoveMask(cmp.AsByte());
+
+                while (mask != 0)
+                {
+                    int bit = BitOperations.TrailingZeroCount(mask);
+                    int lane = bit >> 2;
+                    outputIndexes[count++] = i + lane;
+                    mask &= ~(0xF << (lane << 2));
+                }
+            }
+        }
+
+        for (; i < n; i++)
+            if (encodedColumn[i] != dictionaryIndex)
+                outputIndexes[count++] = i;
+
+        return count;
+    }
+
+    // ── Portable Vector<int> path ──────────────────────────────────────────
+
+    private static int FilterEqualsVector(
+        ReadOnlySpan<int> encodedColumn,
+        int dictionaryIndex,
+        Span<int> outputIndexes)
+    {
+        int n = encodedColumn.Length;
+        int count = 0;
+        int vLen = Vector<int>.Count;
+        var targetVec = new Vector<int>(dictionaryIndex);
+
+        int[] temp = new int[n];
+        encodedColumn.CopyTo(temp);
+
+        int i = 0;
+        for (; i <= n - vLen; i += vLen)
+        {
+            var chunk = new Vector<int>(temp, i);
+            var cmp = Vector.Equals(chunk, targetVec);
+
+            for (int j = 0; j < vLen; j++)
+                if (cmp[j] != 0)
+                    outputIndexes[count++] = i + j;
+        }
+
+        for (; i < n; i++)
+            if (encodedColumn[i] == dictionaryIndex)
+                outputIndexes[count++] = i;
+
+        return count;
+    }
+
+    private static int FilterNotEqualsVector(
+        ReadOnlySpan<int> encodedColumn,
+        int dictionaryIndex,
+        Span<int> outputIndexes)
+    {
+        int n = encodedColumn.Length;
+        int count = 0;
+        int vLen = Vector<int>.Count;
+        var targetVec = new Vector<int>(dictionaryIndex);
+
+        int[] temp = new int[n];
+        encodedColumn.CopyTo(temp);
+
+        int i = 0;
+        for (; i <= n - vLen; i += vLen)
+        {
+            var chunk = new Vector<int>(temp, i);
+            var cmp = Vector.OnesComplement(Vector.Equals(chunk, targetVec));
+
+            for (int j = 0; j < vLen; j++)
+                if (cmp[j] != 0)
+                    outputIndexes[count++] = i + j;
+        }
+
+        for (; i < n; i++)
+            if (encodedColumn[i] != dictionaryIndex)
+                outputIndexes[count++] = i;
+
+        return count;
+    }
+
+    // ── Scalar fallback ────────────────────────────────────────────────────
+
+    private static int FilterEqualsScalar(
+        ReadOnlySpan<int> encodedColumn,
+        int dictionaryIndex,
+        Span<int> outputIndexes)
+    {
+        int count = 0;
+        for (int i = 0; i < encodedColumn.Length; i++)
+            if (encodedColumn[i] == dictionaryIndex)
+                outputIndexes[count++] = i;
+        return count;
+    }
+
+    private static int FilterNotEqualsScalar(
+        ReadOnlySpan<int> encodedColumn,
+        int dictionaryIndex,
+        Span<int> outputIndexes)
+    {
+        int count = 0;
+        for (int i = 0; i < encodedColumn.Length; i++)
+            if (encodedColumn[i] != dictionaryIndex)
+                outputIndexes[count++] = i;
+        return count;
+    }
+}

--- a/BareMetalWeb.Data/DictionaryEncodedColumn.cs
+++ b/BareMetalWeb.Data/DictionaryEncodedColumn.cs
@@ -1,0 +1,167 @@
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+namespace BareMetalWeb.Data;
+
+/// <summary>
+/// Dictionary-encodes a column of repeated values into a compact dictionary + index array.
+/// Reduces memory footprint and enables SIMD filtering via integer index comparison
+/// instead of full value comparison.
+///
+/// <para>Compression tiers based on cardinality:
+///   ≤ 256 unique values  → indexes stored as <c>byte[]</c>
+///   ≤ 65 535              → indexes stored as <c>ushort[]</c>
+///   otherwise             → indexes stored as <c>int[]</c>
+/// </para>
+/// </summary>
+public sealed class DictionaryEncodedColumn<T> where T : notnull
+{
+    /// <summary>Unique values; index position is the dictionary code.</summary>
+    public T[] DictionaryValues { get; }
+
+    /// <summary>Number of unique values in the dictionary.</summary>
+    public int Cardinality => DictionaryValues.Length;
+
+    /// <summary>Number of rows encoded.</summary>
+    public int RowCount { get; }
+
+    // Exactly one of these is non-null, depending on cardinality.
+    private readonly byte[]?   _byteIndexes;
+    private readonly ushort[]? _ushortIndexes;
+    private readonly int[]?    _intIndexes;
+
+    /// <summary>Active compression tier for diagnostics.</summary>
+    public IndexTier Tier { get; }
+
+    public enum IndexTier : byte { Byte = 1, UShort = 2, Int = 4 }
+
+    private DictionaryEncodedColumn(
+        T[] dictionaryValues,
+        int rowCount,
+        byte[]? byteIndexes,
+        ushort[]? ushortIndexes,
+        int[]? intIndexes,
+        IndexTier tier)
+    {
+        DictionaryValues = dictionaryValues;
+        RowCount         = rowCount;
+        _byteIndexes     = byteIndexes;
+        _ushortIndexes   = ushortIndexes;
+        _intIndexes      = intIndexes;
+        Tier             = tier;
+    }
+
+    /// <summary>
+    /// Encodes <paramref name="input"/> into a dictionary + compressed index array.
+    /// Single-pass: builds dictionary and indexes simultaneously.
+    /// </summary>
+    public static DictionaryEncodedColumn<T> Encode(ReadOnlySpan<T> input)
+    {
+        int n = input.Length;
+        if (n == 0)
+            return new DictionaryEncodedColumn<T>([], 0, [], null, null, IndexTier.Byte);
+
+        // Pre-size dictionary: heuristic cap at input length (worst case: all unique).
+        var lookup = new Dictionary<T, int>(Math.Min(n, 4096));
+        var tempIndexes = new int[n];
+        var values = new List<T>(Math.Min(n, 256));
+
+        for (int i = 0; i < n; i++)
+        {
+            T val = input[i];
+            if (!lookup.TryGetValue(val, out int code))
+            {
+                code = values.Count;
+                lookup[val] = code;
+                values.Add(val);
+            }
+            tempIndexes[i] = code;
+        }
+
+        T[] dict = values.ToArray();
+        int cardinality = dict.Length;
+
+        // Select compression tier and copy indexes into the smallest array type.
+        if (cardinality <= 256)
+        {
+            var indexes = new byte[n];
+            for (int i = 0; i < n; i++) indexes[i] = (byte)tempIndexes[i];
+            return new DictionaryEncodedColumn<T>(dict, n, indexes, null, null, IndexTier.Byte);
+        }
+        if (cardinality <= 65_535)
+        {
+            var indexes = new ushort[n];
+            for (int i = 0; i < n; i++) indexes[i] = (ushort)tempIndexes[i];
+            return new DictionaryEncodedColumn<T>(dict, n, null, indexes, null, IndexTier.UShort);
+        }
+        return new DictionaryEncodedColumn<T>(dict, n, null, null, tempIndexes, IndexTier.Int);
+    }
+
+    /// <summary>
+    /// Reconstructs the original column from dictionary + indexes.
+    /// </summary>
+    public void Decode(Span<T> output)
+    {
+        if (output.Length < RowCount)
+            throw new ArgumentException($"Output span too small: need {RowCount}, got {output.Length}");
+
+        switch (Tier)
+        {
+            case IndexTier.Byte:
+                for (int i = 0; i < RowCount; i++) output[i] = DictionaryValues[_byteIndexes![i]];
+                break;
+            case IndexTier.UShort:
+                for (int i = 0; i < RowCount; i++) output[i] = DictionaryValues[_ushortIndexes![i]];
+                break;
+            case IndexTier.Int:
+                for (int i = 0; i < RowCount; i++) output[i] = DictionaryValues[_intIndexes![i]];
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Copies encoded indexes into <paramref name="output"/> as <c>int[]</c>,
+    /// suitable for SIMD filtering via <see cref="DictionaryColumnFilter.FilterEquals"/>.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void GetEncodedIndexesAsInt(Span<int> output)
+    {
+        if (output.Length < RowCount)
+            throw new ArgumentException($"Output span too small: need {RowCount}, got {output.Length}");
+
+        switch (Tier)
+        {
+            case IndexTier.Byte:
+                for (int i = 0; i < RowCount; i++) output[i] = _byteIndexes![i];
+                break;
+            case IndexTier.UShort:
+                for (int i = 0; i < RowCount; i++) output[i] = _ushortIndexes![i];
+                break;
+            case IndexTier.Int:
+                _intIndexes.AsSpan(0, RowCount).CopyTo(output);
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Returns a <see cref="ReadOnlySpan{Int32}"/> over the raw int indexes
+    /// (only available when <see cref="Tier"/> is <see cref="IndexTier.Int"/>).
+    /// For byte/ushort tiers, use <see cref="GetEncodedIndexesAsInt"/> instead.
+    /// </summary>
+    public ReadOnlySpan<int> RawIntIndexes =>
+        Tier == IndexTier.Int ? _intIndexes.AsSpan(0, RowCount) : default;
+
+    /// <summary>
+    /// Looks up the dictionary code for <paramref name="value"/>.
+    /// Returns -1 if the value is not in the dictionary.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public int LookupCode(T value)
+    {
+        var dict = DictionaryValues;
+        for (int i = 0; i < dict.Length; i++)
+            if (EqualityComparer<T>.Default.Equals(dict[i], value))
+                return i;
+        return -1;
+    }
+}


### PR DESCRIPTION
Implements #911 and #912.

**DictionaryEncodedColumn<T>** - Single-pass Encode with auto-compressed index arrays (byte/ushort/int tiers), Decode, LookupCode, GetEncodedIndexesAsInt.

**DictionaryColumnFilter** - 3-tier SIMD: AVX2 (8 ints/cycle), portable Vector<int>, scalar fallback. FilterEquals, FilterNotEquals, FilterIn.

**28 xUnit tests** - round-trip, tier selection, SIMD vs scalar, edge cases, 1M-row validation.

Closes #911
Closes #912