### PR TITLE
feat: record comments / chat thread

### DIFF
--- a/BareMetalWeb.Core/Interfaces/IRouteHandlers.cs
+++ b/BareMetalWeb.Core/Interfaces/IRouteHandlers.cs
@@ -87,4 +87,8 @@ public interface IRouteHandlers
     ValueTask AttachmentsDownloadHandler(BmwContext context);
     ValueTask AttachmentsDeleteHandler(BmwContext context);
     ValueTask AttachmentsVersionsHandler(BmwContext context);
+    ValueTask CommentsListHandler(BmwContext context);
+    ValueTask CommentsAddHandler(BmwContext context);
+    ValueTask CommentsEditHandler(BmwContext context);
+    ValueTask CommentsDeleteHandler(BmwContext context);
 }

--- a/BareMetalWeb.Core/wwwroot/static/js/vnext-app.js
+++ b/BareMetalWeb.Core/wwwroot/static/js/vnext-app.js
@@ -2675,6 +2675,21 @@
         html += '<div id="bm-attachments-body"><div class="text-muted small"><i class="bi bi-hourglass-split me-1"></i>Loading attachments\u2026</div></div>';
         html += '</div></div>';
 
+        // Comments panel — Slack-style chat thread on every record
+        html += '<div class="card bm-page-card mt-3" id="bm-comments-card">';
+        html += '<div class="card-header d-flex align-items-center justify-content-between">';
+        html += '<h6 class="mb-0"><i class="bi bi-chat-dots me-2"></i>Comments</h6>';
+        html += '<span class="badge bg-secondary" id="bm-comments-count">0</span>';
+        html += '</div>';
+        html += '<div class="card-body">';
+        html += '<div id="bm-comments-body"><div class="text-muted small"><i class="bi bi-hourglass-split me-1"></i>Loading comments\u2026</div></div>';
+        html += '<div class="mt-3 border-top pt-3">';
+        html += '<div class="d-flex gap-2">';
+        html += '<input type="text" class="form-control form-control-sm" id="bm-comment-input" placeholder="Write a comment\u2026" maxlength="4000">';
+        html += '<button class="btn btn-sm btn-primary" id="bm-comment-send" disabled><i class="bi bi-send"></i></button>';
+        html += '</div></div>';
+        html += '</div></div>';
+
         html += '</div>';
         setContent(html);
 
@@ -2693,6 +2708,9 @@
 
         // Load and wire attachments panel
         loadAttachmentsPanel(slug, id);
+
+        // Load and wire comments panel
+        loadCommentsPanel(slug, id);
 
         // Wire command buttons
         document.querySelectorAll('.vnext-cmd-btn').forEach(function (btn) {
@@ -3014,6 +3032,118 @@
                     .catch(function (err) { showToast('Could not load version history: ' + err.message, 'error'); });
             });
         });
+    }
+
+    /**
+     * Load comments panel for a record and wire up post/edit/delete.
+     */
+    function loadCommentsPanel(slug, id) {
+        var commentsBody = document.getElementById('bm-comments-body');
+        var commentInput = document.getElementById('bm-comment-input');
+        var sendBtn = document.getElementById('bm-comment-send');
+        var countBadge = document.getElementById('bm-comments-count');
+        if (!commentsBody || !commentInput || !sendBtn) return;
+
+        commentInput.addEventListener('input', function () {
+            sendBtn.disabled = !commentInput.value.trim();
+        });
+        commentInput.addEventListener('keydown', function (e) {
+            if (e.key === 'Enter' && !sendBtn.disabled) postComment();
+        });
+        sendBtn.addEventListener('click', postComment);
+
+        function postComment() {
+            var text = commentInput.value.trim();
+            if (!text) return;
+            sendBtn.disabled = true;
+            commentInput.disabled = true;
+            apiFetch(API + '/' + encodeURIComponent(slug) + '/' + encodeURIComponent(id) + '/_comments', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ text: text })
+            }).then(function () {
+                commentInput.value = '';
+                commentInput.disabled = false;
+                loadComments();
+            }).catch(function (err) {
+                showToast('Could not post comment: ' + err.message, 'error');
+                commentInput.disabled = false;
+                sendBtn.disabled = false;
+            });
+        }
+
+        function loadComments() {
+            apiFetch(API + '/' + encodeURIComponent(slug) + '/' + encodeURIComponent(id) + '/_comments')
+                .then(function (comments) {
+                    if (countBadge) countBadge.textContent = comments.length;
+                    if (!comments || comments.length === 0) {
+                        commentsBody.innerHTML = '<div class="text-muted small">No comments yet. Be the first to comment!</div>';
+                        return;
+                    }
+                    var h = '';
+                    comments.forEach(function (c) {
+                        var date = new Date(c.createdAt);
+                        var edited = c.updatedAt && c.updatedAt !== c.createdAt;
+                        var timeStr = date.toLocaleDateString() + ' ' + date.toLocaleTimeString([], {hour: '2-digit', minute: '2-digit'});
+                        h += '<div class="d-flex mb-2 bm-comment" data-id="' + c.id + '">';
+                        h += '<div class="flex-shrink-0 me-2">';
+                        h += '<div class="rounded-circle bg-primary text-white d-flex align-items-center justify-content-center" style="width:32px;height:32px;font-size:14px">';
+                        h += escHtml((c.author || '?').charAt(0).toUpperCase());
+                        h += '</div></div>';
+                        h += '<div class="flex-grow-1">';
+                        h += '<div class="d-flex align-items-baseline gap-2">';
+                        h += '<strong class="small">' + escHtml(c.author || 'Unknown') + '</strong>';
+                        h += '<span class="text-muted" style="font-size:0.75rem">' + timeStr + '</span>';
+                        if (edited) h += '<span class="text-muted" style="font-size:0.7rem">(edited)</span>';
+                        h += '</div>';
+                        h += '<div class="small bm-comment-text">' + escHtml(c.text) + '</div>';
+                        h += '<div class="bm-comment-actions mt-1" style="display:none">';
+                        h += '<button class="btn btn-xs btn-link text-muted p-0 me-2 bm-comment-edit-btn" data-id="' + c.id + '" data-text="' + escHtml(c.text).replace(/"/g, '&quot;') + '"><i class="bi bi-pencil"></i> Edit</button>';
+                        h += '<button class="btn btn-xs btn-link text-danger p-0 bm-comment-delete-btn" data-id="' + c.id + '"><i class="bi bi-trash"></i> Delete</button>';
+                        h += '</div>';
+                        h += '</div></div>';
+                    });
+                    commentsBody.innerHTML = h;
+
+                    // Show actions on hover
+                    commentsBody.querySelectorAll('.bm-comment').forEach(function (el) {
+                        var actions = el.querySelector('.bm-comment-actions');
+                        el.addEventListener('mouseenter', function () { if (actions) actions.style.display = ''; });
+                        el.addEventListener('mouseleave', function () { if (actions) actions.style.display = 'none'; });
+                    });
+
+                    // Wire edit buttons
+                    commentsBody.querySelectorAll('.bm-comment-edit-btn').forEach(function (btn) {
+                        btn.addEventListener('click', function () {
+                            var newText = prompt('Edit comment:', btn.dataset.text);
+                            if (newText !== null && newText.trim()) {
+                                apiFetch(API + '/_comments/' + btn.dataset.id, {
+                                    method: 'PATCH',
+                                    headers: { 'Content-Type': 'application/json' },
+                                    body: JSON.stringify({ text: newText.trim() })
+                                }).then(loadComments)
+                                  .catch(function (err) { showToast(err.message, 'error'); });
+                            }
+                        });
+                    });
+
+                    // Wire delete buttons
+                    commentsBody.querySelectorAll('.bm-comment-delete-btn').forEach(function (btn) {
+                        btn.addEventListener('click', function () {
+                            if (confirm('Delete this comment?')) {
+                                apiFetch(API + '/_comments/' + btn.dataset.id, { method: 'DELETE' })
+                                    .then(loadComments)
+                                    .catch(function (err) { showToast(err.message, 'error'); });
+                            }
+                        });
+                    });
+                })
+                .catch(function (err) {
+                    commentsBody.innerHTML = '<span class="text-warning small">Could not load comments: ' + escHtml(err.message) + '</span>';
+                });
+        }
+
+        loadComments();
     }
 
     function renderSubListReadonly(items, field) {

--- a/BareMetalWeb.Data/RecordComment.cs
+++ b/BareMetalWeb.Data/RecordComment.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace BareMetalWeb.Data;
+
+/// <summary>
+/// A text comment/message attached to any record in the system.
+/// Provides Slack-style conversation threads on records.
+/// </summary>
+[DataEntity(
+    "Record Comment",
+    Slug = "recordcomment",
+    Permissions = "Authenticated",
+    ShowOnNav = false,
+    IdGeneration = AutoIdStrategy.Sequential
+)]
+public sealed class RecordComment : BaseDataObject
+{
+    public RecordComment() : base() { }
+    public RecordComment(string createdBy) : base(createdBy) { }
+
+    /// <summary>Slug of the entity type this comment belongs to (e.g. "order").</summary>
+    [DataField(Label = "Record Type", Required = true, Order = 1)]
+    [DataIndex(IndexKind.Inverted)]
+    public string RecordType { get; set; } = string.Empty;
+
+    /// <summary>Key of the record this comment belongs to.</summary>
+    [DataField(Label = "Record Key", Required = true, Order = 2)]
+    [DataIndex(IndexKind.Inverted)]
+    public uint RecordKey { get; set; }
+
+    /// <summary>The comment text content.</summary>
+    [DataField(Label = "Text", Required = true, Order = 3)]
+    public string Text { get; set; } = string.Empty;
+}

--- a/BareMetalWeb.Data/SystemEntitySchemas.cs
+++ b/BareMetalWeb.Data/SystemEntitySchemas.cs
@@ -196,6 +196,12 @@ public static class SystemEntitySchemas
         .AddField("UserAgent", FieldType.StringUtf8, typeof(string))
         .Build();
 
+    public static EntitySchema RecordComment { get; } = new EntitySchema.Builder("RecordComment", "recordcomment")
+        .AddField("RecordType", FieldType.StringUtf8, typeof(string), required: true, indexed: true)
+        .AddField("RecordKey", FieldType.UInt32, typeof(uint), required: true, indexed: true)
+        .AddField("Text", FieldType.StringUtf8, typeof(string), required: true)
+        .Build();
+
     /// <summary>All system entity schemas, for bulk registration.</summary>
     public static IReadOnlyList<EntitySchema> All { get; } = new[]
     {
@@ -204,6 +210,7 @@ public static class SystemEntitySchemas
         MfaChallenge, DeviceCodeAuth,
         EntityDefinition, FieldDefinition, IndexDefinition,
         ActionDefinition, ActionCommandDefinition,
-        SessionLog
+        SessionLog,
+        RecordComment
     };
 }

--- a/BareMetalWeb.Host.Tests/RouteRegistrationExtensionsTests.cs
+++ b/BareMetalWeb.Host.Tests/RouteRegistrationExtensionsTests.cs
@@ -1174,6 +1174,10 @@ public class RouteRegistrationExtensionsTests : IDisposable
         public ValueTask AttachmentsDownloadHandler(BmwContext context) => ValueTask.CompletedTask;
         public ValueTask AttachmentsDeleteHandler(BmwContext context) => ValueTask.CompletedTask;
         public ValueTask AttachmentsVersionsHandler(BmwContext context) => ValueTask.CompletedTask;
+        public ValueTask CommentsListHandler(BmwContext context) => ValueTask.CompletedTask;
+        public ValueTask CommentsAddHandler(BmwContext context) => ValueTask.CompletedTask;
+        public ValueTask CommentsEditHandler(BmwContext context) => ValueTask.CompletedTask;
+        public ValueTask CommentsDeleteHandler(BmwContext context) => ValueTask.CompletedTask;
         public ValueTask DataListExportHandler(BmwContext context) => ValueTask.CompletedTask;
         public ValueTask DataViewExportHandler(BmwContext context) => ValueTask.CompletedTask;
         public ValueTask DataBulkDeleteHandler(BmwContext context) => ValueTask.CompletedTask;

--- a/BareMetalWeb.Host/BareMetalWebExtensions.cs
+++ b/BareMetalWeb.Host/BareMetalWebExtensions.cs
@@ -63,6 +63,7 @@ public static class BareMetalWebExtensions
         DataScaffold.RegisterEntity<DashboardDefinition>();
         DataScaffold.RegisterEntity<ViewDefinition>();
         DataScaffold.RegisterEntity<FileAttachment>();
+        DataScaffold.RegisterEntity<RecordComment>();
 
         IDataObjectStore dataStore = ProgramSetup.CreateDataStore(config, contentRoot, serializer, queryEvaluator, logger);
 

--- a/BareMetalWeb.Host/RouteHandlers.cs
+++ b/BareMetalWeb.Host/RouteHandlers.cs
@@ -4240,6 +4240,227 @@ public sealed class RouteHandlers : IRouteHandlers
         await context.Response.WriteAsync(JsonSerializer.Serialize(result, JsonIndented)).ConfigureAwait(false);
     }
 
+    // ── Record comment endpoints ────────────────────────────────────────────────
+
+    private static bool TryGetCommentMeta(out DataEntityMetadata commentMeta)
+        => DataScaffold.TryGetEntity("recordcomment", out commentMeta);
+
+    private static Dictionary<string, object?> BuildCommentApiModel(RecordComment c) =>
+        new()
+        {
+            ["id"]        = c.Key,
+            ["text"]      = c.Text,
+            ["author"]    = c.CreatedBy,
+            ["createdAt"] = c.CreatedOnUtc,
+            ["updatedAt"] = c.UpdatedOnUtc,
+            ["updatedBy"] = c.UpdatedBy
+        };
+
+    /// <summary>GET /api/{type}/{id}/_comments — list comments for a record.</summary>
+    public async ValueTask CommentsListHandler(BmwContext context)
+    {
+        var meta = ResolveEntity(context, out _, out var errorMessage);
+        var idStr = GetRouteValue(context, "id");
+        if (meta == null || string.IsNullOrWhiteSpace(idStr) || !uint.TryParse(idStr, out var recordKey))
+        {
+            context.Response.StatusCode = StatusCodes.Status404NotFound;
+            await context.Response.WriteAsync(errorMessage ?? "Not found.").ConfigureAwait(false);
+            return;
+        }
+        if (!await HasEntityPermissionAsync(context, meta, context.RequestAborted).ConfigureAwait(false))
+        {
+            context.Response.StatusCode = StatusCodes.Status403Forbidden;
+            await context.Response.WriteAsync("Access denied.").ConfigureAwait(false);
+            return;
+        }
+        if (!TryGetCommentMeta(out var commentMeta))
+        {
+            context.Response.ContentType = "application/json";
+            await context.Response.WriteAsync("[]").ConfigureAwait(false);
+            return;
+        }
+
+        var query = new QueryDefinition
+        {
+            Clauses = new List<QueryClause>
+            {
+                new QueryClause { Field = nameof(RecordComment.RecordType), Operator = QueryOperator.Equals, Value = meta.Slug },
+                new QueryClause { Field = nameof(RecordComment.RecordKey),  Operator = QueryOperator.Equals, Value = recordKey.ToString() }
+            }
+        };
+
+        var rawItems = await DataScaffold.QueryAsync(commentMeta, query, context.RequestAborted).ConfigureAwait(false);
+        var result = new List<Dictionary<string, object?>>();
+        foreach (var item in rawItems)
+        {
+            if (item is RecordComment c)
+                result.Add(BuildCommentApiModel(c));
+        }
+        // Sort by creation time ascending (oldest first, chat-style)
+        result.Sort((a, b) => ((DateTime)a["createdAt"]!).CompareTo((DateTime)b["createdAt"]!));
+
+        context.Response.ContentType = "application/json";
+        await context.Response.WriteAsync(JsonSerializer.Serialize(result, JsonIndented)).ConfigureAwait(false);
+    }
+
+    /// <summary>POST /api/{type}/{id}/_comments — add a comment to a record.</summary>
+    public async ValueTask CommentsAddHandler(BmwContext context)
+    {
+        var meta = ResolveEntity(context, out _, out var errorMessage);
+        var idStr = GetRouteValue(context, "id");
+        if (meta == null || string.IsNullOrWhiteSpace(idStr) || !uint.TryParse(idStr, out var recordKey))
+        {
+            context.Response.StatusCode = StatusCodes.Status404NotFound;
+            await context.Response.WriteAsync(errorMessage ?? "Not found.").ConfigureAwait(false);
+            return;
+        }
+        if (!await HasEntityPermissionAsync(context, meta, context.RequestAborted).ConfigureAwait(false))
+        {
+            context.Response.StatusCode = StatusCodes.Status403Forbidden;
+            await context.Response.WriteAsync("Access denied.").ConfigureAwait(false);
+            return;
+        }
+        if (!TryGetCommentMeta(out var commentMeta))
+        {
+            context.Response.StatusCode = StatusCodes.Status500InternalServerError;
+            await context.Response.WriteAsync("Comment entity not registered.").ConfigureAwait(false);
+            return;
+        }
+
+        string? text = null;
+        if (context.HttpRequest.ContentType?.Contains("application/json") == true)
+        {
+            using var reader = new StreamReader(context.HttpRequest.Body);
+            var body = await reader.ReadToEndAsync().ConfigureAwait(false);
+            var doc = JsonSerializer.Deserialize<Dictionary<string, string>>(body);
+            text = doc?.GetValueOrDefault("text");
+        }
+        else if (context.HttpRequest.HasFormContentType)
+        {
+            var form = await context.HttpRequest.ReadFormAsync().ConfigureAwait(false);
+            text = form["text"].ToString();
+        }
+
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            context.Response.StatusCode = StatusCodes.Status400BadRequest;
+            await context.Response.WriteAsync("Comment text is required.").ConfigureAwait(false);
+            return;
+        }
+
+        var user = await UserAuth.GetRequestUserAsync(context, context.RequestAborted).ConfigureAwait(false);
+        var userName = user?.UserName ?? "anonymous";
+        var comment = new RecordComment(userName)
+        {
+            RecordType = meta.Slug,
+            RecordKey  = recordKey,
+            Text       = text.Trim()
+        };
+
+        await DataScaffold.ApplyAutoIdAsync(commentMeta, comment, context.RequestAborted).ConfigureAwait(false);
+        await DataScaffold.SaveAsync(commentMeta, comment, context.RequestAborted).ConfigureAwait(false);
+
+        context.Response.StatusCode = StatusCodes.Status201Created;
+        context.Response.ContentType = "application/json";
+        await context.Response.WriteAsync(JsonSerializer.Serialize(BuildCommentApiModel(comment), JsonIndented)).ConfigureAwait(false);
+    }
+
+    /// <summary>PATCH /api/_comments/{id} — edit a comment (own comments only).</summary>
+    public async ValueTask CommentsEditHandler(BmwContext context)
+    {
+        var idStr = GetRouteValue(context, "id");
+        if (string.IsNullOrWhiteSpace(idStr) || !uint.TryParse(idStr, out var commentId))
+        {
+            context.Response.StatusCode = StatusCodes.Status400BadRequest;
+            await context.Response.WriteAsync("Invalid comment ID.").ConfigureAwait(false);
+            return;
+        }
+        if (!TryGetCommentMeta(out var commentMeta))
+        {
+            context.Response.StatusCode = StatusCodes.Status404NotFound;
+            await context.Response.WriteAsync("Not found.").ConfigureAwait(false);
+            return;
+        }
+
+        var existing = await DataScaffold.LoadAsync(commentMeta, commentId, context.RequestAborted).ConfigureAwait(false);
+        if (existing is not RecordComment comment)
+        {
+            context.Response.StatusCode = StatusCodes.Status404NotFound;
+            await context.Response.WriteAsync("Comment not found.").ConfigureAwait(false);
+            return;
+        }
+
+        var user = await UserAuth.GetRequestUserAsync(context, context.RequestAborted).ConfigureAwait(false);
+        var userName = user?.UserName ?? "anonymous";
+        if (!string.Equals(comment.CreatedBy, userName, StringComparison.OrdinalIgnoreCase))
+        {
+            context.Response.StatusCode = StatusCodes.Status403Forbidden;
+            await context.Response.WriteAsync("You can only edit your own comments.").ConfigureAwait(false);
+            return;
+        }
+
+        string? text = null;
+        if (context.HttpRequest.ContentType?.Contains("application/json") == true)
+        {
+            using var reader = new StreamReader(context.HttpRequest.Body);
+            var body = await reader.ReadToEndAsync().ConfigureAwait(false);
+            var doc = JsonSerializer.Deserialize<Dictionary<string, string>>(body);
+            text = doc?.GetValueOrDefault("text");
+        }
+
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            context.Response.StatusCode = StatusCodes.Status400BadRequest;
+            await context.Response.WriteAsync("Comment text is required.").ConfigureAwait(false);
+            return;
+        }
+
+        comment.Text = text.Trim();
+        comment.Touch(userName);
+        await DataScaffold.SaveAsync(commentMeta, comment, context.RequestAborted).ConfigureAwait(false);
+
+        context.Response.ContentType = "application/json";
+        await context.Response.WriteAsync(JsonSerializer.Serialize(BuildCommentApiModel(comment), JsonIndented)).ConfigureAwait(false);
+    }
+
+    /// <summary>DELETE /api/_comments/{id} — delete a comment (own comments only).</summary>
+    public async ValueTask CommentsDeleteHandler(BmwContext context)
+    {
+        var idStr = GetRouteValue(context, "id");
+        if (string.IsNullOrWhiteSpace(idStr) || !uint.TryParse(idStr, out var commentId))
+        {
+            context.Response.StatusCode = StatusCodes.Status400BadRequest;
+            await context.Response.WriteAsync("Invalid comment ID.").ConfigureAwait(false);
+            return;
+        }
+        if (!TryGetCommentMeta(out var commentMeta))
+        {
+            context.Response.StatusCode = StatusCodes.Status404NotFound;
+            await context.Response.WriteAsync("Not found.").ConfigureAwait(false);
+            return;
+        }
+
+        var existing = await DataScaffold.LoadAsync(commentMeta, commentId, context.RequestAborted).ConfigureAwait(false);
+        if (existing is not RecordComment comment)
+        {
+            context.Response.StatusCode = StatusCodes.Status404NotFound;
+            await context.Response.WriteAsync("Comment not found.").ConfigureAwait(false);
+            return;
+        }
+
+        var user = await UserAuth.GetRequestUserAsync(context, context.RequestAborted).ConfigureAwait(false);
+        var userName = user?.UserName ?? "anonymous";
+        if (!string.Equals(comment.CreatedBy, userName, StringComparison.OrdinalIgnoreCase))
+        {
+            context.Response.StatusCode = StatusCodes.Status403Forbidden;
+            await context.Response.WriteAsync("You can only delete your own comments.").ConfigureAwait(false);
+            return;
+        }
+
+        await DataScaffold.DeleteAsync(commentMeta, commentId, context.RequestAborted).ConfigureAwait(false);
+        context.Response.StatusCode = StatusCodes.Status204NoContent;
+    }
+
     public async ValueTask MetricsJsonHandler(BmwContext context)
     {
         var app = context.GetApp();

--- a/BareMetalWeb.Host/RouteRegistrationExtensions.cs
+++ b/BareMetalWeb.Host/RouteRegistrationExtensions.cs
@@ -592,6 +592,20 @@ public static class RouteRegistrationExtensions
             pageInfoFactory.RawPage("Authenticated", false),
             routeHandlers.AttachmentsVersionsHandler));
 
+        // Comments API routes
+        host.RegisterRoute("GET /api/{type}/{id}/_comments", new RouteHandlerData(
+            pageInfoFactory.RawPage("Authenticated", false),
+            routeHandlers.CommentsListHandler));
+        host.RegisterRoute("POST /api/{type}/{id}/_comments", new RouteHandlerData(
+            pageInfoFactory.RawPage("Authenticated", false),
+            routeHandlers.CommentsAddHandler));
+        host.RegisterRoute("PATCH /api/_comments/{id}", new RouteHandlerData(
+            pageInfoFactory.RawPage("Authenticated", false),
+            routeHandlers.CommentsEditHandler));
+        host.RegisterRoute("DELETE /api/_comments/{id}", new RouteHandlerData(
+            pageInfoFactory.RawPage("Authenticated", false),
+            routeHandlers.CommentsDeleteHandler));
+
         // Document chain — must be before the generic GET /api/{type}/{id} route
         host.RegisterRoute("GET /api/{type}/{id}/_related-chain", new RouteHandlerData(
             pageInfoFactory.RawPage("Authenticated", false),


### PR DESCRIPTION
Fixes #941

## Feature
Slack-style comments attached to any record. Every record detail view now shows a comments panel below attachments.

## Components

**Data model** — `RecordComment` entity (`BareMetalWeb.Data/RecordComment.cs`)
- `RecordType` (slug) + `RecordKey` (uint) — links to any record, same pattern as FileAttachment
- `Text` — comment content (up to 4000 chars)
- Inherits `CreatedBy`, `CreatedOnUtc`, `UpdatedBy`, `UpdatedOnUtc` from BaseDataObject
- Inverted indexes on RecordType + RecordKey for fast lookups

**API endpoints**
| Method | Route | Description |
|--------|-------|-------------|
| GET | `/api/{type}/{id}/_comments` | List comments (sorted oldest-first) |
| POST | `/api/{type}/{id}/_comments` | Add a comment (JSON body: `{text}`) |
| PATCH | `/api/_comments/{id}` | Edit own comment |
| DELETE | `/api/_comments/{id}` | Delete own comment |

**UI** — Bootstrap card panel with:
- Chat-style message bubbles with avatar initials, author name, timestamp
- `(edited)` indicator for modified comments
- Hover-reveal edit/delete actions (own comments only)
- Enter-to-send input with send button
- Comment count badge in card header

**Registration**
- Schema in `SystemEntitySchemas.cs`
- Entity registration in `BareMetalWebExtensions.cs`
- Routes registered before generic `/api/{type}/{id}` routes