### PR TITLE
fix: remove runs-on from reusable workflow jobs in CI/CD pipeline

### DIFF
--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -759,7 +759,6 @@ jobs:
 
   l2-2-early-access:
     name: "L2.2 · Early Access: ${{ matrix.name }}"
-    runs-on: ubuntu-latest
     needs: l2-2-prepare-matrix
     strategy:
       fail-fast: false
@@ -817,7 +816,6 @@ jobs:
 
   l2-3-full-rollout:
     name: "L2.3 · Full Rollout: ${{ matrix.name }}"
-    runs-on: ubuntu-latest
     needs: l2-3-prepare-matrix
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Problem

CI/CD pipeline fails with:
```
Invalid workflow file - Unexpected value 'uses', 'with', 'secrets'
```

## Root Cause

Jobs `l2-2-early-access` and `l2-3-full-rollout` call a reusable workflow via job-level `uses:`, but also specify `runs-on: ubuntu-latest`. These are mutually exclusive — `runs-on` is defined inside the called `deploy-tenant.yml` workflow.

## Fix

Removed `runs-on: ubuntu-latest` from both reusable workflow calling jobs.

Fixes #1028