### PR TITLE
fix: replace MetadataToken sort with name-based sort for AOT compatibility

### DIFF
--- a/BareMetalWeb.Data/DataScaffold.cs
+++ b/BareMetalWeb.Data/DataScaffold.cs
@@ -942,7 +942,7 @@ public static class DataScaffold
         var result = new List<Dictionary<string, object?>>();
 
         var properties = childType.GetProperties(BindingFlags.Public | BindingFlags.Instance);
-        Array.Sort(properties, (a, b) => a.MetadataToken.CompareTo(b.MetadataToken));
+        Array.Sort(properties, (a, b) => string.CompareOrdinal(a.Name, b.Name));
 
         foreach (var prop in properties)
         {
@@ -2540,7 +2540,7 @@ public static class DataScaffold
     {
         var fields = new List<ChildFieldMeta>();
         var properties = childType.GetProperties(BindingFlags.Public | BindingFlags.Instance);
-        Array.Sort(properties, (a, b) => a.MetadataToken.CompareTo(b.MetadataToken));
+        Array.Sort(properties, (a, b) => string.CompareOrdinal(a.Name, b.Name));
 
         foreach (var prop in properties)
         {
@@ -2581,7 +2581,7 @@ public static class DataScaffold
     {
         var fields = new List<ChildFieldMeta>();
         var properties = childType.GetProperties(BindingFlags.Public | BindingFlags.Instance);
-        Array.Sort(properties, (a, b) => a.MetadataToken.CompareTo(b.MetadataToken));
+        Array.Sort(properties, (a, b) => string.CompareOrdinal(a.Name, b.Name));
 
         foreach (var prop in properties)
         {
@@ -3698,7 +3698,7 @@ public static class DataScaffold
 
         var fields = new List<DataFieldMetadata>();
         var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
-        Array.Sort(properties, (a, b) => a.MetadataToken.CompareTo(b.MetadataToken));
+        Array.Sort(properties, (a, b) => string.CompareOrdinal(a.Name, b.Name));
         for (int i = 0; i < properties.Length; i++)
         {
             var prop = properties[i];

--- a/BareMetalWeb.Runtime/MetadataExtractor.cs
+++ b/BareMetalWeb.Runtime/MetadataExtractor.cs
@@ -81,7 +81,7 @@ public static class MetadataExtractor
         var nullabilityCtx = new NullabilityInfoContext();
 
         var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
-        Array.Sort(properties, (a, b) => a.MetadataToken.CompareTo(b.MetadataToken));
+        Array.Sort(properties, (a, b) => string.CompareOrdinal(a.Name, b.Name));
 
         int ordinal = 1;
         for (int i = 0; i < properties.Length; i++)


### PR DESCRIPTION
## Problem

Under Native AOT, `PropertyInfo.MetadataToken` throws `InvalidOperationException: There is no metadata token available for the given member` because AOT-compiled code has no IL metadata tokens.

This crashes the app at startup in `DataScaffold.BuildEntityMetadata<T>()`.

## Fix

Replace all 4 `MetadataToken`-based property sorts with `string.CompareOrdinal(a.Name, b.Name)` — deterministic, stable, and AOT-safe.

**Files changed:**
- `BareMetalWeb.Data/DataScaffold.cs` (4 locations)
- `BareMetalWeb.Runtime/MetadataExtractor.cs` (1 location)

Fixes #1030
