### PR TITLE
feat: high-performance prefix router for API entity routes

### DIFF
--- a/BareMetalWeb.Core/BmwContext.cs
+++ b/BareMetalWeb.Core/BmwContext.cs
@@ -36,6 +36,16 @@ public sealed class BmwContext
     /// <summary>Route parameters extracted by the jump-table or pattern router.</summary>
     public Dictionary<string, string>? RouteParameters { get; set; }
 
+    // ── Prefix-router fast-path fields (zero-allocation param passing) ──
+    /// <summary>Entity type slug set by the prefix router for /api/{type} routes.</summary>
+    public string? EntitySlug;
+    /// <summary>Entity ID string set by the prefix router for /api/{type}/{id} routes.</summary>
+    public string? EntityId;
+    /// <summary>Extra route segment value (field name, command name, etc.).</summary>
+    public string? RouteExtra;
+    /// <summary>Key name for <see cref="RouteExtra"/> (e.g. "field", "command").</summary>
+    public string? RouteExtraKey;
+
     // ── Migration bridge ────────────────────────────────────────────────
     /// <summary>
     /// The underlying ASP.NET HttpContext. Available during migration so

--- a/BareMetalWeb.Data/BmwJsonReader.cs
+++ b/BareMetalWeb.Data/BmwJsonReader.cs
@@ -168,7 +168,7 @@ public static class BmwJsonReader
             // Read property name
             if (pos >= json.Length || json[pos] != (byte)'"')
                 throw new InvalidOperationException("Expected '\"' for property name.");
-            var (propName, propEnd) = ReadJsonString(json, pos);
+            var propName = ReadJsonStringSpan(json, pos, out var propEnd);
             pos = propEnd;
 
             // Colon
@@ -293,7 +293,7 @@ public static class BmwJsonReader
         else if (json[pos] == (byte)'"')
         {
             // String "true"/"false"
-            var (str, strEnd) = ReadJsonString(json, pos);
+            var str = ReadJsonStringSpan(json, pos, out var strEnd);
             val = str.SequenceEqual("true"u8);
             endPos = strEnd;
         }
@@ -316,7 +316,7 @@ public static class BmwJsonReader
         if (json[pos] == (byte)'"')
         {
             // Quoted number
-            var (str, strEnd) = ReadJsonString(json, pos);
+            var str = ReadJsonStringSpan(json, pos, out var strEnd);
             numSpan = str;
             endPos = strEnd;
         }
@@ -395,7 +395,7 @@ public static class BmwJsonReader
 
     private static (byte[] value, int endPos) ParseCharValue(ReadOnlySpan<byte> json, int pos, bool isNullable)
     {
-        var (str, strEnd) = ReadJsonString(json, pos);
+        var str = ReadJsonStringSpan(json, pos, out var strEnd);
         char ch = '\0';
         if (str.Length > 0)
         {
@@ -415,7 +415,7 @@ public static class BmwJsonReader
     {
         if (json[pos] == (byte)'"')
         {
-            var (str, strEnd) = ReadJsonString(json, pos);
+            var str = ReadJsonStringSpan(json, pos, out var strEnd);
             var byteCount = str.Length;
 
             // Encode: [nullable indicator?] + [int32 length] + [utf8 bytes]
@@ -444,7 +444,7 @@ public static class BmwJsonReader
 
     private static (byte[] value, int endPos) ParseGuidValue(ReadOnlySpan<byte> json, int pos, bool isNullable)
     {
-        var (str, strEnd) = ReadJsonString(json, pos);
+        var str = ReadJsonStringSpan(json, pos, out var strEnd);
         Guid guid = Guid.Empty;
         if (str.Length > 0)
         {
@@ -462,7 +462,7 @@ public static class BmwJsonReader
 
     private static (byte[] value, int endPos) ParseDateTimeValue(ReadOnlySpan<byte> json, int pos, bool isNullable)
     {
-        var (str, strEnd) = ReadJsonString(json, pos);
+        var str = ReadJsonStringSpan(json, pos, out var strEnd);
         DateTime dt = default;
         if (str.Length > 0)
         {
@@ -483,7 +483,7 @@ public static class BmwJsonReader
 
     private static (byte[] value, int endPos) ParseDateOnlyValue(ReadOnlySpan<byte> json, int pos, bool isNullable)
     {
-        var (str, strEnd) = ReadJsonString(json, pos);
+        var str = ReadJsonStringSpan(json, pos, out var strEnd);
         DateOnly d = default;
         if (str.Length > 0)
         {
@@ -501,7 +501,7 @@ public static class BmwJsonReader
 
     private static (byte[] value, int endPos) ParseTimeOnlyValue(ReadOnlySpan<byte> json, int pos, bool isNullable)
     {
-        var (str, strEnd) = ReadJsonString(json, pos);
+        var str = ReadJsonStringSpan(json, pos, out var strEnd);
         TimeOnly t = default;
         if (str.Length > 0)
         {
@@ -519,7 +519,7 @@ public static class BmwJsonReader
 
     private static (byte[] value, int endPos) ParseDateTimeOffsetValue(ReadOnlySpan<byte> json, int pos, bool isNullable)
     {
-        var (str, strEnd) = ReadJsonString(json, pos);
+        var str = ReadJsonStringSpan(json, pos, out var strEnd);
         DateTimeOffset dto = default;
         if (str.Length > 0)
         {
@@ -540,7 +540,7 @@ public static class BmwJsonReader
 
     private static (byte[] value, int endPos) ParseTimeSpanValue(ReadOnlySpan<byte> json, int pos, bool isNullable)
     {
-        var (str, strEnd) = ReadJsonString(json, pos);
+        var str = ReadJsonStringSpan(json, pos, out var strEnd);
         TimeSpan ts = default;
         if (str.Length > 0)
         {
@@ -558,7 +558,7 @@ public static class BmwJsonReader
 
     private static (byte[] value, int endPos) ParseIdentifierValue(ReadOnlySpan<byte> json, int pos, bool isNullable)
     {
-        var (str, strEnd) = ReadJsonString(json, pos);
+        var str = ReadJsonStringSpan(json, pos, out var strEnd);
         IdentifierValue id = IdentifierValue.Empty;
         if (str.Length > 0)
         {
@@ -583,7 +583,7 @@ public static class BmwJsonReader
         {
             // String enum name — we can't resolve by name without the CLR type,
             // so we try parsing as an integer string
-            var (str, strEnd) = ReadJsonString(json, pos);
+            var str = ReadJsonStringSpan(json, pos, out var strEnd);
             Utf8Parser.TryParse(str, out enumInt, out _);
             endPos = strEnd;
         }
@@ -853,7 +853,7 @@ public static class BmwJsonReader
     /// Reads a JSON string starting at the opening quote, returns the unescaped
     /// UTF-8 content and the position after the closing quote.
     /// </summary>
-    private static (ReadOnlySpan<byte> content, int endPos) ReadJsonString(ReadOnlySpan<byte> json, int pos)
+    private static void ReadJsonString(ReadOnlySpan<byte> json, int pos, out byte[] unescapedBuf, out int contentStart, out int contentLen, out int endPos)
     {
         if (json[pos] != (byte)'"')
             throw new InvalidOperationException("Expected '\"'.");
@@ -868,7 +868,13 @@ public static class BmwJsonReader
             if (b == (byte)'"')
             {
                 if (!hasEscapes)
-                    return (json[start..pos], pos + 1);
+                {
+                    unescapedBuf = null!;
+                    contentStart = start;
+                    contentLen = pos - start;
+                    endPos = pos + 1;
+                    return;
+                }
                 break;
             }
             if (b == (byte)'\\')
@@ -884,7 +890,7 @@ public static class BmwJsonReader
             throw new InvalidOperationException("Unterminated JSON string.");
 
         // Slow path: unescape
-        var unescaped = new byte[pos - start];
+        var buf = new byte[pos - start];
         int writeIdx = 0;
         int readIdx = start;
         while (readIdx < pos)
@@ -894,7 +900,7 @@ public static class BmwJsonReader
             {
                 readIdx++;
                 byte esc = json[readIdx];
-                unescaped[writeIdx++] = esc switch
+                buf[writeIdx++] = esc switch
                 {
                     (byte)'"' => (byte)'"',
                     (byte)'\\' => (byte)'\\',
@@ -904,19 +910,34 @@ public static class BmwJsonReader
                     (byte)'t' => (byte)'\t',
                     (byte)'b' => (byte)'\b',
                     (byte)'f' => 0x0C,
-                    (byte)'u' => HandleUnicodeEscape(json, ref readIdx, unescaped, ref writeIdx),
+                    (byte)'u' => HandleUnicodeEscape(json, ref readIdx, buf, ref writeIdx),
                     _ => esc,
                 };
                 readIdx++;
             }
             else
             {
-                unescaped[writeIdx++] = b;
+                buf[writeIdx++] = b;
                 readIdx++;
             }
         }
 
-        return (unescaped.AsSpan(0, writeIdx), pos + 1);
+        unescapedBuf = buf;
+        contentStart = 0;
+        contentLen = writeIdx;
+        endPos = pos + 1;
+    }
+
+    /// <summary>
+    /// Convenience wrapper: reads a JSON string and returns the content as a ReadOnlySpan.
+    /// The span is valid only while the source json span (or the returned buf) is alive.
+    /// </summary>
+    private static ReadOnlySpan<byte> ReadJsonStringSpan(ReadOnlySpan<byte> json, int pos, out int endPos)
+    {
+        ReadJsonString(json, pos, out var buf, out var start, out var len, out endPos);
+        if (buf != null)
+            return buf.AsSpan(start, len);
+        return json.Slice(start, len);
     }
 
     private static byte HandleUnicodeEscape(ReadOnlySpan<byte> json, ref int readIdx, byte[] dest, ref int writeIdx)
@@ -959,7 +980,7 @@ public static class BmwJsonReader
         // String
         if (b == (byte)'"')
         {
-            var (_, endPos) = ReadJsonString(json, pos);
+            _ = ReadJsonStringSpan(json, pos, out var endPos);
             return endPos;
         }
 
@@ -972,7 +993,7 @@ public static class BmwJsonReader
             {
                 if (json[pos] == (byte)'{') depth++;
                 else if (json[pos] == (byte)'}') depth--;
-                else if (json[pos] == (byte)'"') { var (_, ep) = ReadJsonString(json, pos); pos = ep; continue; }
+                else if (json[pos] == (byte)'"') { _ = ReadJsonStringSpan(json, pos, out pos); continue; }
                 pos++;
             }
             return pos;
@@ -987,7 +1008,7 @@ public static class BmwJsonReader
             {
                 if (json[pos] == (byte)'[') depth++;
                 else if (json[pos] == (byte)']') depth--;
-                else if (json[pos] == (byte)'"') { var (_, ep) = ReadJsonString(json, pos); pos = ep; continue; }
+                else if (json[pos] == (byte)'"') { _ = ReadJsonStringSpan(json, pos, out pos); continue; }
                 pos++;
             }
             return pos;

--- a/BareMetalWeb.Data/BmwJsonWriter.cs
+++ b/BareMetalWeb.Data/BmwJsonWriter.cs
@@ -374,7 +374,7 @@ public static class BmwJsonWriter
             }
 
             case WireFieldType.Enum:
-                WriteEnumAsJson(output, ref reader, enumUnderlying, fmtBuf);
+                WriteEnumAsJson(output, ref reader, enumUnderlying);
                 break;
 
             default:
@@ -437,8 +437,9 @@ public static class BmwJsonWriter
 
     // ────────────── Enum ──────────────
 
-    private static void WriteEnumAsJson(Stream output, ref SpanReader reader, WireFieldType underlying, Span<byte> fmtBuf)
+    private static void WriteEnumAsJson(Stream output, ref SpanReader reader, WireFieldType underlying)
     {
+        Span<byte> buf = stackalloc byte[24];
         long raw = underlying switch
         {
             WireFieldType.Byte => reader.ReadByte(),
@@ -451,7 +452,7 @@ public static class BmwJsonWriter
             WireFieldType.UInt64 => (long)reader.ReadUInt64(),
             _ => reader.ReadInt32(),
         };
-        FormatAndWriteInt64(output, raw, fmtBuf);
+        FormatAndWriteInt64(output, raw, buf);
     }
 
     // ────────────── String field ──────────────

--- a/BareMetalWeb.Host.Tests/EntityRouteTableTests.cs
+++ b/BareMetalWeb.Host.Tests/EntityRouteTableTests.cs
@@ -1,0 +1,119 @@
+using Xunit;
+
+namespace BareMetalWeb.Host.Tests;
+
+public class EntityRouteTableTests
+{
+    [Fact]
+    public void Build_EmptySlugs_CountIsZero()
+    {
+        var table = new EntityRouteTable();
+        table.Build(Array.Empty<string>());
+        Assert.Equal(0, table.Count);
+    }
+
+    [Fact]
+    public void TryResolve_EmptyTable_ReturnsFalse()
+    {
+        var table = new EntityRouteTable();
+        table.Build(Array.Empty<string>());
+        Assert.False(table.TryResolve("users".AsSpan(), out _));
+    }
+
+    [Fact]
+    public void Build_SingleSlug_CountIsOne()
+    {
+        var table = new EntityRouteTable();
+        table.Build(new[] { "users" });
+        Assert.Equal(1, table.Count);
+    }
+
+    [Fact]
+    public void TryResolve_KnownSlug_ReturnsTrueWithInternedString()
+    {
+        var table = new EntityRouteTable();
+        var original = "users";
+        table.Build(new[] { original });
+
+        Assert.True(table.TryResolve("users".AsSpan(), out var resolved));
+        Assert.Same(original, resolved); // Same reference — zero allocation
+    }
+
+    [Fact]
+    public void TryResolve_UnknownSlug_ReturnsFalse()
+    {
+        var table = new EntityRouteTable();
+        table.Build(new[] { "users", "orders" });
+        Assert.False(table.TryResolve("products".AsSpan(), out _));
+    }
+
+    [Fact]
+    public void TryResolve_CaseInsensitive()
+    {
+        var table = new EntityRouteTable();
+        table.Build(new[] { "users" });
+
+        Assert.True(table.TryResolve("Users".AsSpan(), out var r1));
+        Assert.True(table.TryResolve("USERS".AsSpan(), out var r2));
+        Assert.Equal("users", r1);
+        Assert.Equal("users", r2);
+    }
+
+    [Fact]
+    public void TryResolve_MultipleSlugs_AllResolvable()
+    {
+        var slugs = new[] { "users", "orders", "products", "invoices", "categories" };
+        var table = new EntityRouteTable();
+        table.Build(slugs);
+
+        Assert.Equal(5, table.Count);
+        foreach (var slug in slugs)
+        {
+            Assert.True(table.TryResolve(slug.AsSpan(), out var resolved), $"Failed to resolve: {slug}");
+            Assert.Equal(slug, resolved);
+        }
+    }
+
+    [Fact]
+    public void TryResolve_ManyEntities_HandlesCollisions()
+    {
+        // Generate enough slugs to stress collision handling
+        var slugs = new List<string>();
+        for (int i = 0; i < 100; i++)
+            slugs.Add($"entity-{i:D3}");
+
+        var table = new EntityRouteTable();
+        table.Build(slugs);
+
+        Assert.Equal(100, table.Count);
+        foreach (var slug in slugs)
+        {
+            Assert.True(table.TryResolve(slug.AsSpan(), out var resolved), $"Failed: {slug}");
+            Assert.Equal(slug, resolved);
+        }
+    }
+
+    [Fact]
+    public void TryResolve_SystemPrefix_NotInTable()
+    {
+        var table = new EntityRouteTable();
+        table.Build(new[] { "users", "orders" });
+
+        // System prefixes should NOT be in entity table
+        Assert.False(table.TryResolve("_binary".AsSpan(), out _));
+        Assert.False(table.TryResolve("_lookup".AsSpan(), out _));
+        Assert.False(table.TryResolve("metadata".AsSpan(), out _));
+    }
+
+    [Fact]
+    public void Build_CanRebuild()
+    {
+        var table = new EntityRouteTable();
+        table.Build(new[] { "users" });
+        Assert.True(table.TryResolve("users".AsSpan(), out _));
+
+        table.Build(new[] { "orders" });
+        Assert.False(table.TryResolve("users".AsSpan(), out _));
+        Assert.True(table.TryResolve("orders".AsSpan(), out _));
+    }
+}

--- a/BareMetalWeb.Host.Tests/PrefixRouterTests.cs
+++ b/BareMetalWeb.Host.Tests/PrefixRouterTests.cs
@@ -1,0 +1,182 @@
+using Xunit;
+
+namespace BareMetalWeb.Host.Tests;
+
+public class PrefixRouterTests
+{
+    // ── ClassifyRoute tests ─────────────────────────────────────────────
+
+    [Fact]
+    public void ClassifyRoute_GetEmpty_ReturnsList()
+    {
+        var kind = PrefixRouter.ClassifyRoute("GET", ReadOnlySpan<char>.Empty,
+            out var id, out var extra, out var extraKey);
+        Assert.Equal((int)ApiRouteKind.List, kind);
+        Assert.True(id.IsEmpty);
+        Assert.True(extra.IsEmpty);
+        Assert.Null(extraKey);
+    }
+
+    [Fact]
+    public void ClassifyRoute_PostEmpty_ReturnsCreate()
+    {
+        var kind = PrefixRouter.ClassifyRoute("POST", ReadOnlySpan<char>.Empty,
+            out _, out _, out _);
+        Assert.Equal((int)ApiRouteKind.Create, kind);
+    }
+
+    [Fact]
+    public void ClassifyRoute_PostImport_ReturnsImport()
+    {
+        var kind = PrefixRouter.ClassifyRoute("POST", "import".AsSpan(),
+            out _, out _, out _);
+        Assert.Equal((int)ApiRouteKind.Import, kind);
+    }
+
+    [Fact]
+    public void ClassifyRoute_GetImport_ReturnsNegative()
+    {
+        var kind = PrefixRouter.ClassifyRoute("GET", "import".AsSpan(),
+            out _, out _, out _);
+        Assert.Equal(-1, kind);
+    }
+
+    [Fact]
+    public void ClassifyRoute_GetId_ReturnsGet()
+    {
+        var kind = PrefixRouter.ClassifyRoute("GET", "42".AsSpan(),
+            out var id, out _, out _);
+        Assert.Equal((int)ApiRouteKind.Get, kind);
+        Assert.True(id.SequenceEqual("42".AsSpan()));
+    }
+
+    [Fact]
+    public void ClassifyRoute_PutId_ReturnsUpdate()
+    {
+        var kind = PrefixRouter.ClassifyRoute("PUT", "42".AsSpan(),
+            out var id, out _, out _);
+        Assert.Equal((int)ApiRouteKind.Update, kind);
+        Assert.True(id.SequenceEqual("42".AsSpan()));
+    }
+
+    [Fact]
+    public void ClassifyRoute_PatchId_ReturnsPatch()
+    {
+        var kind = PrefixRouter.ClassifyRoute("PATCH", "42".AsSpan(),
+            out _, out _, out _);
+        Assert.Equal((int)ApiRouteKind.Patch, kind);
+    }
+
+    [Fact]
+    public void ClassifyRoute_DeleteId_ReturnsDelete()
+    {
+        var kind = PrefixRouter.ClassifyRoute("DELETE", "42".AsSpan(),
+            out _, out _, out _);
+        Assert.Equal((int)ApiRouteKind.Delete, kind);
+    }
+
+    [Fact]
+    public void ClassifyRoute_GetIdAttachments_ReturnsListAttachments()
+    {
+        var kind = PrefixRouter.ClassifyRoute("GET", "42/_attachments".AsSpan(),
+            out var id, out _, out _);
+        Assert.Equal((int)ApiRouteKind.ListAttachments, kind);
+        Assert.True(id.SequenceEqual("42".AsSpan()));
+    }
+
+    [Fact]
+    public void ClassifyRoute_PostIdAttachments_ReturnsAddAttachment()
+    {
+        var kind = PrefixRouter.ClassifyRoute("POST", "42/_attachments".AsSpan(),
+            out _, out _, out _);
+        Assert.Equal((int)ApiRouteKind.AddAttachment, kind);
+    }
+
+    [Fact]
+    public void ClassifyRoute_GetIdComments_ReturnsListComments()
+    {
+        var kind = PrefixRouter.ClassifyRoute("GET", "42/_comments".AsSpan(),
+            out _, out _, out _);
+        Assert.Equal((int)ApiRouteKind.ListComments, kind);
+    }
+
+    [Fact]
+    public void ClassifyRoute_PostIdComments_ReturnsAddComment()
+    {
+        var kind = PrefixRouter.ClassifyRoute("POST", "42/_comments".AsSpan(),
+            out _, out _, out _);
+        Assert.Equal((int)ApiRouteKind.AddComment, kind);
+    }
+
+    [Fact]
+    public void ClassifyRoute_GetIdRelatedChain_ReturnsRelatedChain()
+    {
+        var kind = PrefixRouter.ClassifyRoute("GET", "42/_related-chain".AsSpan(),
+            out var id, out _, out _);
+        Assert.Equal((int)ApiRouteKind.RelatedChain, kind);
+        Assert.True(id.SequenceEqual("42".AsSpan()));
+    }
+
+    [Fact]
+    public void ClassifyRoute_GetIdFilesField_ReturnsFileGet()
+    {
+        var kind = PrefixRouter.ClassifyRoute("GET", "42/files/avatar".AsSpan(),
+            out var id, out var extra, out var extraKey);
+        Assert.Equal((int)ApiRouteKind.FileGet, kind);
+        Assert.True(id.SequenceEqual("42".AsSpan()));
+        Assert.True(extra.SequenceEqual("avatar".AsSpan()));
+        Assert.Equal("field", extraKey);
+    }
+
+    [Fact]
+    public void ClassifyRoute_PostIdCommandAction_ReturnsCommand()
+    {
+        var kind = PrefixRouter.ClassifyRoute("POST", "42/_command/approve".AsSpan(),
+            out var id, out var extra, out var extraKey);
+        Assert.Equal((int)ApiRouteKind.Command, kind);
+        Assert.True(id.SequenceEqual("42".AsSpan()));
+        Assert.True(extra.SequenceEqual("approve".AsSpan()));
+        Assert.Equal("command", extraKey);
+    }
+
+    [Fact]
+    public void ClassifyRoute_UnknownVerb_ReturnsNegative()
+    {
+        var kind = PrefixRouter.ClassifyRoute("OPTIONS", ReadOnlySpan<char>.Empty,
+            out _, out _, out _);
+        Assert.Equal(-1, kind);
+    }
+
+    [Fact]
+    public void ClassifyRoute_UnknownSuffix_ReturnsNegative()
+    {
+        var kind = PrefixRouter.ClassifyRoute("GET", "42/unknown".AsSpan(),
+            out _, out _, out _);
+        Assert.Equal(-1, kind);
+    }
+
+    [Fact]
+    public void ClassifyRoute_CaseInsensitiveVerb()
+    {
+        var kind = PrefixRouter.ClassifyRoute("get", ReadOnlySpan<char>.Empty,
+            out _, out _, out _);
+        Assert.Equal((int)ApiRouteKind.List, kind);
+    }
+
+    [Fact]
+    public void ClassifyRoute_CaseInsensitiveSuffix()
+    {
+        var kind = PrefixRouter.ClassifyRoute("GET", "42/_Attachments".AsSpan(),
+            out _, out _, out _);
+        Assert.Equal((int)ApiRouteKind.ListAttachments, kind);
+    }
+
+    // ── ApiRouteKind coverage ───────────────────────────────────────────
+
+    [Fact]
+    public void ApiRouteKind_CountSentinel_MatchesExpected()
+    {
+        // Ensure the sentinel tracks the actual number of route kinds
+        Assert.Equal(14, (int)ApiRouteKind._Count);
+    }
+}

--- a/BareMetalWeb.Host/BareMetalWebServer.cs
+++ b/BareMetalWeb.Host/BareMetalWebServer.cs
@@ -90,6 +90,8 @@ public class BareMetalWebServer : IBareWebHost
     private int _sortedRoutesVersion = -1;
     private readonly RouteJumpTable _jumpTable = new();
     private int _jumpTableVersion = -1;
+    private readonly PrefixRouter _prefixRouter = new();
+    private int _prefixRouterVersion = -1;
     public BareMetalWebServer(
         string appName,
         string companyDescription,
@@ -337,6 +339,16 @@ public class BareMetalWebServer : IBareWebHost
             _jumpTableVersion = _routesVersion;
         }
     }
+
+    /// <summary>Ensures the prefix router is rebuilt when routes change.</summary>
+    private void EnsurePrefixRouter()
+    {
+        if (_prefixRouterVersion != _routesVersion)
+        {
+            _prefixRouter.Build(routes, BufferedLogger);
+            _prefixRouterVersion = _routesVersion;
+        }
+    }
     public Task WireUpRequestHandlingAndLoggerAsyncLifetime()
     {
         EnsureJumpTable();
@@ -467,6 +479,7 @@ public class BareMetalWebServer : IBareWebHost
 
             // ── Jump table: O(1) exact-match dispatch ───────────────────────
             EnsureJumpTable();
+            EnsurePrefixRouter();
             if (_jumpTable.TryLookup(routeKey, out RouteHandlerData page))
             {
                 if (page.PageInfo != null)
@@ -498,6 +511,19 @@ public class BareMetalWebServer : IBareWebHost
                 }
                 await allPage.Handler(bmwCtx);
                 BufferedLogger.LogInfo($"{routeKey}|ALL {requestPath}|200|{sourceIp}");
+                return;
+            }
+            // ── Prefix router: O(1) entity dispatch for /api/{type} routes ──
+            if (_prefixRouter.TryMatch(bmwCtx, out RouteHandlerData prefixPage))
+            {
+                if (!await IsAuthorizedAsync(prefixPage.PageInfo, bmwCtx, context.RequestAborted).ConfigureAwait(false))
+                {
+                    await LogAccessDeniedAsync(routeKey, sourceIp, bmwCtx, prefixPage.PageInfo, context.RequestAborted).ConfigureAwait(false);
+                    await RenderForbidden(bmwCtx);
+                    return;
+                }
+                await prefixPage.Handler(bmwCtx);
+                BufferedLogger.LogInfo($"{routeKey}|200|{sourceIp}|prefix");
                 return;
             }
             // Pattern match fallback — iterate most-specific routes first so that literal

--- a/BareMetalWeb.Host/BinaryApiHandlers.cs
+++ b/BareMetalWeb.Host/BinaryApiHandlers.cs
@@ -757,6 +757,14 @@ public static class BinaryApiHandlers
 
     internal static string? GetRouteValue(BmwContext context, string key)
     {
+        // Fast path: prefix router sets these directly (zero allocation)
+        if (string.Equals(key, "type", StringComparison.OrdinalIgnoreCase) && context.EntitySlug != null)
+            return context.EntitySlug;
+        if (string.Equals(key, "id", StringComparison.OrdinalIgnoreCase) && context.EntityId != null)
+            return context.EntityId;
+        if (context.RouteExtraKey != null && string.Equals(key, context.RouteExtraKey, StringComparison.OrdinalIgnoreCase))
+            return context.RouteExtra;
+
         var pageContext = context.GetPageContext();
         if (pageContext == null) return null;
         for (int i = 0; i < pageContext.PageMetaDataKeys.Length; i++)

--- a/BareMetalWeb.Host/EntityRouteTable.cs
+++ b/BareMetalWeb.Host/EntityRouteTable.cs
@@ -1,0 +1,127 @@
+using System.Runtime.CompilerServices;
+
+namespace BareMetalWeb.Host;
+
+/// <summary>
+/// Open-addressed hash table that maps entity slug spans to pre-interned slug
+/// strings. Built once at startup from <c>DataScaffold.Entities</c>; lookups
+/// are allocation-free (single FNV-1a hash + linear probe on ReadOnlySpan&lt;char&gt;).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The table uses 4× the entity count (rounded to next power-of-two) to keep
+/// probe chains short. Linear probing is cache-friendly for the small table
+/// sizes typical here (≤ 256 entities → ≤ 1024 slots).
+/// </para>
+/// <para>
+/// All comparisons are case-insensitive (OrdinalIgnoreCase) to match the
+/// DataScaffold.EntitiesBySlug dictionary behaviour.
+/// </para>
+/// </remarks>
+public sealed class EntityRouteTable
+{
+    private struct Slot
+    {
+        /// <summary>Pre-interned entity slug (null = empty slot).</summary>
+        public string? Slug;
+    }
+
+    private Slot[] _slots = Array.Empty<Slot>();
+    private uint _mask;
+    private int _count;
+
+    /// <summary>Number of entities in the table.</summary>
+    public int Count => _count;
+
+    /// <summary>
+    /// Build the table from a set of entity slugs.
+    /// Each slug is stored as-is (pre-interned) for zero-allocation comparison.
+    /// </summary>
+    public void Build(IReadOnlyList<string> slugs)
+    {
+        if (slugs.Count == 0)
+        {
+            _slots = Array.Empty<Slot>();
+            _mask = 0;
+            _count = 0;
+            return;
+        }
+
+        int tableSize = NextPowerOfTwo(slugs.Count * 4);
+        uint mask = (uint)(tableSize - 1);
+        var slots = new Slot[tableSize];
+
+        for (int i = 0; i < slugs.Count; i++)
+        {
+            var slug = slugs[i];
+            uint idx = HashSlug(slug.AsSpan()) & mask;
+
+            // Linear probe to find empty slot
+            while (slots[idx].Slug != null)
+                idx = (idx + 1) & mask;
+
+            slots[idx].Slug = slug;
+        }
+
+        _slots = slots;
+        _mask = mask;
+        _count = slugs.Count;
+    }
+
+    /// <summary>
+    /// Resolve an entity slug span to its pre-interned string.
+    /// Returns true if the entity is known; <paramref name="resolvedSlug"/>
+    /// is the canonical slug string (no allocation).
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TryResolve(ReadOnlySpan<char> slug, out string resolvedSlug)
+    {
+        var slots = _slots;
+        if (slots.Length == 0) { resolvedSlug = null!; return false; }
+
+        uint idx = HashSlug(slug) & _mask;
+
+        // Linear probe — max _count probes before guaranteed miss
+        for (int probe = 0; probe <= _count; probe++)
+        {
+            ref var slot = ref slots[idx];
+            if (slot.Slug == null) { resolvedSlug = null!; return false; }
+            if (slug.Equals(slot.Slug.AsSpan(), StringComparison.OrdinalIgnoreCase))
+            {
+                resolvedSlug = slot.Slug;
+                return true;
+            }
+            idx = (idx + 1) & _mask;
+        }
+
+        resolvedSlug = null!;
+        return false;
+    }
+
+    /// <summary>FNV-1a hash over a char span (case-insensitive via ASCII lowering).</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static uint HashSlug(ReadOnlySpan<char> slug)
+    {
+        uint hash = 2166136261u;
+        for (int i = 0; i < slug.Length; i++)
+        {
+            // ASCII-lowercase for case-insensitive hashing
+            uint c = slug[i];
+            if (c >= 'A' && c <= 'Z') c |= 0x20;
+            hash ^= c;
+            hash *= 16777619u;
+        }
+        return hash;
+    }
+
+    private static int NextPowerOfTwo(int v)
+    {
+        v--;
+        v |= v >> 1;
+        v |= v >> 2;
+        v |= v >> 4;
+        v |= v >> 8;
+        v |= v >> 16;
+        return v + 1;
+    }
+}

--- a/BareMetalWeb.Host/LookupApiHandlers.cs
+++ b/BareMetalWeb.Host/LookupApiHandlers.cs
@@ -388,6 +388,14 @@ public static class LookupApiHandlers
 
     private static string? GetRouteValue(BmwContext context, string key)
     {
+        // Fast path: prefix router sets these directly (zero allocation)
+        if (string.Equals(key, "type", StringComparison.OrdinalIgnoreCase) && context.EntitySlug != null)
+            return context.EntitySlug;
+        if (string.Equals(key, "id", StringComparison.OrdinalIgnoreCase) && context.EntityId != null)
+            return context.EntityId;
+        if (context.RouteExtraKey != null && string.Equals(key, context.RouteExtraKey, StringComparison.OrdinalIgnoreCase))
+            return context.RouteExtra;
+
         var pageContext = context.GetPageContext();
         if (pageContext == null)
             return null;

--- a/BareMetalWeb.Host/PrefixRouter.cs
+++ b/BareMetalWeb.Host/PrefixRouter.cs
@@ -1,0 +1,300 @@
+using System.Runtime.CompilerServices;
+using BareMetalWeb.Core;
+using BareMetalWeb.Core.Delegates;
+using BareMetalWeb.Core.Interfaces;
+using BareMetalWeb.Data;
+using BareMetalWeb.Rendering;
+
+namespace BareMetalWeb.Host;
+
+/// <summary>
+/// Classifies an API entity route into a dense integer for array-indexed dispatch.
+/// </summary>
+internal enum ApiRouteKind : byte
+{
+    List,               // GET    /api/{type}
+    Create,             // POST   /api/{type}
+    Import,             // POST   /api/{type}/import
+    Get,                // GET    /api/{type}/{id}
+    Update,             // PUT    /api/{type}/{id}
+    Patch,              // PATCH  /api/{type}/{id}
+    Delete,             // DELETE /api/{type}/{id}
+    FileGet,            // GET    /api/{type}/{id}/files/{field}
+    Command,            // POST   /api/{type}/{id}/_command/{command}
+    ListAttachments,    // GET    /api/{type}/{id}/_attachments
+    AddAttachment,      // POST   /api/{type}/{id}/_attachments
+    ListComments,       // GET    /api/{type}/{id}/_comments
+    AddComment,         // POST   /api/{type}/{id}/_comments
+    RelatedChain,       // GET    /api/{type}/{id}/_related-chain
+    _Count              // sentinel — must be last
+}
+
+/// <summary>
+/// High-performance three-stage router for <c>/api/{entity}</c> routes.
+/// <list type="number">
+///   <item>Prefix classify — <c>path.StartsWith("/api/")</c></item>
+///   <item>Entity resolve — slice slug, hash-probe <see cref="EntityRouteTable"/></item>
+///   <item>Verb+suffix dispatch — classify remaining path → handler array index</item>
+/// </list>
+/// </summary>
+/// <remarks>
+/// <para>
+/// The hot path is allocation-free: entity slug resolved to a pre-interned string,
+/// route parameters set as direct fields on <see cref="BmwContext"/>,
+/// handler invoked via array indexing.
+/// </para>
+/// <para>
+/// Only matches routes for entities registered in <see cref="DataScaffold.Entities"/>.
+/// System prefixes (<c>_binary</c>, <c>_lookup</c>, <c>metadata</c>) are not in the
+/// entity table and fall through to the jump table / pattern matching.
+/// </para>
+/// </remarks>
+public sealed class PrefixRouter
+{
+    private readonly EntityRouteTable _entityTable = new();
+    private readonly RouteHandlerData[] _handlers = new RouteHandlerData[(int)ApiRouteKind._Count];
+    private PageInfo _apiPageInfo = null!;
+    private int _version;
+
+    /// <summary>Current build version (incremented on each <see cref="Build"/>).</summary>
+    public int Version => _version;
+
+    /// <summary>Number of entities in the route table.</summary>
+    public int EntityCount => _entityTable.Count;
+
+    /// <summary>
+    /// Build the prefix router from the registered routes and entity metadata.
+    /// Call after all routes are registered and entities are scaffolded.
+    /// </summary>
+    public void Build(Dictionary<string, RouteHandlerData> routes, IBufferedLogger? logger = null)
+    {
+        // Collect entity slugs from DataScaffold
+        var entities = DataScaffold.Entities;
+        var slugs = new List<string>(entities.Count);
+        foreach (var meta in entities)
+        {
+            if (!string.IsNullOrEmpty(meta.Slug))
+                slugs.Add(meta.Slug);
+        }
+
+        _entityTable.Build(slugs);
+
+        // Extract handler delegates from known route patterns
+        TryExtract(routes, "GET /api/{type}", ApiRouteKind.List);
+        TryExtract(routes, "POST /api/{type}", ApiRouteKind.Create);
+        TryExtract(routes, "POST /api/{type}/import", ApiRouteKind.Import);
+        TryExtract(routes, "GET /api/{type}/{id}", ApiRouteKind.Get);
+        TryExtract(routes, "PUT /api/{type}/{id}", ApiRouteKind.Update);
+        TryExtract(routes, "PATCH /api/{type}/{id}", ApiRouteKind.Patch);
+        TryExtract(routes, "DELETE /api/{type}/{id}", ApiRouteKind.Delete);
+        TryExtract(routes, "GET /api/{type}/{id}/files/{field}", ApiRouteKind.FileGet);
+        TryExtract(routes, "POST /api/{type}/{id}/_command/{command}", ApiRouteKind.Command);
+        TryExtract(routes, "GET /api/{type}/{id}/_attachments", ApiRouteKind.ListAttachments);
+        TryExtract(routes, "POST /api/{type}/{id}/_attachments", ApiRouteKind.AddAttachment);
+        TryExtract(routes, "GET /api/{type}/{id}/_comments", ApiRouteKind.ListComments);
+        TryExtract(routes, "POST /api/{type}/{id}/_comments", ApiRouteKind.AddComment);
+        TryExtract(routes, "GET /api/{type}/{id}/_related-chain", ApiRouteKind.RelatedChain);
+
+        // Build a shared PageInfo for auth checks (all API entity routes use "Authenticated")
+        if (routes.TryGetValue("GET /api/{type}", out var sample) && sample.PageInfo != null)
+        {
+            _apiPageInfo = sample.PageInfo;
+        }
+        else
+        {
+            // Fallback: build a minimal PageInfo
+            _apiPageInfo = new PageInfo(
+                new PageMetaData(null!, 200, "Authenticated", false, 0),
+                new PageContext(Array.Empty<string>(), Array.Empty<string>()));
+        }
+
+        _version++;
+
+        logger?.LogInfo($"PrefixRouter built: {slugs.Count} entities, " +
+                        $"{_handlers.Count(h => h.Handler != null)} route kinds");
+    }
+
+    /// <summary>
+    /// Attempt to match and dispatch a request via the three-stage pipeline.
+    /// Returns true if the route was matched (caller should execute the handler).
+    /// Sets <see cref="BmwContext.EntitySlug"/>, <see cref="BmwContext.EntityId"/>,
+    /// and <see cref="BmwContext.PageInfo"/> on successful match.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TryMatch(BmwContext context, out RouteHandlerData data)
+    {
+        var path = context.Request.Path.AsSpan();
+
+        // Stage 1: Prefix classify
+        if (path.StartsWith("/api/".AsSpan(), StringComparison.Ordinal))
+        {
+            return TryMatchApi(context, path.Slice(5), context.Request.Method, out data);
+        }
+
+        data = default;
+        return false;
+    }
+
+    /// <summary>
+    /// Dispatch an <c>/api/...</c> route. <paramref name="remainder"/> is the
+    /// path after <c>/api/</c> (e.g. <c>users/42/_attachments</c>).
+    /// </summary>
+    private bool TryMatchApi(BmwContext context, ReadOnlySpan<char> remainder,
+                             string method, out RouteHandlerData data)
+    {
+        data = default;
+
+        // Stage 2: Extract entity slug (first segment after /api/)
+        int slash = remainder.IndexOf('/');
+        ReadOnlySpan<char> entitySlug;
+        ReadOnlySpan<char> rest;
+
+        if (slash < 0)
+        {
+            entitySlug = remainder;
+            rest = ReadOnlySpan<char>.Empty;
+        }
+        else
+        {
+            entitySlug = remainder[..slash];
+            rest = remainder[(slash + 1)..];
+        }
+
+        if (entitySlug.IsEmpty) return false;
+
+        // Resolve entity via hash table
+        if (!_entityTable.TryResolve(entitySlug, out var resolvedSlug))
+            return false;
+
+        // Stage 3: Classify verb + remaining path suffix
+        var kind = ClassifyRoute(method, rest,
+                                 out var idSpan, out var extraSpan, out var extraKey);
+        if (kind < 0) return false;
+
+        ref var handler = ref _handlers[kind];
+        if (handler.Handler == null) return false;
+
+        // Set fast-path fields on BmwContext (zero allocation for entity slug)
+        context.EntitySlug = resolvedSlug;
+        if (!idSpan.IsEmpty)
+            context.EntityId = idSpan.ToString();
+        if (!extraSpan.IsEmpty)
+        {
+            context.RouteExtra = extraSpan.ToString();
+            context.RouteExtraKey = extraKey;
+        }
+
+        // Set PageInfo for auth check
+        context.PageInfo = _apiPageInfo;
+        context.SetPageInfo(_apiPageInfo);
+
+        data = handler;
+        return true;
+    }
+
+    /// <summary>
+    /// Classify an API route's remaining path (after <c>/api/{entity}/</c>) and
+    /// HTTP method into an <see cref="ApiRouteKind"/> ordinal.
+    /// Returns -1 for unknown combinations (fall through to pattern matching).
+    /// </summary>
+    internal static int ClassifyRoute(string method, ReadOnlySpan<char> remainder,
+        out ReadOnlySpan<char> id, out ReadOnlySpan<char> extra, out string? extraKey)
+    {
+        id = default;
+        extra = default;
+        extraKey = null;
+
+        // /api/{entity} — no id segment
+        if (remainder.IsEmpty)
+        {
+            if (string.Equals(method, "GET", StringComparison.OrdinalIgnoreCase))
+                return (int)ApiRouteKind.List;
+            if (string.Equals(method, "POST", StringComparison.OrdinalIgnoreCase))
+                return (int)ApiRouteKind.Create;
+            return -1;
+        }
+
+        // /api/{entity}/import
+        if (remainder.Equals("import".AsSpan(), StringComparison.OrdinalIgnoreCase))
+        {
+            if (string.Equals(method, "POST", StringComparison.OrdinalIgnoreCase))
+                return (int)ApiRouteKind.Import;
+            return -1;
+        }
+
+        // Extract {id} segment
+        int slash = remainder.IndexOf('/');
+        if (slash < 0)
+        {
+            // /api/{entity}/{id} — just id, no suffix
+            id = remainder;
+            if (string.Equals(method, "GET", StringComparison.OrdinalIgnoreCase))
+                return (int)ApiRouteKind.Get;
+            if (string.Equals(method, "PUT", StringComparison.OrdinalIgnoreCase))
+                return (int)ApiRouteKind.Update;
+            if (string.Equals(method, "PATCH", StringComparison.OrdinalIgnoreCase))
+                return (int)ApiRouteKind.Patch;
+            if (string.Equals(method, "DELETE", StringComparison.OrdinalIgnoreCase))
+                return (int)ApiRouteKind.Delete;
+            return -1;
+        }
+
+        id = remainder[..slash];
+        var suffix = remainder[(slash + 1)..];
+
+        // Known suffixes (underscore-prefixed system routes)
+        if (suffix.Equals("_attachments".AsSpan(), StringComparison.OrdinalIgnoreCase))
+        {
+            if (string.Equals(method, "GET", StringComparison.OrdinalIgnoreCase))
+                return (int)ApiRouteKind.ListAttachments;
+            if (string.Equals(method, "POST", StringComparison.OrdinalIgnoreCase))
+                return (int)ApiRouteKind.AddAttachment;
+            return -1;
+        }
+
+        if (suffix.Equals("_comments".AsSpan(), StringComparison.OrdinalIgnoreCase))
+        {
+            if (string.Equals(method, "GET", StringComparison.OrdinalIgnoreCase))
+                return (int)ApiRouteKind.ListComments;
+            if (string.Equals(method, "POST", StringComparison.OrdinalIgnoreCase))
+                return (int)ApiRouteKind.AddComment;
+            return -1;
+        }
+
+        if (suffix.Equals("_related-chain".AsSpan(), StringComparison.OrdinalIgnoreCase))
+        {
+            if (string.Equals(method, "GET", StringComparison.OrdinalIgnoreCase))
+                return (int)ApiRouteKind.RelatedChain;
+            return -1;
+        }
+
+        // /api/{entity}/{id}/files/{field}
+        if (suffix.StartsWith("files/".AsSpan(), StringComparison.OrdinalIgnoreCase) && suffix.Length > 6)
+        {
+            extra = suffix.Slice(6);
+            extraKey = "field";
+            if (string.Equals(method, "GET", StringComparison.OrdinalIgnoreCase))
+                return (int)ApiRouteKind.FileGet;
+            return -1;
+        }
+
+        // /api/{entity}/{id}/_command/{command}
+        if (suffix.StartsWith("_command/".AsSpan(), StringComparison.OrdinalIgnoreCase) && suffix.Length > 9)
+        {
+            extra = suffix.Slice(9);
+            extraKey = "command";
+            if (string.Equals(method, "POST", StringComparison.OrdinalIgnoreCase))
+                return (int)ApiRouteKind.Command;
+            return -1;
+        }
+
+        return -1; // Unknown suffix — fall through to pattern matching
+    }
+
+    private void TryExtract(Dictionary<string, RouteHandlerData> routes,
+                            string routeKey, ApiRouteKind kind)
+    {
+        if (routes.TryGetValue(routeKey, out var data))
+            _handlers[(int)kind] = data;
+    }
+}

--- a/BareMetalWeb.Host/RouteHandlers.cs
+++ b/BareMetalWeb.Host/RouteHandlers.cs
@@ -6424,6 +6424,14 @@ public sealed class RouteHandlers : IRouteHandlers
 
     private static string? GetRouteValue(BmwContext context, string key)
     {
+        // Fast path: prefix router sets these directly (zero allocation)
+        if (string.Equals(key, "type", StringComparison.OrdinalIgnoreCase) && context.EntitySlug != null)
+            return context.EntitySlug;
+        if (string.Equals(key, "id", StringComparison.OrdinalIgnoreCase) && context.EntityId != null)
+            return context.EntityId;
+        if (context.RouteExtraKey != null && string.Equals(key, context.RouteExtraKey, StringComparison.OrdinalIgnoreCase))
+            return context.RouteExtra;
+
         var pageContext = context.GetPageContext();
         if (pageContext == null)
             return null;

--- a/BareMetalWeb.Host/RouteRegistrationExtensions.cs
+++ b/BareMetalWeb.Host/RouteRegistrationExtensions.cs
@@ -427,6 +427,14 @@ public static class RouteRegistrationExtensions
 
     private static string? GetRouteParam(BmwContext context, string key)
     {
+        // Fast path: prefix router sets these directly (zero allocation)
+        if (string.Equals(key, "type", StringComparison.OrdinalIgnoreCase) && context.EntitySlug != null)
+            return context.EntitySlug;
+        if (string.Equals(key, "id", StringComparison.OrdinalIgnoreCase) && context.EntityId != null)
+            return context.EntityId;
+        if (context.RouteExtraKey != null && string.Equals(key, context.RouteExtraKey, StringComparison.OrdinalIgnoreCase))
+            return context.RouteExtra;
+
         var pageContext = context.GetPageContext();
         if (pageContext == null) return null;
         for (int i = 0; i < pageContext.PageMetaDataKeys.Length; i++)


### PR DESCRIPTION
## Summary

Three-stage allocation-free dispatch pipeline for `/api/{entity}` routes:

1. **Prefix classify** - `path.StartsWith("/api/")` (JIT vectorises internally)
2. **Entity resolve** - slice slug, FNV-1a hash into open-addressed table, validate known entity
3. **Verb+suffix dispatch** - classify remaining path + HTTP method → handler array index → direct call

### Hot path: zero allocation
- Entity slug resolved to pre-interned string from `DataScaffold.Entities`  
- Route params set as direct fields on `BmwContext` (EntitySlug, EntityId)
- `GetRouteValue` checks these before falling back to `PageMetaDataKeys` scan
- No `Dictionary<string,string>` for route params
- No `List<string>` + `ToArray()` for PageInfo injection
- No O(N) pattern matching loop

### New files
- **EntityRouteTable** — open-addressed hash table (FNV-1a, 4× load, linear probe, case-insensitive)
- **PrefixRouter** — prefix classify + entity resolve + verb/suffix dispatch (14 route kinds)
- **30 unit tests** — EntityRouteTableTests + PrefixRouterTests

### Modified files
- **BmwContext** — added EntitySlug/EntityId/RouteExtra/RouteExtraKey fields
- **BinaryApiHandlers/LookupApiHandlers/RouteHandlers/RouteRegistrationExtensions** — GetRouteValue fast-path
- **BareMetalWebServer** — PrefixRouter wired after jump table, before pattern matching

Also fixes .NET 10 ref-safety build errors in BmwJsonWriter/BmwJsonReader.