### PR TITLE
feat: MetadataCompiler — dense struct-of-arrays runtime tables

### DIFF
--- a/BareMetalWeb.Data.Tests/MetadataCompilerTests.cs
+++ b/BareMetalWeb.Data.Tests/MetadataCompilerTests.cs
@@ -1,0 +1,249 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using BareMetalWeb.Core;
+using BareMetalWeb.Data;
+using BareMetalWeb.Rendering.Models;
+using Xunit;
+
+namespace BareMetalWeb.Data.Tests;
+
+public class MetadataCompilerTests
+{
+    // Shared no-op handlers for test metadata
+    private static readonly DataEntityHandlers DummyHandlers = new(
+        Create: () => throw new NotSupportedException(),
+        LoadAsync: (_, _) => ValueTask.FromResult<BaseDataObject?>(null),
+        SaveAsync: (_, _) => ValueTask.CompletedTask,
+        DeleteAsync: (_, _) => ValueTask.CompletedTask,
+        QueryAsync: (_, _) => ValueTask.FromResult<IEnumerable<BaseDataObject>>(Array.Empty<BaseDataObject>()),
+        CountAsync: (_, _) => ValueTask.FromResult(0)
+    );
+
+    private static DataFieldMetadata MakeField(string name, FormFieldType type = FormFieldType.String, int order = 0,
+        bool required = false, bool readOnly = false, int columnSpan = 12) =>
+        new(
+            Property: typeof(string).GetProperty(nameof(string.Length))!, // dummy PropertyInfo
+            Name: name,
+            Label: name,
+            FieldType: type,
+            Order: order,
+            Required: required,
+            List: true,
+            View: true,
+            Edit: true,
+            Create: true,
+            ReadOnly: readOnly,
+            Placeholder: null,
+            Lookup: null,
+            IdGeneration: IdGenerationStrategy.None,
+            Computed: null,
+            Upload: null,
+            Calculated: null,
+            Validation: null,
+            ColumnSpan: columnSpan
+        );
+
+    private static DataEntityMetadata MakeEntity(string slug, params DataFieldMetadata[] fields) =>
+        new(
+            Type: typeof(object),
+            Name: slug,
+            Slug: slug,
+            Permissions: "",
+            ShowOnNav: true,
+            NavGroup: null,
+            NavOrder: 0,
+            IdGeneration: AutoIdStrategy.Sequential,
+            ViewType: ViewType.Table,
+            ParentField: null,
+            Fields: fields,
+            Handlers: DummyHandlers,
+            Commands: Array.Empty<RemoteCommandMetadata>()
+        );
+
+    [Fact]
+    public void Compile_EmptyList_ReturnsEmptyTables()
+    {
+        var snapshot = MetadataCompiler.Compile(Array.Empty<DataEntityMetadata>());
+
+        Assert.Equal(0, snapshot.Entities.Count);
+        Assert.Equal(0, snapshot.Fields.Count);
+    }
+
+    [Fact]
+    public void Compile_SingleEntity_AssignsEntityIdZero()
+    {
+        var entity = MakeEntity("orders", MakeField("total", FormFieldType.Money), MakeField("status"));
+        var snapshot = MetadataCompiler.Compile(new[] { entity });
+
+        Assert.Equal(1, snapshot.Entities.Count);
+        Assert.Equal(2, snapshot.Fields.Count);
+
+        Assert.Equal("orders", snapshot.Entities.Slugs[0]);
+        Assert.Equal(0, snapshot.Entities.FieldStart[0]);
+        Assert.Equal(2, snapshot.Entities.FieldCount[0]);
+    }
+
+    [Fact]
+    public void Compile_MultipleEntities_SortedBySlug_ContiguousFieldIds()
+    {
+        var e1 = MakeEntity("zeta", MakeField("z1"));
+        var e2 = MakeEntity("alpha", MakeField("a1"), MakeField("a2"));
+        var e3 = MakeEntity("mid", MakeField("m1"), MakeField("m2"), MakeField("m3"));
+
+        var snapshot = MetadataCompiler.Compile(new[] { e1, e2, e3 });
+
+        Assert.Equal(3, snapshot.Entities.Count);
+        Assert.Equal(6, snapshot.Fields.Count);
+
+        // Sorted by slug: alpha=0, mid=1, zeta=2
+        Assert.Equal("alpha", snapshot.Entities.Slugs[0]);
+        Assert.Equal("mid", snapshot.Entities.Slugs[1]);
+        Assert.Equal("zeta", snapshot.Entities.Slugs[2]);
+
+        // alpha: fields 0..1
+        Assert.Equal(0, snapshot.Entities.FieldStart[0]);
+        Assert.Equal(2, snapshot.Entities.FieldCount[0]);
+
+        // mid: fields 2..4
+        Assert.Equal(2, snapshot.Entities.FieldStart[1]);
+        Assert.Equal(3, snapshot.Entities.FieldCount[1]);
+
+        // zeta: fields 5..5
+        Assert.Equal(5, snapshot.Entities.FieldStart[2]);
+        Assert.Equal(1, snapshot.Entities.FieldCount[2]);
+
+        // Verify field→entity back-reference
+        Assert.Equal(0, snapshot.Fields.EntityIds[0]); // a1 → alpha
+        Assert.Equal(0, snapshot.Fields.EntityIds[1]); // a2 → alpha
+        Assert.Equal(1, snapshot.Fields.EntityIds[2]); // m1 → mid
+        Assert.Equal(2, snapshot.Fields.EntityIds[5]); // z1 → zeta
+    }
+
+    [Fact]
+    public void Compile_SlugLookup_ReturnsCorrectEntityId()
+    {
+        var entities = new[]
+        {
+            MakeEntity("products", MakeField("name")),
+            MakeEntity("customers", MakeField("email")),
+            MakeEntity("orders", MakeField("total")),
+        };
+
+        var snapshot = MetadataCompiler.Compile(entities);
+
+        // Sorted: customers=0, orders=1, products=2
+        Assert.True(snapshot.Entities.TryResolveSlug("customers", out int id0));
+        Assert.Equal(0, id0);
+
+        Assert.True(snapshot.Entities.TryResolveSlug("orders", out int id1));
+        Assert.Equal(1, id1);
+
+        Assert.True(snapshot.Entities.TryResolveSlug("products", out int id2));
+        Assert.Equal(2, id2);
+
+        Assert.False(snapshot.Entities.TryResolveSlug("nonexistent", out _));
+    }
+
+    [Fact]
+    public void Compile_FieldFlags_PackedCorrectly()
+    {
+        var field = MakeField("name", required: true, readOnly: true);
+        var entity = MakeEntity("test", field);
+
+        var snapshot = MetadataCompiler.Compile(new[] { entity });
+
+        var flags = snapshot.Fields.Flags[0];
+        Assert.True((flags & FieldFlags.Required) != 0);
+        Assert.True((flags & FieldFlags.ReadOnly) != 0);
+        Assert.True((flags & FieldFlags.Lookup) == 0);
+    }
+
+    [Fact]
+    public void Compile_WireTypeMapping_CorrectForKnownTypes()
+    {
+        var fields = new[]
+        {
+            MakeField("flag", FormFieldType.YesNo),
+            MakeField("count", FormFieldType.Integer),
+            MakeField("price", FormFieldType.Money),
+            MakeField("when", FormFieldType.DateTime),
+            MakeField("label", FormFieldType.String),
+        };
+
+        var snapshot = MetadataCompiler.Compile(new[] { MakeEntity("test", fields) });
+
+        Assert.Equal(MetadataWireSerializer.WireFieldType.Bool, snapshot.Fields.WireTypes[0]);
+        Assert.Equal(MetadataWireSerializer.WireFieldType.Int32, snapshot.Fields.WireTypes[1]);
+        Assert.Equal(MetadataWireSerializer.WireFieldType.Decimal, snapshot.Fields.WireTypes[2]);
+        Assert.Equal(MetadataWireSerializer.WireFieldType.DateTime, snapshot.Fields.WireTypes[3]);
+        Assert.Equal(MetadataWireSerializer.WireFieldType.String, snapshot.Fields.WireTypes[4]);
+    }
+
+    [Fact]
+    public void RouteTable_SetAndResolve_RoundTrips()
+    {
+        var snapshot = MetadataCompiler.Compile(new[] { MakeEntity("test", MakeField("f1")) });
+
+        bool called = false;
+        snapshot.Routes.Set(0, ApiVerb.List, ctx => { called = true; return ValueTask.CompletedTask; });
+
+        var handler = snapshot.Routes.Resolve(0, ApiVerb.List);
+        Assert.NotNull(handler);
+
+        Assert.Null(snapshot.Routes.Resolve(0, ApiVerb.Delete));
+    }
+
+    [Fact]
+    public void CompileAndSwap_AtomicallyReplacesSnapshot()
+    {
+        var e1 = MakeEntity("v1", MakeField("f1"));
+        var first = MetadataCompiler.CompileAndSwap(new[] { e1 });
+
+        Assert.Same(first, RuntimeSnapshot.Current);
+
+        var e2 = MakeEntity("v2", MakeField("f2"), MakeField("f3"));
+        var second = MetadataCompiler.CompileAndSwap(new[] { e2 });
+
+        Assert.Same(second, RuntimeSnapshot.Current);
+        Assert.NotSame(first, second);
+
+        // Old snapshot is still valid (immutable)
+        Assert.Equal(1, first.Entities.Count);
+        Assert.Equal(1, first.Fields.Count);
+
+        // New snapshot reflects changes
+        Assert.Equal(1, second.Entities.Count);
+        Assert.Equal(2, second.Fields.Count);
+    }
+
+    [Fact]
+    public void Compile_IdStrategy_PreservedFromMetadata()
+    {
+        var entity = MakeEntity("test", MakeField("f1"));
+        var snapshot = MetadataCompiler.Compile(new[] { entity });
+
+        Assert.Equal(AutoIdStrategy.Sequential, snapshot.Entities.IdStrategies[0]);
+    }
+
+    [Fact]
+    public void Compile_NavMetadata_PreservedFromMetadata()
+    {
+        var entity = MakeEntity("test", MakeField("f1"));
+        var snapshot = MetadataCompiler.Compile(new[] { entity });
+
+        Assert.True(snapshot.Entities.ShowOnNav[0]);
+        Assert.Equal(0, snapshot.Entities.NavOrder[0]);
+    }
+
+    [Fact]
+    public void Compile_ColumnSpan_PreservedFromMetadata()
+    {
+        var field = MakeField("wide", columnSpan: 6);
+        var snapshot = MetadataCompiler.Compile(new[] { MakeEntity("test", field) });
+
+        Assert.Equal(6, snapshot.Fields.ColumnSpans[0]);
+    }
+}

--- a/BareMetalWeb.Data/EntityTable.cs
+++ b/BareMetalWeb.Data/EntityTable.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Runtime.CompilerServices;
+using BareMetalWeb.Core;
+
+namespace BareMetalWeb.Data;
+
+/// <summary>
+/// Dense struct-of-arrays table for entity metadata, indexed by contiguous EntityId (0..Count-1).
+/// Immutable after construction — safe for concurrent reads without locking.
+/// </summary>
+public sealed class EntityTable
+{
+    public readonly int Count;
+    public readonly string[] Names;
+    public readonly string[] Slugs;
+    public readonly int[] FieldStart;   // first global FieldId for this entity
+    public readonly int[] FieldCount;   // number of fields for this entity
+    public readonly bool[] ShowOnNav;
+    public readonly int[] NavOrder;
+    public readonly AutoIdStrategy[] IdStrategies;
+    public readonly DataEntityHandlers[] Handlers;
+
+    // slug → EntityId resolver (sorted slugs + binary search)
+    private readonly string[] _sortedSlugs;
+    private readonly int[] _sortedEntityIds;
+
+    public EntityTable(
+        string[] names,
+        string[] slugs,
+        int[] fieldStart,
+        int[] fieldCount,
+        bool[] showOnNav,
+        int[] navOrder,
+        AutoIdStrategy[] idStrategies,
+        DataEntityHandlers[] handlers,
+        string[] sortedSlugs,
+        int[] sortedEntityIds)
+    {
+        Count = names.Length;
+        Names = names;
+        Slugs = slugs;
+        FieldStart = fieldStart;
+        FieldCount = fieldCount;
+        ShowOnNav = showOnNav;
+        NavOrder = navOrder;
+        IdStrategies = idStrategies;
+        Handlers = handlers;
+        _sortedSlugs = sortedSlugs;
+        _sortedEntityIds = sortedEntityIds;
+    }
+
+    /// <summary>
+    /// Resolves an entity slug to its EntityId. Returns -1 if not found.
+    /// O(log N) via binary search on sorted slug array.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public int ResolveSlug(string slug)
+    {
+        int idx = Array.BinarySearch(_sortedSlugs, slug, StringComparer.OrdinalIgnoreCase);
+        return idx >= 0 ? _sortedEntityIds[idx] : -1;
+    }
+
+    /// <summary>
+    /// Resolves an entity slug to its EntityId. Returns false if not found.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TryResolveSlug(string slug, out int entityId)
+    {
+        entityId = ResolveSlug(slug);
+        return entityId >= 0;
+    }
+}

--- a/BareMetalWeb.Data/FieldTable.cs
+++ b/BareMetalWeb.Data/FieldTable.cs
@@ -1,0 +1,41 @@
+using System;
+using BareMetalWeb.Rendering.Models;
+using static BareMetalWeb.Data.MetadataWireSerializer;
+
+namespace BareMetalWeb.Data;
+
+/// <summary>
+/// Dense struct-of-arrays table for field metadata, indexed by contiguous FieldId (0..Count-1).
+/// Fields are grouped by entity: entity E's fields span FieldTable[EntityTable.FieldStart[E] .. +FieldCount[E]).
+/// Immutable after construction — safe for concurrent reads without locking.
+/// </summary>
+public sealed class FieldTable
+{
+    public readonly int Count;
+    public readonly string[] Names;
+    public readonly WireFieldType[] WireTypes;
+    public readonly FormFieldType[] FormTypes;
+    public readonly FieldFlags[] Flags;
+    public readonly int[] Orders;        // display order
+    public readonly int[] EntityIds;     // owning EntityId
+    public readonly int[] ColumnSpans;   // Bootstrap grid width (1-12)
+
+    public FieldTable(
+        string[] names,
+        WireFieldType[] wireTypes,
+        FormFieldType[] formTypes,
+        FieldFlags[] flags,
+        int[] orders,
+        int[] entityIds,
+        int[] columnSpans)
+    {
+        Count = names.Length;
+        Names = names;
+        WireTypes = wireTypes;
+        FormTypes = formTypes;
+        Flags = flags;
+        Orders = orders;
+        EntityIds = entityIds;
+        ColumnSpans = columnSpans;
+    }
+}

--- a/BareMetalWeb.Data/MetadataCompiler.cs
+++ b/BareMetalWeb.Data/MetadataCompiler.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using BareMetalWeb.Core;
+using BareMetalWeb.Rendering.Models;
+using static BareMetalWeb.Data.MetadataWireSerializer;
+
+namespace BareMetalWeb.Data;
+
+/// <summary>
+/// Compiles DataEntityMetadata/DataFieldMetadata into dense, ordinal-indexed
+/// runtime tables optimised for cache-friendly array reads on hot paths.
+/// Runs at startup after WAL replay and on metadata/gallery changes.
+/// </summary>
+public static class MetadataCompiler
+{
+    /// <summary>
+    /// Compiles a set of entity metadata into an immutable <see cref="RuntimeSnapshot"/>.
+    /// Assigns contiguous EntityIds (sorted by slug) and contiguous FieldIds.
+    /// </summary>
+    public static RuntimeSnapshot Compile(IReadOnlyList<DataEntityMetadata> entities)
+    {
+        int entityCount = entities.Count;
+
+        // Sort entities by slug for deterministic ID assignment
+        var sorted = new DataEntityMetadata[entityCount];
+        for (int i = 0; i < entityCount; i++) sorted[i] = entities[i];
+        Array.Sort(sorted, (a, b) => string.Compare(a.Slug, b.Slug, StringComparison.OrdinalIgnoreCase));
+
+        // --- Pass 1: count total fields ---
+        int totalFields = 0;
+        for (int i = 0; i < entityCount; i++)
+            totalFields += sorted[i].Fields.Count;
+
+        // --- Allocate entity arrays ---
+        var eNames        = new string[entityCount];
+        var eSlugs        = new string[entityCount];
+        var eFieldStart   = new int[entityCount];
+        var eFieldCount   = new int[entityCount];
+        var eShowOnNav    = new bool[entityCount];
+        var eNavOrder     = new int[entityCount];
+        var eIdStrategies = new AutoIdStrategy[entityCount];
+        var eHandlers     = new DataEntityHandlers[entityCount];
+
+        // --- Allocate field arrays ---
+        var fNames       = new string[totalFields];
+        var fWireTypes   = new WireFieldType[totalFields];
+        var fFormTypes   = new FormFieldType[totalFields];
+        var fFlags       = new FieldFlags[totalFields];
+        var fOrders      = new int[totalFields];
+        var fEntityIds   = new int[totalFields];
+        var fColumnSpans = new int[totalFields];
+
+        // --- Slug lookup arrays (sorted for binary search) ---
+        var sortedSlugs     = new string[entityCount];
+        var sortedEntityIds = new int[entityCount];
+
+        // --- Pass 2: populate ---
+        int fieldOffset = 0;
+        for (int entityId = 0; entityId < entityCount; entityId++)
+        {
+            var meta = sorted[entityId];
+
+            eNames[entityId]        = meta.Name;
+            eSlugs[entityId]        = meta.Slug;
+            eFieldStart[entityId]   = fieldOffset;
+            eFieldCount[entityId]   = meta.Fields.Count;
+            eShowOnNav[entityId]    = meta.ShowOnNav;
+            eNavOrder[entityId]     = meta.NavOrder;
+            eIdStrategies[entityId] = meta.IdGeneration;
+            eHandlers[entityId]     = meta.Handlers;
+
+            sortedSlugs[entityId]     = meta.Slug;
+            sortedEntityIds[entityId] = entityId;
+
+            var fields = meta.Fields;
+            for (int fi = 0; fi < fields.Count; fi++)
+            {
+                int globalFieldId = fieldOffset + fi;
+                var field = fields[fi];
+
+                fNames[globalFieldId]       = field.Name;
+                fWireTypes[globalFieldId]   = ResolveFormFieldToWireType(field.FieldType);
+                fFormTypes[globalFieldId]   = field.FieldType;
+                fFlags[globalFieldId]       = PackFlags(field);
+                fOrders[globalFieldId]      = field.Order;
+                fEntityIds[globalFieldId]   = entityId;
+                fColumnSpans[globalFieldId] = field.ColumnSpan;
+            }
+
+            fieldOffset += fields.Count;
+        }
+
+        var entityTable = new EntityTable(
+            eNames, eSlugs, eFieldStart, eFieldCount,
+            eShowOnNav, eNavOrder, eIdStrategies, eHandlers,
+            sortedSlugs, sortedEntityIds);
+
+        var fieldTable = new FieldTable(
+            fNames, fWireTypes, fFormTypes, fFlags,
+            fOrders, fEntityIds, fColumnSpans);
+
+        var routeTable = new RouteTable(entityCount);
+
+        return new RuntimeSnapshot(entityTable, fieldTable, routeTable);
+    }
+
+    /// <summary>
+    /// Compiles and atomically swaps the current <see cref="RuntimeSnapshot"/>.
+    /// </summary>
+    public static RuntimeSnapshot CompileAndSwap(IReadOnlyList<DataEntityMetadata> entities)
+    {
+        var snapshot = Compile(entities);
+        RuntimeSnapshot.Swap(snapshot);
+        return snapshot;
+    }
+
+    private static FieldFlags PackFlags(DataFieldMetadata field)
+    {
+        var flags = FieldFlags.None;
+        if (field.Required)                         flags |= FieldFlags.Required;
+        if (field.ReadOnly)                         flags |= FieldFlags.ReadOnly;
+        if (field.Lookup != null)                   flags |= FieldFlags.Lookup;
+        if (field.Computed != null)                  flags |= FieldFlags.Computed;
+        return flags;
+    }
+
+    private static WireFieldType ResolveFormFieldToWireType(FormFieldType formType) => formType switch
+    {
+        FormFieldType.YesNo        => WireFieldType.Bool,
+        FormFieldType.Integer      => WireFieldType.Int32,
+        FormFieldType.Decimal      => WireFieldType.Decimal,
+        FormFieldType.Money        => WireFieldType.Decimal,
+        FormFieldType.DateTime     => WireFieldType.DateTime,
+        FormFieldType.DateOnly     => WireFieldType.DateOnly,
+        FormFieldType.TimeOnly     => WireFieldType.TimeOnly,
+        FormFieldType.Enum         => WireFieldType.Enum,
+        FormFieldType.LookupList   => WireFieldType.String,
+        FormFieldType.GeoCoordinate => WireFieldType.Float64,
+        _                          => WireFieldType.String,
+    };
+}

--- a/BareMetalWeb.Data/RouteTable.cs
+++ b/BareMetalWeb.Data/RouteTable.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Runtime.CompilerServices;
+using BareMetalWeb.Core.Delegates;
+
+namespace BareMetalWeb.Data;
+
+/// <summary>
+/// Verb/action ordinals for entity API routes.
+/// Combined with EntityId to form a flat dispatch index: (entityId &lt;&lt; VerbBits) | verb.
+/// </summary>
+public enum ApiVerb : byte
+{
+    List           = 0,
+    Create         = 1,
+    Import         = 2,
+    Get            = 3,
+    Update         = 4,
+    Patch          = 5,
+    Delete         = 6,
+    FileGet        = 7,
+    Command        = 8,
+    AttachList     = 9,
+    AttachAdd      = 10,
+    CommentList    = 11,
+    CommentAdd     = 12,
+    RelatedChain   = 13,
+    GlobalSearch   = 14,
+    // room for 1 more before hitting 16 (4 bits)
+}
+
+/// <summary>
+/// Flat dispatch table for entity API routes.
+/// Indexed by (entityId &lt;&lt; VerbBits) | verbOrdinal for O(1) handler lookup.
+/// Immutable after construction — safe for concurrent reads without locking.
+/// </summary>
+public sealed class RouteTable
+{
+    public const int VerbBits = 4;
+    public const int VerbCount = 1 << VerbBits; // 16
+
+    private readonly RouteHandlerDelegate?[] _handlers;
+    public readonly int EntityCount;
+
+    public RouteTable(int entityCount)
+    {
+        EntityCount = entityCount;
+        _handlers = new RouteHandlerDelegate?[entityCount * VerbCount];
+    }
+
+    /// <summary>
+    /// Sets a handler for a specific entity + verb combination.
+    /// Called during compilation only (before the table is published).
+    /// </summary>
+    public void Set(int entityId, ApiVerb verb, RouteHandlerDelegate handler)
+    {
+        _handlers[(entityId << VerbBits) | (int)verb] = handler;
+    }
+
+    /// <summary>
+    /// Resolves a handler for a specific entity + verb combination.
+    /// Returns null if no handler is registered.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public RouteHandlerDelegate? Resolve(int entityId, ApiVerb verb)
+    {
+        int index = (entityId << VerbBits) | (int)verb;
+        return (uint)index < (uint)_handlers.Length ? _handlers[index] : null;
+    }
+}

--- a/BareMetalWeb.Data/RuntimeSnapshot.cs
+++ b/BareMetalWeb.Data/RuntimeSnapshot.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Threading;
+
+namespace BareMetalWeb.Data;
+
+/// <summary>
+/// Immutable compiled snapshot of all entity/field/route metadata,
+/// optimised for cache-friendly array-indexed reads on hot paths.
+/// Rebuilt and atomically swapped when metadata changes.
+/// </summary>
+public sealed class RuntimeSnapshot
+{
+    private static volatile RuntimeSnapshot? _current;
+
+    /// <summary>
+    /// The currently active snapshot. Null until first compilation.
+    /// Reads are lock-free (volatile reference swap).
+    /// </summary>
+    public static RuntimeSnapshot? Current
+    {
+        get => _current;
+        private set => _current = value;
+    }
+
+    public readonly EntityTable Entities;
+    public readonly FieldTable Fields;
+    public readonly RouteTable Routes;
+    public readonly long CompiledAtTicks;
+
+    public RuntimeSnapshot(EntityTable entities, FieldTable fields, RouteTable routes)
+    {
+        Entities = entities;
+        Fields = fields;
+        Routes = routes;
+        CompiledAtTicks = DateTime.UtcNow.Ticks;
+    }
+
+    /// <summary>
+    /// Atomically replaces the current snapshot. Returns the previous snapshot (for diagnostics).
+    /// </summary>
+    public static RuntimeSnapshot? Swap(RuntimeSnapshot newSnapshot)
+    {
+        return Interlocked.Exchange(ref _current, newSnapshot);
+    }
+}

--- a/BareMetalWeb.Host/BareMetalWebExtensions.cs
+++ b/BareMetalWeb.Host/BareMetalWebExtensions.cs
@@ -117,6 +117,11 @@ public static class BareMetalWebExtensions
             dataRoot,
             msg => logger.LogInfo($"[RuntimeEntityRegistry] {msg}")).ConfigureAwait(false);
 
+        // Compile metadata into dense runtime tables (struct-of-arrays)
+        MetadataCompiler.CompileAndSwap(DataScaffold.Entities);
+        logger.LogInfo($"[MetadataCompiler] Compiled {RuntimeSnapshot.Current!.Entities.Count} entities, " +
+                       $"{RuntimeSnapshot.Current.Fields.Count} fields");
+
         // Permissions
         var permSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var e in DataScaffold.Entities)

--- a/BareMetalWeb.Host/RouteHandlers.cs
+++ b/BareMetalWeb.Host/RouteHandlers.cs
@@ -4067,6 +4067,7 @@ public sealed class RouteHandlers : IRouteHandlers
             try
             {
                 await RuntimeEntityRegistry.RebuildAsync().ConfigureAwait(false);
+                MetadataCompiler.CompileAndSwap(DataScaffold.Entities);
                 _logger?.LogInfo($"Gallery|deployed|{packageSlug}|entities={deployed.Count}|registry-rebuilt");
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary

Adds a **MetadataCompiler** that converts registered DataEntityMetadata/DataFieldMetadata into dense, ordinal-indexed struct-of-arrays runtime tables at startup for cache-friendly hot-path access.

### New Files
- **EntityTable.cs** — struct-of-arrays indexed by contiguous EntityId (sorted by slug), with binary-search slug→EntityId resolver
- **FieldTable.cs** — struct-of-arrays indexed by contiguous FieldId (entity-grouped), packed FieldFlags, WireFieldType mapping  
- **RouteTable.cs** — flat dispatch array: handlers[(entityId << 4) | verb] for O(1) handler resolution
- **RuntimeSnapshot.cs** — immutable container with atomic Interlocked.Exchange swap
- **MetadataCompiler.cs** — assigns contiguous IDs, builds all tables, returns frozen snapshot
- **MetadataCompilerTests.cs** — 11 tests covering compilation, lookup, flags, wire types, dispatch, atomic swap

### Integration
- Wired into startup after RuntimeEntityRegistry.BuildAsync() 
- Wired into gallery rebuild after RuntimeEntityRegistry.RebuildAsync()

Closes #1056