### PR TITLE
perf: reduce hot-path allocations in BmwJson and RouteHandlers

### DIFF
--- a/BareMetalWeb.Data/BmwJsonReader.cs
+++ b/BareMetalWeb.Data/BmwJsonReader.cs
@@ -333,61 +333,73 @@ public static class BmwJsonReader
 
     private static byte[] EncodeNumeric(ReadOnlySpan<byte> utf8Num, FieldPlan fp)
     {
-        var buf = new ArrayBufferWriter<byte>(fp.IsNullable ? 17 : 16);
-        var writer = new SpanWriter(buf);
+        // Max numeric field: nullable(1) + decimal(16) = 17 bytes
+        Span<byte> buf = stackalloc byte[17];
+        int off = 0;
 
-        if (fp.IsNullable) writer.WriteByte(1); // has value
+        if (fp.IsNullable) buf[off++] = 1; // has value
 
         switch (fp.WireType)
         {
             case WireFieldType.Byte:
                 Utf8Parser.TryParse(utf8Num, out byte byteVal, out _);
-                writer.WriteByte(byteVal);
+                buf[off++] = byteVal;
                 break;
             case WireFieldType.SByte:
                 Utf8Parser.TryParse(utf8Num, out sbyte sbyteVal, out _);
-                writer.WriteSByte(sbyteVal);
+                buf[off++] = unchecked((byte)sbyteVal);
                 break;
             case WireFieldType.Int16:
                 Utf8Parser.TryParse(utf8Num, out short i16, out _);
-                writer.WriteInt16(i16);
+                BinaryPrimitives.WriteInt16LittleEndian(buf.Slice(off), i16);
+                off += 2;
                 break;
             case WireFieldType.UInt16:
                 Utf8Parser.TryParse(utf8Num, out ushort u16, out _);
-                writer.WriteUInt16(u16);
+                BinaryPrimitives.WriteUInt16LittleEndian(buf.Slice(off), u16);
+                off += 2;
                 break;
             case WireFieldType.Int32:
                 Utf8Parser.TryParse(utf8Num, out int i32, out _);
-                writer.WriteInt32(i32);
+                BinaryPrimitives.WriteInt32LittleEndian(buf.Slice(off), i32);
+                off += 4;
                 break;
             case WireFieldType.UInt32:
                 Utf8Parser.TryParse(utf8Num, out uint u32, out _);
-                writer.WriteUInt32(u32);
+                BinaryPrimitives.WriteUInt32LittleEndian(buf.Slice(off), u32);
+                off += 4;
                 break;
             case WireFieldType.Int64:
                 Utf8Parser.TryParse(utf8Num, out long i64, out _);
-                writer.WriteInt64(i64);
+                BinaryPrimitives.WriteInt64LittleEndian(buf.Slice(off), i64);
+                off += 8;
                 break;
             case WireFieldType.UInt64:
                 Utf8Parser.TryParse(utf8Num, out ulong u64, out _);
-                writer.WriteUInt64(u64);
+                BinaryPrimitives.WriteUInt64LittleEndian(buf.Slice(off), u64);
+                off += 8;
                 break;
             case WireFieldType.Float32:
                 Utf8Parser.TryParse(utf8Num, out float f32, out _);
-                writer.WriteSingle(f32);
+                BinaryPrimitives.WriteInt32LittleEndian(buf.Slice(off), BitConverter.SingleToInt32Bits(f32));
+                off += 4;
                 break;
             case WireFieldType.Float64:
                 Utf8Parser.TryParse(utf8Num, out double f64, out _);
-                writer.WriteDouble(f64);
+                BinaryPrimitives.WriteInt64LittleEndian(buf.Slice(off), BitConverter.DoubleToInt64Bits(f64));
+                off += 8;
                 break;
             case WireFieldType.Decimal:
                 Utf8Parser.TryParse(utf8Num, out decimal dec, out _);
-                writer.WriteDecimal(dec);
+                var bits = decimal.GetBits(dec);
+                BinaryPrimitives.WriteInt32LittleEndian(buf.Slice(off), bits[0]); off += 4;
+                BinaryPrimitives.WriteInt32LittleEndian(buf.Slice(off), bits[1]); off += 4;
+                BinaryPrimitives.WriteInt32LittleEndian(buf.Slice(off), bits[2]); off += 4;
+                BinaryPrimitives.WriteInt32LittleEndian(buf.Slice(off), bits[3]); off += 4;
                 break;
         }
 
-        writer.Commit();
-        return buf.WrittenSpan.ToArray();
+        return buf[..off].ToArray();
     }
 
     private static (byte[] value, int endPos) ParseCharValue(ReadOnlySpan<byte> json, int pos, bool isNullable)
@@ -594,26 +606,32 @@ public static class BmwJsonReader
             endPos = numEnd;
         }
 
-        // Encode as the underlying type
+        // Encode as the underlying type using stackalloc (max 9 bytes: nullable + int64)
         var underlying = fp.EnumUnderlying == default ? WireFieldType.Int32 : fp.EnumUnderlying;
-        var buf = new ArrayBufferWriter<byte>(fp.IsNullable ? 9 : 8);
-        var writer = new SpanWriter(buf);
-        if (fp.IsNullable) writer.WriteByte(1);
+        Span<byte> buf = stackalloc byte[9];
+        int off = 0;
+        if (fp.IsNullable) buf[off++] = 1;
 
         switch (underlying)
         {
-            case WireFieldType.Byte: writer.WriteByte((byte)enumInt); break;
-            case WireFieldType.SByte: writer.WriteSByte((sbyte)enumInt); break;
-            case WireFieldType.Int16: writer.WriteInt16((short)enumInt); break;
-            case WireFieldType.UInt16: writer.WriteUInt16((ushort)enumInt); break;
-            case WireFieldType.Int32: writer.WriteInt32(enumInt); break;
-            case WireFieldType.UInt32: writer.WriteUInt32((uint)enumInt); break;
-            case WireFieldType.Int64: writer.WriteInt64(enumInt); break;
-            case WireFieldType.UInt64: writer.WriteUInt64((ulong)enumInt); break;
-            default: writer.WriteInt32(enumInt); break;
+            case WireFieldType.Byte: buf[off++] = (byte)enumInt; break;
+            case WireFieldType.SByte: buf[off++] = unchecked((byte)(sbyte)enumInt); break;
+            case WireFieldType.Int16:
+                BinaryPrimitives.WriteInt16LittleEndian(buf.Slice(off), (short)enumInt); off += 2; break;
+            case WireFieldType.UInt16:
+                BinaryPrimitives.WriteUInt16LittleEndian(buf.Slice(off), (ushort)enumInt); off += 2; break;
+            case WireFieldType.Int32:
+                BinaryPrimitives.WriteInt32LittleEndian(buf.Slice(off), enumInt); off += 4; break;
+            case WireFieldType.UInt32:
+                BinaryPrimitives.WriteUInt32LittleEndian(buf.Slice(off), (uint)enumInt); off += 4; break;
+            case WireFieldType.Int64:
+                BinaryPrimitives.WriteInt64LittleEndian(buf.Slice(off), enumInt); off += 8; break;
+            case WireFieldType.UInt64:
+                BinaryPrimitives.WriteUInt64LittleEndian(buf.Slice(off), (ulong)enumInt); off += 8; break;
+            default:
+                BinaryPrimitives.WriteInt32LittleEndian(buf.Slice(off), enumInt); off += 4; break;
         }
-        writer.Commit();
-        return (buf.WrittenSpan.ToArray(), endPos);
+        return (buf[..off].ToArray(), endPos);
     }
 
     // ────────────── Binary assembly ──────────────
@@ -1041,8 +1059,44 @@ public static class BmwJsonReader
         if (input is MemoryStream ms && ms.TryGetBuffer(out var msBuffer))
             return msBuffer.Array!.AsSpan(msBuffer.Offset, msBuffer.Count).ToArray();
 
-        using var buffer = new MemoryStream();
-        input.CopyTo(buffer);
-        return buffer.ToArray();
+        // Use ArrayPool to avoid MemoryStream + double-copy
+        int length;
+        byte[] rented;
+        if (input.CanSeek)
+        {
+            length = (int)input.Length;
+            rented = ArrayPool<byte>.Shared.Rent(Math.Max(length, 256));
+            int read = 0;
+            while (read < length)
+            {
+                int n = input.Read(rented, read, length - read);
+                if (n == 0) break;
+                read += n;
+            }
+            length = read;
+        }
+        else
+        {
+            rented = ArrayPool<byte>.Shared.Rent(4096);
+            length = 0;
+            while (true)
+            {
+                if (length == rented.Length)
+                {
+                    var bigger = ArrayPool<byte>.Shared.Rent(rented.Length * 2);
+                    rented.AsSpan(0, length).CopyTo(bigger);
+                    ArrayPool<byte>.Shared.Return(rented);
+                    rented = bigger;
+                }
+                int n = input.Read(rented, length, rented.Length - length);
+                if (n == 0) break;
+                length += n;
+            }
+        }
+
+        // Copy exact slice and return rental
+        var result = rented.AsSpan(0, length).ToArray();
+        ArrayPool<byte>.Shared.Return(rented);
+        return result;
     }
 }

--- a/BareMetalWeb.Data/BmwJsonWriter.cs
+++ b/BareMetalWeb.Data/BmwJsonWriter.cs
@@ -23,18 +23,19 @@ public static class BmwJsonWriter
     private const int HeaderSize = 45; // magic(4) + version(4) + schema(4) + arch(1) + sig(32)
     private const int MaxStringBytes = 4 * 1024 * 1024;
 
-    // Precomputed JSON literal fragments (UTF-8)
-    private static readonly byte[] JsonObjectStart = [(byte)'{'];
-    private static readonly byte[] JsonObjectEnd = [(byte)'}'];
-    private static readonly byte[] JsonArrayStart = [(byte)'['];
-    private static readonly byte[] JsonArrayEnd = [(byte)']'];
-    private static readonly byte[] JsonNull = "null"u8.ToArray();
-    private static readonly byte[] JsonTrue = "true"u8.ToArray();
-    private static readonly byte[] JsonFalse = "false"u8.ToArray();
-    private static readonly byte[] JsonQuote = [(byte)'"'];
-    private static readonly byte[] JsonComma = [(byte)','];
-    private static readonly byte[] DataPrefix = "\"data\":"u8.ToArray();
-    private static readonly byte[] CountPrefix = ",\"count\":"u8.ToArray();
+    // Precomputed JSON literal fragments (UTF-8) — ReadOnlySpan properties
+    // JIT inlines these; they point directly at the assembly's static data section (zero allocation).
+    private static ReadOnlySpan<byte> JsonObjectStart => "{"u8;
+    private static ReadOnlySpan<byte> JsonObjectEnd => "}"u8;
+    private static ReadOnlySpan<byte> JsonArrayStart => "["u8;
+    private static ReadOnlySpan<byte> JsonArrayEnd => "]"u8;
+    private static ReadOnlySpan<byte> JsonNull => "null"u8;
+    private static ReadOnlySpan<byte> JsonTrue => "true"u8;
+    private static ReadOnlySpan<byte> JsonFalse => "false"u8;
+    private static ReadOnlySpan<byte> JsonQuote => "\""u8;
+    private static ReadOnlySpan<byte> JsonComma => ","u8;
+    private static ReadOnlySpan<byte> DataPrefix => "\"data\":"u8;
+    private static ReadOnlySpan<byte> CountPrefix => ",\"count\":"u8;
 
     // ────────────── Fragment plan ──────────────
 
@@ -204,7 +205,7 @@ public static class BmwJsonWriter
         switch (wireType)
         {
             case WireFieldType.Bool:
-                output.Write(reader.ReadBoolean() ? JsonTrue : JsonFalse);
+                if (reader.ReadBoolean()) output.Write(JsonTrue); else output.Write(JsonFalse);
                 break;
 
             case WireFieldType.Byte:

--- a/BareMetalWeb.Host/RouteHandlers.cs
+++ b/BareMetalWeb.Host/RouteHandlers.cs
@@ -116,6 +116,57 @@ public sealed class RouteHandlers : IRouteHandlers
         }
     }
 
+    // ────── ThreadStatic pools for hot-path collection types ──────
+
+    [ThreadStatic] private static List<string>? t_stringList;
+    [ThreadStatic] private static Dictionary<string, object?>? t_objectDict;
+    [ThreadStatic] private static List<Dictionary<string, object?>>? t_dictList;
+    [ThreadStatic] private static List<QueryClause>? t_queryClauseList;
+
+    private static List<string> RentStringList(int capacity = 16)
+    {
+        var list = t_stringList;
+        if (list != null) { t_stringList = null; list.Clear(); return list; }
+        return new List<string>(capacity);
+    }
+    private static void ReturnStringList(List<string> list)
+    {
+        if (list.Count < 1024) { list.Clear(); t_stringList = list; }
+    }
+
+    private static Dictionary<string, object?> RentObjectDictionary(int capacity = 16)
+    {
+        var dict = t_objectDict;
+        if (dict != null) { t_objectDict = null; dict.Clear(); return dict; }
+        return new Dictionary<string, object?>(capacity, StringComparer.OrdinalIgnoreCase);
+    }
+    private static void ReturnObjectDictionary(Dictionary<string, object?> dict)
+    {
+        if (dict.Count < 1024) { dict.Clear(); t_objectDict = dict; }
+    }
+
+    private static List<Dictionary<string, object?>> RentDictList(int capacity = 16)
+    {
+        var list = t_dictList;
+        if (list != null) { t_dictList = null; list.Clear(); return list; }
+        return new List<Dictionary<string, object?>>(capacity);
+    }
+    private static void ReturnDictList(List<Dictionary<string, object?>> list)
+    {
+        if (list.Count < 1024) { list.Clear(); t_dictList = list; }
+    }
+
+    private static List<QueryClause> RentQueryClauseList(int capacity = 8)
+    {
+        var list = t_queryClauseList;
+        if (list != null) { t_queryClauseList = null; list.Clear(); return list; }
+        return new List<QueryClause>(capacity);
+    }
+    private static void ReturnQueryClauseList(List<QueryClause> list)
+    {
+        if (list.Count < 256) { list.Clear(); t_queryClauseList = list; }
+    }
+
     public RouteHandlers(IHtmlRenderer renderer, ITemplateStore templateStore, bool allowAccountCreation, string mfaKeyRootFolder, AuditService auditService,
         IReadOnlyList<(string SettingId, string Value, string Description)>? settingDefaults = null, IBufferedLogger? logger = null, BmwConfig? config = null)
     {
@@ -1980,14 +2031,16 @@ public sealed class RouteHandlers : IRouteHandlers
             return;
         }
 
-        var apiCreateErrors = new List<string>();
+        var apiCreateErrors = RentStringList();
         await ValidateUserUniquenessAsync(meta, instance, excludeId: null, apiCreateErrors, context.RequestAborted).ConfigureAwait(false);
         if (apiCreateErrors.Count > 0)
         {
             context.Response.StatusCode = StatusCodes.Status409Conflict;
             await context.Response.WriteAsync(string.Join(" | ", apiCreateErrors));
+            ReturnStringList(apiCreateErrors);
             return;
         }
+        ReturnStringList(apiCreateErrors);
 
         ApplyAuditInfo(instance, (await UserAuth.GetUserAsync(context, context.RequestAborted).ConfigureAwait(false))?.UserName ?? "system", isCreate: true);
         await DataScaffold.ApplyAutoIdAsync(meta, instance, context.RequestAborted).ConfigureAwait(false);
@@ -2072,14 +2125,16 @@ public sealed class RouteHandlers : IRouteHandlers
             return;
         }
 
-        var apiPutErrors = new List<string>();
+        var apiPutErrors = RentStringList();
         await ValidateUserUniquenessAsync(meta, instance, excludeId: id, apiPutErrors, context.RequestAborted).ConfigureAwait(false);
         if (apiPutErrors.Count > 0)
         {
             context.Response.StatusCode = StatusCodes.Status409Conflict;
             await context.Response.WriteAsync(string.Join(" | ", apiPutErrors));
+            ReturnStringList(apiPutErrors);
             return;
         }
+        ReturnStringList(apiPutErrors);
 
         ApplyAuditInfo(instance, (await UserAuth.GetUserAsync(context, context.RequestAborted).ConfigureAwait(false))?.UserName ?? "system", isCreate: false);
         await DataScaffold.ApplyComputedFieldsAsync(meta, (BaseDataObject)instance, ComputedTrigger.OnUpdate, context.RequestAborted).ConfigureAwait(false);
@@ -2312,7 +2367,7 @@ public sealed class RouteHandlers : IRouteHandlers
         };
 
         var rawItems = await DataScaffold.QueryAsync(attachMeta, query, context.RequestAborted).ConfigureAwait(false);
-        var result = new List<Dictionary<string, object?>>();
+        var result = RentDictList();
         foreach (var item in rawItems)
         {
             if (item is FileAttachment a)
@@ -2321,6 +2376,7 @@ public sealed class RouteHandlers : IRouteHandlers
 
         context.Response.ContentType = "application/json";
         await context.Response.WriteAsync(JsonSerializer.Serialize(result, JsonIndented)).ConfigureAwait(false);
+        ReturnDictList(result);
     }
 
     /// <summary>POST /api/{type}/{id}/_attachments — upload a new attachment (or new version) for a record.</summary>
@@ -2659,7 +2715,7 @@ public sealed class RouteHandlers : IRouteHandlers
         };
 
         var rawItems = await DataScaffold.QueryAsync(commentMeta, query, context.RequestAborted).ConfigureAwait(false);
-        var result = new List<Dictionary<string, object?>>();
+        var result = RentDictList();
         foreach (var item in rawItems)
         {
             if (item is RecordComment c)
@@ -2670,6 +2726,7 @@ public sealed class RouteHandlers : IRouteHandlers
 
         context.Response.ContentType = "application/json";
         await context.Response.WriteAsync(JsonSerializer.Serialize(result, JsonIndented)).ConfigureAwait(false);
+        ReturnDictList(result);
     }
 
     /// <summary>POST /api/{type}/{id}/_comments — add a comment to a record.</summary>
@@ -3886,7 +3943,7 @@ public sealed class RouteHandlers : IRouteHandlers
     {
         var entries = QueryPlanHistory.GetSnapshot();
 
-        var payload = new List<Dictionary<string, object?>>();
+        var payload = RentDictList();
         foreach (var e in entries)
         {
             var stepsList = new List<Dictionary<string, object?>>();
@@ -3933,6 +3990,7 @@ public sealed class RouteHandlers : IRouteHandlers
         }
 
         await WriteJsonResponseAsync(context, payload);
+        ReturnDictList(payload);
     }
 
     public async ValueTask EntityDesignerHandler(BmwContext context)
@@ -4052,7 +4110,7 @@ public sealed class RouteHandlers : IRouteHandlers
             return;
         }
 
-        var messages = new List<string>();
+        var messages = RentStringList();
         var deployed = await SampleGalleryService.DeployPackageAsync(
             pkg,
             DataStoreProvider.Current,
@@ -4060,6 +4118,7 @@ public sealed class RouteHandlers : IRouteHandlers
             msg => messages.Add(msg),
             context.RequestAborted)
             .ConfigureAwait(false);
+        ReturnStringList(messages);
 
         // Hot-reload the entity registry so deployed entities are immediately usable
         if (deployed.Count > 0)


### PR DESCRIPTION
## Summary

Reduces GC pressure on request hot paths by eliminating unnecessary heap allocations.

### BmwJsonWriter (#1049)
- Convert 11 static \yte[]\ fields to \ReadOnlySpan<byte>\ properties (JIT-inlined, zero allocation)

### BmwJsonReader (#1049)  
- Replace \ArrayBufferWriter\ + \.ToArray()\ in \EncodeNumeric\ and \ParseEnumValue\ with \stackalloc\ (eliminates heap alloc per field parse)
- Replace \MemoryStream\ + \.ToArray()\ in \ReadStreamToBytes\ with \ArrayPool<byte>\ rental

### RouteHandlers (#1044)
- Add ThreadStatic pooling for \List<string>\, \Dictionary<string,object?>\, \List<Dictionary<string,object?>>\, and \List<QueryClause>\
- Apply to 6 hot-path handlers: AttachmentsList, CommentsList, QueryPlanHistory, DataApiPost, DataApiPut, gallery deploy

**Tests:** 137 Data tests pass, 808 Host tests pass (4 pre-existing MetricsTracker emoji failures unrelated).

Fixes #1044, fixes #1049