### PR TITLE
perf: migrate handlers to RuntimeSnapshot ordinal dispatch

### DIFF
--- a/BareMetalWeb.Core/BmwContext.cs
+++ b/BareMetalWeb.Core/BmwContext.cs
@@ -45,6 +45,8 @@ public sealed class BmwContext
     public string? RouteExtra;
     /// <summary>Key name for <see cref="RouteExtra"/> (e.g. "field", "command").</summary>
     public string? RouteExtraKey;
+    /// <summary>Compiled entity ordinal from RuntimeSnapshot (-1 = unresolved). Enables O(1) array-indexed metadata access.</summary>
+    public int EntityOrdinal = -1;
 
     // ── Migration bridge ────────────────────────────────────────────────
     /// <summary>

--- a/BareMetalWeb.Data/EntityTable.cs
+++ b/BareMetalWeb.Data/EntityTable.cs
@@ -19,6 +19,8 @@ public sealed class EntityTable
     public readonly int[] NavOrder;
     public readonly AutoIdStrategy[] IdStrategies;
     public readonly DataEntityHandlers[] Handlers;
+    /// <summary>Original DataEntityMetadata references indexed by EntityId, for handlers that need full metadata.</summary>
+    public readonly DataEntityMetadata[] Metadata;
 
     // slug → EntityId resolver (sorted slugs + binary search)
     private readonly string[] _sortedSlugs;
@@ -34,7 +36,8 @@ public sealed class EntityTable
         AutoIdStrategy[] idStrategies,
         DataEntityHandlers[] handlers,
         string[] sortedSlugs,
-        int[] sortedEntityIds)
+        int[] sortedEntityIds,
+        DataEntityMetadata[] metadata)
     {
         Count = names.Length;
         Names = names;
@@ -47,6 +50,7 @@ public sealed class EntityTable
         Handlers = handlers;
         _sortedSlugs = sortedSlugs;
         _sortedEntityIds = sortedEntityIds;
+        Metadata = metadata;
     }
 
     /// <summary>

--- a/BareMetalWeb.Data/MetadataCompiler.cs
+++ b/BareMetalWeb.Data/MetadataCompiler.cs
@@ -93,7 +93,7 @@ public static class MetadataCompiler
         var entityTable = new EntityTable(
             eNames, eSlugs, eFieldStart, eFieldCount,
             eShowOnNav, eNavOrder, eIdStrategies, eHandlers,
-            sortedSlugs, sortedEntityIds);
+            sortedSlugs, sortedEntityIds, sorted);
 
         var fieldTable = new FieldTable(
             fNames, fWireTypes, fFormTypes, fFlags,

--- a/BareMetalWeb.Host.Tests/EntityRouteTableTests.cs
+++ b/BareMetalWeb.Host.Tests/EntityRouteTableTests.cs
@@ -17,7 +17,7 @@ public class EntityRouteTableTests
     {
         var table = new EntityRouteTable();
         table.Build(Array.Empty<string>());
-        Assert.False(table.TryResolve("users".AsSpan(), out _));
+        Assert.False(table.TryResolve("users".AsSpan(), out _, out _));
     }
 
     [Fact]
@@ -35,7 +35,7 @@ public class EntityRouteTableTests
         var original = "users";
         table.Build(new[] { original });
 
-        Assert.True(table.TryResolve("users".AsSpan(), out var resolved));
+        Assert.True(table.TryResolve("users".AsSpan(), out var resolved, out _));
         Assert.Same(original, resolved); // Same reference — zero allocation
     }
 
@@ -44,7 +44,7 @@ public class EntityRouteTableTests
     {
         var table = new EntityRouteTable();
         table.Build(new[] { "users", "orders" });
-        Assert.False(table.TryResolve("products".AsSpan(), out _));
+        Assert.False(table.TryResolve("products".AsSpan(), out _, out _));
     }
 
     [Fact]
@@ -53,8 +53,8 @@ public class EntityRouteTableTests
         var table = new EntityRouteTable();
         table.Build(new[] { "users" });
 
-        Assert.True(table.TryResolve("Users".AsSpan(), out var r1));
-        Assert.True(table.TryResolve("USERS".AsSpan(), out var r2));
+        Assert.True(table.TryResolve("Users".AsSpan(), out var r1, out _));
+        Assert.True(table.TryResolve("USERS".AsSpan(), out var r2, out _));
         Assert.Equal("users", r1);
         Assert.Equal("users", r2);
     }
@@ -69,7 +69,7 @@ public class EntityRouteTableTests
         Assert.Equal(5, table.Count);
         foreach (var slug in slugs)
         {
-            Assert.True(table.TryResolve(slug.AsSpan(), out var resolved), $"Failed to resolve: {slug}");
+            Assert.True(table.TryResolve(slug.AsSpan(), out var resolved, out _), $"Failed to resolve: {slug}");
             Assert.Equal(slug, resolved);
         }
     }
@@ -88,7 +88,7 @@ public class EntityRouteTableTests
         Assert.Equal(100, table.Count);
         foreach (var slug in slugs)
         {
-            Assert.True(table.TryResolve(slug.AsSpan(), out var resolved), $"Failed: {slug}");
+            Assert.True(table.TryResolve(slug.AsSpan(), out var resolved, out _), $"Failed: {slug}");
             Assert.Equal(slug, resolved);
         }
     }
@@ -100,9 +100,9 @@ public class EntityRouteTableTests
         table.Build(new[] { "users", "orders" });
 
         // System prefixes should NOT be in entity table
-        Assert.False(table.TryResolve("_binary".AsSpan(), out _));
-        Assert.False(table.TryResolve("_lookup".AsSpan(), out _));
-        Assert.False(table.TryResolve("metadata".AsSpan(), out _));
+        Assert.False(table.TryResolve("_binary".AsSpan(), out _, out _));
+        Assert.False(table.TryResolve("_lookup".AsSpan(), out _, out _));
+        Assert.False(table.TryResolve("metadata".AsSpan(), out _, out _));
     }
 
     [Fact]
@@ -110,10 +110,10 @@ public class EntityRouteTableTests
     {
         var table = new EntityRouteTable();
         table.Build(new[] { "users" });
-        Assert.True(table.TryResolve("users".AsSpan(), out _));
+        Assert.True(table.TryResolve("users".AsSpan(), out _, out _));
 
         table.Build(new[] { "orders" });
-        Assert.False(table.TryResolve("users".AsSpan(), out _));
-        Assert.True(table.TryResolve("orders".AsSpan(), out _));
+        Assert.False(table.TryResolve("users".AsSpan(), out _, out _));
+        Assert.True(table.TryResolve("orders".AsSpan(), out _, out _));
     }
 }

--- a/BareMetalWeb.Host/BinaryApiHandlers.cs
+++ b/BareMetalWeb.Host/BinaryApiHandlers.cs
@@ -709,7 +709,18 @@ public static class BinaryApiHandlers
         if (string.IsNullOrWhiteSpace(typeSlug))
             return (null, typeSlug, (400, "Entity type not specified."));
 
-        if (!DataScaffold.TryGetEntity(typeSlug, out var meta))
+        // Fast path: use compiled ordinal from PrefixRouter → O(1) array index
+        DataEntityMetadata? meta = null;
+        var snapshot = RuntimeSnapshot.Current;
+        if (context.EntityOrdinal >= 0 && snapshot != null)
+        {
+            var entities = snapshot.Entities;
+            if ((uint)context.EntityOrdinal < (uint)entities.Count)
+                meta = entities.Metadata[context.EntityOrdinal];
+        }
+
+        // Fallback: dictionary lookup
+        if (meta == null && !DataScaffold.TryGetEntity(typeSlug, out meta))
             return (null, typeSlug, (404, "Not found."));
 
         // Permission check

--- a/BareMetalWeb.Host/DeltaApiHandlers.cs
+++ b/BareMetalWeb.Host/DeltaApiHandlers.cs
@@ -52,7 +52,18 @@ public static class DeltaApiHandlers
             return;
         }
 
-        if (!DataScaffold.TryGetEntity(typeSlug, out var meta))
+        // Fast path: use compiled ordinal from PrefixRouter → O(1) array index
+        DataEntityMetadata? meta = null;
+        var snapshot = RuntimeSnapshot.Current;
+        if (context.EntityOrdinal >= 0 && snapshot != null)
+        {
+            var entities = snapshot.Entities;
+            if ((uint)context.EntityOrdinal < (uint)entities.Count)
+                meta = entities.Metadata[context.EntityOrdinal];
+        }
+
+        // Fallback: dictionary lookup
+        if (meta == null && !DataScaffold.TryGetEntity(typeSlug, out meta))
         {
             await WriteResult(context, 404, MutationResult.EntityNotFound, "Not found.");
             return;
@@ -162,7 +173,18 @@ public static class DeltaApiHandlers
     public static async ValueTask LayoutHandler(BmwContext context)
     {
         var typeSlug = BinaryApiHandlers.GetRouteValue(context, "type") ?? string.Empty;
-        if (!DataScaffold.TryGetEntity(typeSlug, out var meta))
+
+        // Fast path: compiled ordinal → O(1) array index
+        DataEntityMetadata? meta = null;
+        var snapshot2 = RuntimeSnapshot.Current;
+        if (context.EntityOrdinal >= 0 && snapshot2 != null)
+        {
+            var entities = snapshot2.Entities;
+            if ((uint)context.EntityOrdinal < (uint)entities.Count)
+                meta = entities.Metadata[context.EntityOrdinal];
+        }
+
+        if (meta == null && !DataScaffold.TryGetEntity(typeSlug, out meta))
         {
             context.Response.StatusCode = 404;
             return;

--- a/BareMetalWeb.Host/EntityRouteTable.cs
+++ b/BareMetalWeb.Host/EntityRouteTable.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using BareMetalWeb.Data;
 
 namespace BareMetalWeb.Host;
 
@@ -24,6 +25,8 @@ public sealed class EntityRouteTable
     {
         /// <summary>Pre-interned entity slug (null = empty slot).</summary>
         public string? Slug;
+        /// <summary>Compiled entity ordinal from RuntimeSnapshot (-1 = unresolved).</summary>
+        public int EntityOrdinal;
     }
 
     private Slot[] _slots = Array.Empty<Slot>();
@@ -61,6 +64,10 @@ public sealed class EntityRouteTable
                 idx = (idx + 1) & mask;
 
             slots[idx].Slug = slug;
+
+            // Resolve compiled ordinal from RuntimeSnapshot (if available)
+            var snapshot = RuntimeSnapshot.Current;
+            slots[idx].EntityOrdinal = snapshot?.Entities.TryResolveSlug(slug, out int eid) == true ? eid : -1;
         }
 
         _slots = slots;
@@ -69,15 +76,16 @@ public sealed class EntityRouteTable
     }
 
     /// <summary>
-    /// Resolve an entity slug span to its pre-interned string.
+    /// Resolve an entity slug span to its pre-interned string and compiled ordinal.
     /// Returns true if the entity is known; <paramref name="resolvedSlug"/>
-    /// is the canonical slug string (no allocation).
+    /// is the canonical slug string (no allocation), <paramref name="entityOrdinal"/>
+    /// is the RuntimeSnapshot EntityId (-1 if snapshot was not available at build time).
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool TryResolve(ReadOnlySpan<char> slug, out string resolvedSlug)
+    public bool TryResolve(ReadOnlySpan<char> slug, out string resolvedSlug, out int entityOrdinal)
     {
         var slots = _slots;
-        if (slots.Length == 0) { resolvedSlug = null!; return false; }
+        if (slots.Length == 0) { resolvedSlug = null!; entityOrdinal = -1; return false; }
 
         uint idx = HashSlug(slug) & _mask;
 
@@ -85,16 +93,18 @@ public sealed class EntityRouteTable
         for (int probe = 0; probe <= _count; probe++)
         {
             ref var slot = ref slots[idx];
-            if (slot.Slug == null) { resolvedSlug = null!; return false; }
+            if (slot.Slug == null) { resolvedSlug = null!; entityOrdinal = -1; return false; }
             if (slug.Equals(slot.Slug.AsSpan(), StringComparison.OrdinalIgnoreCase))
             {
                 resolvedSlug = slot.Slug;
+                entityOrdinal = slot.EntityOrdinal;
                 return true;
             }
             idx = (idx + 1) & _mask;
         }
 
         resolvedSlug = null!;
+        entityOrdinal = -1;
         return false;
     }
 

--- a/BareMetalWeb.Host/LookupApiHandlers.cs
+++ b/BareMetalWeb.Host/LookupApiHandlers.cs
@@ -336,7 +336,18 @@ public static class LookupApiHandlers
             return (null, typeSlug, new ErrorResponse(StatusCodes.Status400BadRequest, "Entity type not specified."));
         }
 
-        if (!DataScaffold.TryGetEntity(typeSlug, out var metadata))
+        // Fast path: use compiled ordinal from PrefixRouter → O(1) array index
+        DataEntityMetadata? metadata = null;
+        var snapshot = RuntimeSnapshot.Current;
+        if (context.EntityOrdinal >= 0 && snapshot != null)
+        {
+            var entities = snapshot.Entities;
+            if ((uint)context.EntityOrdinal < (uint)entities.Count)
+                metadata = entities.Metadata[context.EntityOrdinal];
+        }
+
+        // Fallback: dictionary lookup
+        if (metadata == null && !DataScaffold.TryGetEntity(typeSlug, out metadata))
         {
             return (null, typeSlug, new ErrorResponse(StatusCodes.Status404NotFound, "Not found."));
         }

--- a/BareMetalWeb.Host/PrefixRouter.cs
+++ b/BareMetalWeb.Host/PrefixRouter.cs
@@ -163,7 +163,7 @@ public sealed class PrefixRouter
         if (entitySlug.IsEmpty) return false;
 
         // Resolve entity via hash table
-        if (!_entityTable.TryResolve(entitySlug, out var resolvedSlug))
+        if (!_entityTable.TryResolve(entitySlug, out var resolvedSlug, out var entityOrdinal))
             return false;
 
         // Stage 3: Classify verb + remaining path suffix
@@ -176,6 +176,7 @@ public sealed class PrefixRouter
 
         // Set fast-path fields on BmwContext (zero allocation for entity slug)
         context.EntitySlug = resolvedSlug;
+        context.EntityOrdinal = entityOrdinal;
         if (!idSpan.IsEmpty)
             context.EntityId = idSpan.ToString();
         if (!extraSpan.IsEmpty)


### PR DESCRIPTION
## Summary

Migrates hot-path API handlers to use the compiled RuntimeSnapshot for O(1) array-indexed entity metadata access, completing the #1056 MetadataCompiler initiative.

### Changes
- **BmwContext**: Add `EntityOrdinal` field (`int`, default -1) for compiled entity ID
- **EntityRouteTable**: Extended `TryResolve` to also return the RuntimeSnapshot entity ordinal; ordinals populated at Build time from `RuntimeSnapshot.Current`
- **PrefixRouter**: Sets `context.EntityOrdinal` during slug resolution
- **BinaryApiHandlers**: `ValidateAsync` uses ordinal for O(1) `Metadata[ordinal]` lookup with `DataScaffold.TryGetEntity` fallback
- **LookupApiHandlers**: `ValidateAndResolveEntityAsync` uses ordinal fast path
- **DeltaApiHandlers**: Mutation and layout handlers use ordinal fast path  
- **EntityTable**: Added `Metadata[]` array storing `DataEntityMetadata` references indexed by EntityId

### Performance
- Hot-path entity resolution: O(1) array index vs O(1) dictionary hash (eliminates hash computation + bucket chain traversal)
- Graceful fallback: if snapshot unavailable or ordinal unset, falls back to existing `DataScaffold.TryGetEntity()`

### Tests
All 41 relevant tests pass (11 MetadataCompiler + 30 Host tests including EntityRouteTable + PrefixRouter).

Part of #1056