### PR TITLE
fix: AOT crash — source-gen JSON context + remove Marshal interop

### DIFF
--- a/BareMetalWeb.Data/AuditEntry.cs
+++ b/BareMetalWeb.Data/AuditEntry.cs
@@ -74,10 +74,10 @@ public sealed class AuditEntry : BaseDataObject
     {
         get
         {
-            try { return string.IsNullOrEmpty(FieldChangesJson) ? new() : System.Text.Json.JsonSerializer.Deserialize<List<FieldChange>>(FieldChangesJson) ?? new(); }
+            try { return string.IsNullOrEmpty(FieldChangesJson) ? new() : System.Text.Json.JsonSerializer.Deserialize(FieldChangesJson, BmwDataJsonContext.Default.ListFieldChange) ?? new(); }
             catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"AuditEntry.FieldChanges deserialization failed: {ex.Message}"); return new(); }
         }
-        set { FieldChangesJson = System.Text.Json.JsonSerializer.Serialize(value ?? new List<FieldChange>()); }
+        set { FieldChangesJson = System.Text.Json.JsonSerializer.Serialize(value ?? new List<FieldChange>(), BmwDataJsonContext.Default.ListFieldChange); }
     }
 
     /// <summary>

--- a/BareMetalWeb.Data/BinaryObjectSerializer.cs
+++ b/BareMetalWeb.Data/BinaryObjectSerializer.cs
@@ -1894,7 +1894,33 @@ public sealed class BinaryObjectSerializer : ISchemaAwareObjectSerializer
         if (!IsBlittable(type))
             throw new NotSupportedException($"Type '{type.FullName}' is not blittable.");
 
-        return Marshal.SizeOf(type);
+        // AOT-safe: compute size from fields instead of using Marshal.SizeOf
+        // which requires runtime marshalling data generation.
+        return ComputeBlittableSize(type);
+    }
+
+    private static int ComputeBlittableSize(Type type)
+    {
+        if (type.IsPrimitive) return GetPrimitiveSize(type);
+
+        var fields = type.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        int total = 0;
+        for (int i = 0; i < fields.Length; i++)
+        {
+            var ft = fields[i].FieldType;
+            total += ft.IsPrimitive ? GetPrimitiveSize(ft) : ComputeBlittableSize(ft);
+        }
+        return total;
+    }
+
+    private static int GetPrimitiveSize(Type type)
+    {
+        if (type == typeof(byte) || type == typeof(sbyte) || type == typeof(bool)) return 1;
+        if (type == typeof(short) || type == typeof(ushort) || type == typeof(char)) return 2;
+        if (type == typeof(int) || type == typeof(uint) || type == typeof(float)) return 4;
+        if (type == typeof(long) || type == typeof(ulong) || type == typeof(double)) return 8;
+        if (type == typeof(decimal)) return 16;
+        return Marshal.SizeOf(type); // fallback for exotic primitives
     }
 
     private static Action<object?, byte[]> CreateBlittableWrite(Type type)
@@ -1902,7 +1928,8 @@ public sealed class BinaryObjectSerializer : ISchemaAwareObjectSerializer
         if (!IsBlittable(type))
             throw new NotSupportedException($"Type '{type.FullName}' is not blittable.");
 
-        var size = Marshal.SizeOf(type);
+        var size = ComputeBlittableSize(type);
+        var fields = type.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
         return (value, buffer) =>
         {
             if (buffer is null) throw new ArgumentNullException(nameof(buffer));
@@ -1915,10 +1942,43 @@ public sealed class BinaryObjectSerializer : ISchemaAwareObjectSerializer
                 return;
             }
 
-            var handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
-            try { Marshal.StructureToPtr(value, handle.AddrOfPinnedObject(), false); }
-            finally { handle.Free(); }
+            // AOT-safe: write fields directly instead of Marshal.StructureToPtr
+            int offset = 0;
+            for (int i = 0; i < fields.Length; i++)
+            {
+                var fv = fields[i].GetValue(value);
+                var ft = fields[i].FieldType;
+                WritePrimitiveOrStruct(buffer, ref offset, ft, fv);
+            }
         };
+    }
+
+    private static void WritePrimitiveOrStruct(byte[] buffer, ref int offset, Type fieldType, object? value)
+    {
+        if (fieldType == typeof(byte))   { buffer[offset++] = (byte)(value ?? (byte)0); return; }
+        if (fieldType == typeof(sbyte))  { buffer[offset++] = unchecked((byte)(sbyte)(value ?? (sbyte)0)); return; }
+        if (fieldType == typeof(bool))   { buffer[offset++] = (bool)(value ?? false) ? (byte)1 : (byte)0; return; }
+        if (fieldType == typeof(short))  { BinaryPrimitives.WriteInt16LittleEndian(buffer.AsSpan(offset), (short)(value ?? (short)0)); offset += 2; return; }
+        if (fieldType == typeof(ushort)) { BinaryPrimitives.WriteUInt16LittleEndian(buffer.AsSpan(offset), (ushort)(value ?? (ushort)0)); offset += 2; return; }
+        if (fieldType == typeof(char))   { BinaryPrimitives.WriteUInt16LittleEndian(buffer.AsSpan(offset), (ushort)(char)(value ?? '\0')); offset += 2; return; }
+        if (fieldType == typeof(int))    { BinaryPrimitives.WriteInt32LittleEndian(buffer.AsSpan(offset), (int)(value ?? 0)); offset += 4; return; }
+        if (fieldType == typeof(uint))   { BinaryPrimitives.WriteUInt32LittleEndian(buffer.AsSpan(offset), (uint)(value ?? 0u)); offset += 4; return; }
+        if (fieldType == typeof(float))  { BinaryPrimitives.WriteInt32LittleEndian(buffer.AsSpan(offset), BitConverter.SingleToInt32Bits((float)(value ?? 0f))); offset += 4; return; }
+        if (fieldType == typeof(long))   { BinaryPrimitives.WriteInt64LittleEndian(buffer.AsSpan(offset), (long)(value ?? 0L)); offset += 8; return; }
+        if (fieldType == typeof(ulong))  { BinaryPrimitives.WriteUInt64LittleEndian(buffer.AsSpan(offset), (ulong)(value ?? 0UL)); offset += 8; return; }
+        if (fieldType == typeof(double)) { BinaryPrimitives.WriteInt64LittleEndian(buffer.AsSpan(offset), BitConverter.DoubleToInt64Bits((double)(value ?? 0.0))); offset += 8; return; }
+
+        // Nested blittable struct
+        if (value is null)
+        {
+            var sz = ComputeBlittableSize(fieldType);
+            buffer.AsSpan(offset, sz).Clear();
+            offset += sz;
+            return;
+        }
+        var nestedFields = fieldType.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        for (int i = 0; i < nestedFields.Length; i++)
+            WritePrimitiveOrStruct(buffer, ref offset, nestedFields[i].FieldType, nestedFields[i].GetValue(value));
     }
 
     private static Func<byte[], object> CreateBlittableRead(Type type)
@@ -1926,17 +1986,52 @@ public sealed class BinaryObjectSerializer : ISchemaAwareObjectSerializer
         if (!IsBlittable(type))
             throw new NotSupportedException($"Type '{type.FullName}' is not blittable.");
 
+        var fields = type.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
         return buffer =>
         {
             if (buffer is null) throw new ArgumentNullException(nameof(buffer));
-            var size = Marshal.SizeOf(type);
+            var size = ComputeBlittableSize(type);
             if (buffer.Length < size)
                 throw new ArgumentException("Blittable buffer is too small.", nameof(buffer));
 
-            var handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
-            try { return Marshal.PtrToStructure(handle.AddrOfPinnedObject(), type)!; }
-            finally { handle.Free(); }
+            // AOT-safe: read fields directly instead of Marshal.PtrToStructure
+            var instance = Activator.CreateInstance(type)!;
+            int offset = 0;
+            ReadPrimitiveOrStruct(buffer, ref offset, type, ref instance, fields);
+            return instance;
         };
+    }
+
+    private static void ReadPrimitiveOrStruct(byte[] buffer, ref int offset, Type type, ref object instance, FieldInfo[] fields)
+    {
+        for (int i = 0; i < fields.Length; i++)
+        {
+            var ft = fields[i].FieldType;
+            object fieldValue;
+
+            if (ft == typeof(byte))        { fieldValue = buffer[offset++]; }
+            else if (ft == typeof(sbyte))  { fieldValue = unchecked((sbyte)buffer[offset++]); }
+            else if (ft == typeof(bool))   { fieldValue = buffer[offset++] != 0; }
+            else if (ft == typeof(short))  { fieldValue = BinaryPrimitives.ReadInt16LittleEndian(buffer.AsSpan(offset)); offset += 2; }
+            else if (ft == typeof(ushort)) { fieldValue = BinaryPrimitives.ReadUInt16LittleEndian(buffer.AsSpan(offset)); offset += 2; }
+            else if (ft == typeof(char))   { fieldValue = (char)BinaryPrimitives.ReadUInt16LittleEndian(buffer.AsSpan(offset)); offset += 2; }
+            else if (ft == typeof(int))    { fieldValue = BinaryPrimitives.ReadInt32LittleEndian(buffer.AsSpan(offset)); offset += 4; }
+            else if (ft == typeof(uint))   { fieldValue = BinaryPrimitives.ReadUInt32LittleEndian(buffer.AsSpan(offset)); offset += 4; }
+            else if (ft == typeof(float))  { fieldValue = BitConverter.Int32BitsToSingle(BinaryPrimitives.ReadInt32LittleEndian(buffer.AsSpan(offset))); offset += 4; }
+            else if (ft == typeof(long))   { fieldValue = BinaryPrimitives.ReadInt64LittleEndian(buffer.AsSpan(offset)); offset += 8; }
+            else if (ft == typeof(ulong))  { fieldValue = BinaryPrimitives.ReadUInt64LittleEndian(buffer.AsSpan(offset)); offset += 8; }
+            else if (ft == typeof(double)) { fieldValue = BitConverter.Int64BitsToDouble(BinaryPrimitives.ReadInt64LittleEndian(buffer.AsSpan(offset))); offset += 8; }
+            else
+            {
+                // Nested blittable struct
+                var nested = Activator.CreateInstance(ft)!;
+                var nestedFields = ft.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                ReadPrimitiveOrStruct(buffer, ref offset, ft, ref nested, nestedFields);
+                fieldValue = nested;
+            }
+
+            fields[i].SetValue(instance, fieldValue);
+        }
     }
 
     private static byte[] LoadOrCreateSigningKey(string keyFilePath)

--- a/BareMetalWeb.Data/BmwDataJsonContext.cs
+++ b/BareMetalWeb.Data/BmwDataJsonContext.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace BareMetalWeb.Data;
+
+// Source-generated JSON context for AOT-safe serialization.
+// All types serialized/deserialized via JsonSerializer in the Data project
+// must be registered here.
+
+[JsonSerializable(typeof(SchemaDefinitionFile))]
+[JsonSerializable(typeof(MemberSignatureFile))]
+[JsonSerializable(typeof(List<MemberSignatureFile>))]
+[JsonSerializable(typeof(List<FieldChange>))]
+[JsonSerializable(typeof(FieldChange))]
+[JsonSerializable(typeof(List<DashboardTile>))]
+[JsonSerializable(typeof(DashboardTile))]
+[JsonSerializable(typeof(List<ReportJoin>))]
+[JsonSerializable(typeof(List<ReportColumn>))]
+[JsonSerializable(typeof(List<ReportFilter>))]
+[JsonSerializable(typeof(List<ReportParameter>))]
+[JsonSerializable(typeof(ReportJoin))]
+[JsonSerializable(typeof(ReportColumn))]
+[JsonSerializable(typeof(ReportFilter))]
+[JsonSerializable(typeof(ReportParameter))]
+[JsonSerializable(typeof(List<ViewProjection>))]
+[JsonSerializable(typeof(List<ViewJoinDefinition>))]
+[JsonSerializable(typeof(List<ViewFilterDefinition>))]
+[JsonSerializable(typeof(List<ViewSortDefinition>))]
+[JsonSerializable(typeof(ViewProjection))]
+[JsonSerializable(typeof(ViewJoinDefinition))]
+[JsonSerializable(typeof(ViewFilterDefinition))]
+[JsonSerializable(typeof(ViewSortDefinition))]
+[JsonSerializable(typeof(TenantOptions))]
+[JsonSerializable(typeof(List<Dictionary<string, string>>))]
+[JsonSerializable(typeof(Dictionary<string, string>))]
+[JsonSerializable(typeof(Dictionary<string, object>))]
+[JsonSerializable(typeof(Dictionary<string, object?>))]
+[JsonSerializable(typeof(List<Dictionary<string, object?>>))]
+[JsonSerializable(typeof(List<string>))]
+[JsonSerializable(typeof(string))]
+[JsonSerializable(typeof(int))]
+[JsonSerializable(typeof(long))]
+[JsonSerializable(typeof(bool))]
+[JsonSerializable(typeof(double))]
+[JsonSourceGenerationOptions(DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+internal partial class BmwDataJsonContext : JsonSerializerContext { }

--- a/BareMetalWeb.Data/DashboardDefinition.cs
+++ b/BareMetalWeb.Data/DashboardDefinition.cs
@@ -33,7 +33,7 @@ public sealed class DashboardDefinition : BaseDataObject
     public List<DashboardTile> Tiles
     {
         get => DeserializeTiles(TilesJson);
-        set => TilesJson = JsonSerializer.Serialize(value ?? new List<DashboardTile>());
+        set => TilesJson = JsonSerializer.Serialize(value ?? new List<DashboardTile>(), BmwDataJsonContext.Default.ListDashboardTile);
     }
 
     private static List<DashboardTile> DeserializeTiles(string json)
@@ -42,7 +42,7 @@ public sealed class DashboardDefinition : BaseDataObject
         {
             return string.IsNullOrWhiteSpace(json)
                 ? new List<DashboardTile>()
-                : JsonSerializer.Deserialize<List<DashboardTile>>(json) ?? new List<DashboardTile>();
+                : JsonSerializer.Deserialize(json, BmwDataJsonContext.Default.ListDashboardTile) ?? new List<DashboardTile>();
         }
         catch
         {

--- a/BareMetalWeb.Data/LocalFolderBinaryDataProvider.cs
+++ b/BareMetalWeb.Data/LocalFolderBinaryDataProvider.cs
@@ -1142,7 +1142,7 @@ public sealed class LocalFolderBinaryDataProvider : IDataProvider
         try
         {
             var bytes = File.ReadAllBytes(path);
-            return JsonSerializer.Deserialize<SchemaDefinitionFile>(bytes);
+            return JsonSerializer.Deserialize(bytes, BmwDataJsonContext.Default.SchemaDefinitionFile);
         }
         catch (Exception ex)
         {
@@ -1154,7 +1154,7 @@ public sealed class LocalFolderBinaryDataProvider : IDataProvider
     private void SaveSchemaFile(Type type, SchemaDefinitionFile schema)
     {
         var path = GetSchemaFilePath(type, schema.Version);
-        var bytes = JsonSerializer.SerializeToUtf8Bytes(schema);
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(schema, BmwDataJsonContext.Default.SchemaDefinitionFile);
         File.WriteAllBytes(path, bytes);
     }
 

--- a/BareMetalWeb.Data/ReportDefinition.cs
+++ b/BareMetalWeb.Data/ReportDefinition.cs
@@ -50,38 +50,38 @@ public sealed class ReportDefinition : BaseDataObject
     [System.Text.Json.Serialization.JsonIgnore]
     public List<ReportJoin> Joins
     {
-        get => Deserialize<ReportJoin>(JoinsJson);
-        set => JoinsJson = JsonSerializer.Serialize(value ?? new List<ReportJoin>());
+        get => DeserializeList(JoinsJson, BmwDataJsonContext.Default.ListReportJoin);
+        set => JoinsJson = JsonSerializer.Serialize(value ?? new List<ReportJoin>(), BmwDataJsonContext.Default.ListReportJoin);
     }
 
     [System.Text.Json.Serialization.JsonIgnore]
     public List<ReportColumn> Columns
     {
-        get => Deserialize<ReportColumn>(ColumnsJson);
-        set => ColumnsJson = JsonSerializer.Serialize(value ?? new List<ReportColumn>());
+        get => DeserializeList(ColumnsJson, BmwDataJsonContext.Default.ListReportColumn);
+        set => ColumnsJson = JsonSerializer.Serialize(value ?? new List<ReportColumn>(), BmwDataJsonContext.Default.ListReportColumn);
     }
 
     [System.Text.Json.Serialization.JsonIgnore]
     public List<ReportFilter> Filters
     {
-        get => Deserialize<ReportFilter>(FiltersJson);
-        set => FiltersJson = JsonSerializer.Serialize(value ?? new List<ReportFilter>());
+        get => DeserializeList(FiltersJson, BmwDataJsonContext.Default.ListReportFilter);
+        set => FiltersJson = JsonSerializer.Serialize(value ?? new List<ReportFilter>(), BmwDataJsonContext.Default.ListReportFilter);
     }
 
     [System.Text.Json.Serialization.JsonIgnore]
     public List<ReportParameter> Parameters
     {
-        get => Deserialize<ReportParameter>(ParametersJson);
-        set => ParametersJson = JsonSerializer.Serialize(value ?? new List<ReportParameter>());
+        get => DeserializeList(ParametersJson, BmwDataJsonContext.Default.ListReportParameter);
+        set => ParametersJson = JsonSerializer.Serialize(value ?? new List<ReportParameter>(), BmwDataJsonContext.Default.ListReportParameter);
     }
 
-    private static List<T> Deserialize<T>(string json)
+    private static List<T> DeserializeList<T>(string json, System.Text.Json.Serialization.Metadata.JsonTypeInfo<List<T>> typeInfo)
     {
         try
         {
             return string.IsNullOrWhiteSpace(json)
                 ? new List<T>()
-                : JsonSerializer.Deserialize<List<T>>(json) ?? new List<T>();
+                : JsonSerializer.Deserialize(json, typeInfo) ?? new List<T>();
         }
         catch
         {

--- a/BareMetalWeb.Data/ViewDefinition.cs
+++ b/BareMetalWeb.Data/ViewDefinition.cs
@@ -57,38 +57,38 @@ public sealed class ViewDefinition : BaseDataObject
     [System.Text.Json.Serialization.JsonIgnore]
     public List<ViewProjection> Projections
     {
-        get => Deserialise<ViewProjection>(ProjectionsJson);
-        set => ProjectionsJson = JsonSerializer.Serialize(value ?? new List<ViewProjection>());
+        get => DeserializeList(ProjectionsJson, BmwDataJsonContext.Default.ListViewProjection);
+        set => ProjectionsJson = JsonSerializer.Serialize(value ?? new List<ViewProjection>(), BmwDataJsonContext.Default.ListViewProjection);
     }
 
     [System.Text.Json.Serialization.JsonIgnore]
     public List<ViewJoinDefinition> Joins
     {
-        get => Deserialise<ViewJoinDefinition>(JoinsJson);
-        set => JoinsJson = JsonSerializer.Serialize(value ?? new List<ViewJoinDefinition>());
+        get => DeserializeList(JoinsJson, BmwDataJsonContext.Default.ListViewJoinDefinition);
+        set => JoinsJson = JsonSerializer.Serialize(value ?? new List<ViewJoinDefinition>(), BmwDataJsonContext.Default.ListViewJoinDefinition);
     }
 
     [System.Text.Json.Serialization.JsonIgnore]
     public List<ViewFilterDefinition> Filters
     {
-        get => Deserialise<ViewFilterDefinition>(FiltersJson);
-        set => FiltersJson = JsonSerializer.Serialize(value ?? new List<ViewFilterDefinition>());
+        get => DeserializeList(FiltersJson, BmwDataJsonContext.Default.ListViewFilterDefinition);
+        set => FiltersJson = JsonSerializer.Serialize(value ?? new List<ViewFilterDefinition>(), BmwDataJsonContext.Default.ListViewFilterDefinition);
     }
 
     [System.Text.Json.Serialization.JsonIgnore]
     public List<ViewSortDefinition> Sorts
     {
-        get => Deserialise<ViewSortDefinition>(SortsJson);
-        set => SortsJson = JsonSerializer.Serialize(value ?? new List<ViewSortDefinition>());
+        get => DeserializeList(SortsJson, BmwDataJsonContext.Default.ListViewSortDefinition);
+        set => SortsJson = JsonSerializer.Serialize(value ?? new List<ViewSortDefinition>(), BmwDataJsonContext.Default.ListViewSortDefinition);
     }
 
-    private static List<T> Deserialise<T>(string json)
+    private static List<T> DeserializeList<T>(string json, System.Text.Json.Serialization.Metadata.JsonTypeInfo<List<T>> typeInfo)
     {
         try
         {
             return string.IsNullOrWhiteSpace(json)
                 ? new List<T>()
-                : JsonSerializer.Deserialize<List<T>>(json) ?? new List<T>();
+                : JsonSerializer.Deserialize(json, typeInfo) ?? new List<T>();
         }
         catch
         {

--- a/BareMetalWeb.Data/WalDataProvider.cs
+++ b/BareMetalWeb.Data/WalDataProvider.cs
@@ -1750,7 +1750,7 @@ public sealed class WalDataProvider : IDataProvider, IRawBinaryProvider, IDispos
         try
         {
             var bytes = File.ReadAllBytes(path);
-            return JsonSerializer.Deserialize<SchemaDefinitionFile>(bytes);
+            return JsonSerializer.Deserialize(bytes, BmwDataJsonContext.Default.SchemaDefinitionFile);
         }
         catch (Exception ex)
         {
@@ -1762,7 +1762,7 @@ public sealed class WalDataProvider : IDataProvider, IRawBinaryProvider, IDispos
     private void SaveSchemaFile(Type type, SchemaDefinitionFile schema)
     {
         var path  = GetSchemaFilePath(type, schema.Version);
-        var bytes = JsonSerializer.SerializeToUtf8Bytes(schema);
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(schema, BmwDataJsonContext.Default.SchemaDefinitionFile);
         File.WriteAllBytes(path, bytes);
     }
 


### PR DESCRIPTION
## Two AOT runtime crashes fixed

### 1. JsonSerializer crash on startup
\SchemaDefinitionFile\ contains \MemberSignatureFile\ with \int? BlittableSize\ — \Nullable<int>\ metadata was trimmed.

**Fix:** Created \BmwDataJsonContext\ source-generated \JsonSerializerContext\ (45 registered types) and converted all \JsonSerializer.Serialize/Deserialize\ calls in the Data project to use source-gen overloads:
- WalDataProvider (schema save/load)
- LocalFolderBinaryDataProvider (schema save/load)  
- AuditEntry (FieldChanges property)
- DashboardDefinition (Tiles property)
- ReportDefinition (Joins/Columns/Filters/Parameters)
- ViewDefinition (Projections/Joins/Filters/Sorts)

### 2. Marshal.SizeOf crash on \IdentifierValue\
\Marshal.SizeOf(type)\, \Marshal.StructureToPtr\, and \Marshal.PtrToStructure\ require runtime marshalling data that's trimmed under AOT.

**Fix:** Replaced all three with AOT-safe alternatives:
- \Marshal.SizeOf\ → field-sum size computation via \GetFields()\
- \Marshal.StructureToPtr\ → direct \BinaryPrimitives.Write*\ per field
- \Marshal.PtrToStructure\ → direct \BinaryPrimitives.Read*\ per field

### Verified
- AOT binary starts and serves **HTTP 200** on \/\
- 77 Data tests pass, 809 Host tests pass (4 pre-existing MetricsTracker failures)