### PR TITLE
feat: add 5 new metrics — route dispatch, WAL read, UI render, serialization, GC stats

### DIFF
--- a/BareMetalWeb.Core/Interfaces/IMetricsTracker.cs
+++ b/BareMetalWeb.Core/Interfaces/IMetricsTracker.cs
@@ -8,6 +8,11 @@ public interface IMetricsTracker
 {
     void RecordRequest(int statusCode, TimeSpan elapsed);
     void RecordThrottled(TimeSpan elapsed);
+    void RecordRouteDispatch(TimeSpan elapsed);
+    void RecordWalRead(TimeSpan elapsed);
+    void RecordUiRender(TimeSpan elapsed);
+    void RecordSerialization(TimeSpan elapsed);
+    void RecordGcPause(TimeSpan elapsed);
     void GetMetricTable(out string[] tableColumns, out string[][] tableRows);
     MetricsSnapshot GetSnapshot();
 }

--- a/BareMetalWeb.Core/MetricsSnapshot.cs
+++ b/BareMetalWeb.Core/MetricsSnapshot.cs
@@ -18,5 +18,17 @@ public readonly record struct MetricsSnapshot(
     int ProcessId,
     long WorkingSet64,
     long VirtualMemorySize64,
-    TimeSpan ProcessUptime
+    TimeSpan ProcessUptime,
+    long RouteDispatchCount,
+    TimeSpan RouteDispatchAverage,
+    long WalReadCount,
+    TimeSpan WalReadAverage,
+    long UiRenderCount,
+    TimeSpan UiRenderAverage,
+    long SerializationCount,
+    TimeSpan SerializationAverage,
+    int GcGen0Collections,
+    int GcGen1Collections,
+    int GcGen2Collections,
+    long GcTotalAllocatedBytes
 );

--- a/BareMetalWeb.Data/BmwJsonWriter.cs
+++ b/BareMetalWeb.Data/BmwJsonWriter.cs
@@ -1,6 +1,7 @@
 using System.Buffers;
 using System.Buffers.Text;
 using System.Collections;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text;
 using WireFieldType = BareMetalWeb.Data.MetadataWireSerializer.WireFieldType;
@@ -20,6 +21,8 @@ namespace BareMetalWeb.Data;
 /// </summary>
 public static class BmwJsonWriter
 {
+    internal static Action<TimeSpan>? OnSerializationComplete;
+
     private const int HeaderSize = 45; // magic(4) + version(4) + schema(4) + arch(1) + sig(32)
     private const int MaxStringBytes = 4 * 1024 * 1024;
 
@@ -86,6 +89,7 @@ public static class BmwJsonWriter
     /// </summary>
     public static void WriteEntity(Stream output, ReadOnlySpan<byte> rowBinary, JsonFieldFragment[] fragments)
     {
+        var sw = Stopwatch.StartNew();
         if (rowBinary.Length < HeaderSize + 1)
             throw new InvalidOperationException("Binary payload too short for BSO1 header.");
 
@@ -97,12 +101,16 @@ public static class BmwJsonWriter
         if (hasValue == 0)
         {
             output.Write(JsonNull);
+            sw.Stop();
+            OnSerializationComplete?.Invoke(sw.Elapsed);
             return;
         }
 
         output.Write(JsonObjectStart);
         WriteFieldsFromBinary(output, ref reader, fragments);
         output.Write(JsonObjectEnd);
+        sw.Stop();
+        OnSerializationComplete?.Invoke(sw.Elapsed);
     }
 
     /// <summary>
@@ -111,6 +119,7 @@ public static class BmwJsonWriter
     /// </summary>
     public static void WriteEntityList(Stream output, IReadOnlyList<ReadOnlyMemory<byte>> rows, JsonFieldFragment[] fragments, int count)
     {
+        var sw = Stopwatch.StartNew();
         output.Write(JsonObjectStart);
         output.Write(DataPrefix);
         output.Write(JsonArrayStart);
@@ -132,6 +141,8 @@ public static class BmwJsonWriter
             output.Write("0"u8);
 
         output.Write(JsonObjectEnd);
+        sw.Stop();
+        OnSerializationComplete?.Invoke(sw.Elapsed);
     }
 
     /// <summary>
@@ -147,6 +158,7 @@ public static class BmwJsonWriter
         MetadataWireSerializer serializer,
         int count)
     {
+        var sw = Stopwatch.StartNew();
         output.Write(JsonObjectStart);
         output.Write(DataPrefix);
         output.Write(JsonArrayStart);
@@ -169,6 +181,8 @@ public static class BmwJsonWriter
         else
             output.Write("0"u8);
         output.Write(JsonObjectEnd);
+        sw.Stop();
+        OnSerializationComplete?.Invoke(sw.Elapsed);
     }
 
     // ────────────── Field iteration ──────────────

--- a/BareMetalWeb.Data/WalDataProvider.cs
+++ b/BareMetalWeb.Data/WalDataProvider.cs
@@ -3,6 +3,7 @@ using System.Buffers;
 using System.Buffers.Binary;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Numerics;
 using System.Reflection;
@@ -36,6 +37,8 @@ namespace BareMetalWeb.Data;
 /// </summary>
 public sealed class WalDataProvider : IDataProvider, IRawBinaryProvider, IDisposable
 {
+    internal static Action<TimeSpan>? OnWalReadComplete;
+
     // ── Constants ────────────────────────────────────────────────────────────
 
     private const string WalSubFolder          = "wal";
@@ -323,25 +326,28 @@ public sealed class WalDataProvider : IDataProvider, IRawBinaryProvider, IDispos
 
     public T? Load<T>(uint key) where T : BaseDataObject
     {
+        var sw = Stopwatch.StartNew();
         if (key == 0)
             throw new ArgumentException("Key cannot be zero.", nameof(key));
 
         var typeName = typeof(T).Name;
         var idMap    = GetOrLoadIdMap(typeName);
 
-        if (!idMap.TryGetValue(key, out var walKey)) return default;
-        if (!_walStore.TryGetHead(walKey, out var ptr)) return default;
+        if (!idMap.TryGetValue(key, out var walKey)) { sw.Stop(); OnWalReadComplete?.Invoke(sw.Elapsed); return default; }
+        if (!_walStore.TryGetHead(walKey, out var ptr)) { sw.Stop(); OnWalReadComplete?.Invoke(sw.Elapsed); return default; }
 
         // Check deserialization cache — hit if WAL pointer unchanged
         var cacheKey = (typeName, key, ptr);
         if (_deserCache.TryGetValue(cacheKey, out var cachedObj))
         {
             _deserCacheAccess[cacheKey] = Environment.TickCount64;
+            sw.Stop();
+            OnWalReadComplete?.Invoke(sw.Elapsed);
             return cachedObj as T;
         }
 
-        if (!_walStore.TryReadOpPayload(ptr, walKey, out var payload)) return default;
-        if (payload.IsEmpty) return default;
+        if (!_walStore.TryReadOpPayload(ptr, walKey, out var payload)) { sw.Stop(); OnWalReadComplete?.Invoke(sw.Elapsed); return default; }
+        if (payload.IsEmpty) { sw.Stop(); OnWalReadComplete?.Invoke(sw.Elapsed); return default; }
 
         T? result;
         try
@@ -351,6 +357,8 @@ public sealed class WalDataProvider : IDataProvider, IRawBinaryProvider, IDispos
         catch (Exception ex)
         {
             _logger?.LogError($"Corrupt payload for {typeName} Key={key} WalPtr={ptr}: {ex.Message}", ex);
+            sw.Stop();
+            OnWalReadComplete?.Invoke(sw.Elapsed);
             return default;
         }
         if (result != null)
@@ -360,6 +368,8 @@ public sealed class WalDataProvider : IDataProvider, IRawBinaryProvider, IDispos
             _deserCache[cacheKey] = result;
             _deserCacheAccess[cacheKey] = Environment.TickCount64;
         }
+        sw.Stop();
+        OnWalReadComplete?.Invoke(sw.Elapsed);
         return result;
     }
 
@@ -420,8 +430,9 @@ public sealed class WalDataProvider : IDataProvider, IRawBinaryProvider, IDispos
     /// <inheritdoc/>
     public IReadOnlyList<ReadOnlyMemory<byte>> QueryBinary(string typeName, QueryDefinition? query = null)
     {
+        var sw = Stopwatch.StartNew();
         var idMap = GetOrLoadIdMap(typeName);
-        if (idMap.Count == 0) return Array.Empty<ReadOnlyMemory<byte>>();
+        if (idMap.Count == 0) { sw.Stop(); OnWalReadComplete?.Invoke(sw.Elapsed); return Array.Empty<ReadOnlyMemory<byte>>(); }
 
         var results = new List<ReadOnlyMemory<byte>>();
 
@@ -445,6 +456,8 @@ public sealed class WalDataProvider : IDataProvider, IRawBinaryProvider, IDispos
             taken++;
         }
 
+        sw.Stop();
+        OnWalReadComplete?.Invoke(sw.Elapsed);
         return results;
     }
 

--- a/BareMetalWeb.Host.Tests/BareMetalWebServerTests.cs
+++ b/BareMetalWeb.Host.Tests/BareMetalWebServerTests.cs
@@ -1113,6 +1113,11 @@ public class BareMetalWebServerTests : IDisposable
     {
         public void RecordRequest(int statusCode, TimeSpan duration) { }
         public void RecordThrottled(TimeSpan duration) { }
+        public void RecordRouteDispatch(TimeSpan elapsed) { }
+        public void RecordWalRead(TimeSpan elapsed) { }
+        public void RecordUiRender(TimeSpan elapsed) { }
+        public void RecordSerialization(TimeSpan elapsed) { }
+        public void RecordGcPause(TimeSpan elapsed) { }
         public void GetMetricTable(out string[] tableColumns, out string[][] tableRows)
         {
             tableColumns = Array.Empty<string>();
@@ -1120,7 +1125,8 @@ public class BareMetalWebServerTests : IDisposable
         }
         public MetricsSnapshot GetSnapshot() => new MetricsSnapshot(
             0, 0, TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero,
-            TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero, 0, 0, 0, 0, 0, 0, 0, 0, TimeSpan.Zero);
+            TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero, 0, 0, 0, 0, 0, 0, 0, 0, TimeSpan.Zero,
+            0, TimeSpan.Zero, 0, TimeSpan.Zero, 0, TimeSpan.Zero, 0, TimeSpan.Zero, 0, 0, 0, 0);
     }
 
     private class MockClientRequestTracker : IClientRequestTracker

--- a/BareMetalWeb.Host.Tests/LookupApiHandlerTests.cs
+++ b/BareMetalWeb.Host.Tests/LookupApiHandlerTests.cs
@@ -709,6 +709,11 @@ public class LookupApiHandlerTests : IDisposable
     {
         public void RecordRequest(int statusCode, TimeSpan elapsed) { }
         public void RecordThrottled(TimeSpan elapsed) { }
+        public void RecordRouteDispatch(TimeSpan elapsed) { }
+        public void RecordWalRead(TimeSpan elapsed) { }
+        public void RecordUiRender(TimeSpan elapsed) { }
+        public void RecordSerialization(TimeSpan elapsed) { }
+        public void RecordGcPause(TimeSpan elapsed) { }
         public void GetMetricTable(out string[] tableColumns, out string[][] tableRows)
         {
             tableColumns = Array.Empty<string>();
@@ -716,7 +721,8 @@ public class LookupApiHandlerTests : IDisposable
         }
         public MetricsSnapshot GetSnapshot() => new MetricsSnapshot(
             0, 0, TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero,
-            TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero, 0, 0, 0, 0, 0, 0, 0, 0, TimeSpan.Zero);
+            TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero, 0, 0, 0, 0, 0, 0, 0, 0, TimeSpan.Zero,
+            0, TimeSpan.Zero, 0, TimeSpan.Zero, 0, TimeSpan.Zero, 0, TimeSpan.Zero, 0, 0, 0, 0);
     }
 
     private class MockClientRequestTracker : IClientRequestTracker

--- a/BareMetalWeb.Host.Tests/RouteRegistrationExtensionsTests.cs
+++ b/BareMetalWeb.Host.Tests/RouteRegistrationExtensionsTests.cs
@@ -910,6 +910,11 @@ public class RouteRegistrationExtensionsTests : IDisposable
     {
         public void RecordRequest(int statusCode, TimeSpan duration) { }
         public void RecordThrottled(TimeSpan duration) { }
+        public void RecordRouteDispatch(TimeSpan elapsed) { }
+        public void RecordWalRead(TimeSpan elapsed) { }
+        public void RecordUiRender(TimeSpan elapsed) { }
+        public void RecordSerialization(TimeSpan elapsed) { }
+        public void RecordGcPause(TimeSpan elapsed) { }
         public void GetMetricTable(out string[] tableColumns, out string[][] tableRows)
         {
             tableColumns = Array.Empty<string>();
@@ -917,7 +922,8 @@ public class RouteRegistrationExtensionsTests : IDisposable
         }
         public MetricsSnapshot GetSnapshot() => new MetricsSnapshot(
             0, 0, TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero,
-            TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero, 0, 0, 0, 0, 0, 0, 0, 0, TimeSpan.Zero);
+            TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero, 0, 0, 0, 0, 0, 0, 0, 0, TimeSpan.Zero,
+            0, TimeSpan.Zero, 0, TimeSpan.Zero, 0, TimeSpan.Zero, 0, TimeSpan.Zero, 0, 0, 0, 0);
     }
     private class MockClientRequestTracker : IClientRequestTracker
     {

--- a/BareMetalWeb.Host/BareMetalWebExtensions.cs
+++ b/BareMetalWeb.Host/BareMetalWebExtensions.cs
@@ -209,6 +209,11 @@ public static class BareMetalWebExtensions
         appInfo.PrivacyPolicyUrl   = SettingsService.GetValue(WellKnownSettings.AppPrivacyPolicyUrl, "");
         appInfo.ShowHostDiagnostics = string.Equals(SettingsService.GetValue(WellKnownSettings.ShowHostInfo, "False"), "True", StringComparison.OrdinalIgnoreCase);
 
+        // Wire up metrics callbacks for subsystem timers
+        BmwJsonWriter.OnSerializationComplete = elapsed => metricsTracker.RecordSerialization(elapsed);
+        WalDataProvider.OnWalReadComplete = elapsed => metricsTracker.RecordWalRead(elapsed);
+        BareMetalWeb.Rendering.HtmlRenderer.OnRenderComplete = elapsed => metricsTracker.RecordUiRender(elapsed);
+
         // Wire up the tenant registry so RequestHandler can resolve tenants per-request.
         if (multitenancyOptions.Enabled)
             appInfo.TenantRegistry = tenantRegistry;

--- a/BareMetalWeb.Host/BareMetalWebServer.cs
+++ b/BareMetalWeb.Host/BareMetalWebServer.cs
@@ -477,6 +477,7 @@ public class BareMetalWebServer : IBareWebHost
             // not for static assets (bundles, files) served above.
             await BuildAppInfoMenuOptionsAsync(bmwCtx, context.RequestAborted).ConfigureAwait(false);
 
+            var dispatchSw = Stopwatch.StartNew();
             // ── Jump table: O(1) exact-match dispatch ───────────────────────
             EnsureJumpTable();
             EnsurePrefixRouter();
@@ -490,10 +491,14 @@ public class BareMetalWebServer : IBareWebHost
                 {
                     await LogAccessDeniedAsync(routeKey, sourceIp, bmwCtx, page.PageInfo, context.RequestAborted).ConfigureAwait(false);
                     await RenderForbidden(bmwCtx);
+                    dispatchSw.Stop();
+                    Metrics.RecordRouteDispatch(dispatchSw.Elapsed);
                     return;
                 }
                 await page.Handler(bmwCtx);
                 BufferedLogger.LogInfo($"{routeKey}|200|{sourceIp}");
+                dispatchSw.Stop();
+                Metrics.RecordRouteDispatch(dispatchSw.Elapsed);
                 return;
             }
             // Jump table also handles "ALL" verb routes
@@ -507,10 +512,14 @@ public class BareMetalWebServer : IBareWebHost
                 {
                     await LogAccessDeniedAsync(routeKey, sourceIp, bmwCtx, allPage.PageInfo, context.RequestAborted).ConfigureAwait(false);
                     await RenderForbidden(bmwCtx);
+                    dispatchSw.Stop();
+                    Metrics.RecordRouteDispatch(dispatchSw.Elapsed);
                     return;
                 }
                 await allPage.Handler(bmwCtx);
                 BufferedLogger.LogInfo($"{routeKey}|ALL {requestPath}|200|{sourceIp}");
+                dispatchSw.Stop();
+                Metrics.RecordRouteDispatch(dispatchSw.Elapsed);
                 return;
             }
             // ── Prefix router: O(1) entity dispatch for /api/{type} routes ──
@@ -520,13 +529,17 @@ public class BareMetalWebServer : IBareWebHost
                 {
                     await LogAccessDeniedAsync(routeKey, sourceIp, bmwCtx, prefixPage.PageInfo, context.RequestAborted).ConfigureAwait(false);
                     await RenderForbidden(bmwCtx);
+                    dispatchSw.Stop();
+                    Metrics.RecordRouteDispatch(dispatchSw.Elapsed);
                     return;
                 }
                 await prefixPage.Handler(bmwCtx);
                 BufferedLogger.LogInfo($"{routeKey}|200|{sourceIp}|prefix");
+                dispatchSw.Stop();
+                Metrics.RecordRouteDispatch(dispatchSw.Elapsed);
                 return;
             }
-            // Pattern match fallback — iterate most-specific routes first so that literal
+            // Pattern match fallback— iterate most-specific routes first so that literal
             // segments (e.g. /api/_lookup/{type}) beat generic routes (e.g. /api/{type}/{id}).
             bool methodNotAllowed = false;
             foreach (var (_, routeData, compiled) in GetSortedRoutes())
@@ -549,6 +562,8 @@ public class BareMetalWebServer : IBareWebHost
                     {
                         await LogAccessDeniedAsync(routeKey, sourceIp, bmwCtx, injectedPage.PageInfo, context.RequestAborted).ConfigureAwait(false);
                         await RenderForbidden(bmwCtx);
+                        dispatchSw.Stop();
+                        Metrics.RecordRouteDispatch(dispatchSw.Elapsed);
                         return;
                     }
                     await injectedPage.Handler(bmwCtx);
@@ -557,6 +572,8 @@ public class BareMetalWebServer : IBareWebHost
                     foreach (var p in parameters)
                         paramParts[paramIdx++] = $"{p.Key}={p.Value}";
                     BufferedLogger.LogInfo($"{routeKey}|{method}|{compiled.Verb}|{string.Join(", ", paramParts)}|200|{sourceIp}");
+                    dispatchSw.Stop();
+                    Metrics.RecordRouteDispatch(dispatchSw.Elapsed);
                     return;
                 }
             }
@@ -581,6 +598,8 @@ public class BareMetalWebServer : IBareWebHost
                     {
                         await LogAccessDeniedAsync(routeKey, sourceIp, bmwCtx, injectedPage.PageInfo, context.RequestAborted).ConfigureAwait(false);
                         await RenderForbidden(bmwCtx);
+                        dispatchSw.Stop();
+                        Metrics.RecordRouteDispatch(dispatchSw.Elapsed);
                         return;
                     }
                     await injectedPage.Handler(bmwCtx);
@@ -589,6 +608,8 @@ public class BareMetalWebServer : IBareWebHost
                     foreach (var p in parameters)
                         paramParts2[paramIdx2++] = $"{p.Key}={p.Value}";
                     BufferedLogger.LogInfo($"{routeKey}|{method}|{compiled.Verb}|{string.Join(", ", paramParts2)}|200|{sourceIp}");
+                    dispatchSw.Stop();
+                    Metrics.RecordRouteDispatch(dispatchSw.Elapsed);
                     return;
                 }
             }
@@ -598,11 +619,15 @@ public class BareMetalWebServer : IBareWebHost
                 bmwCtx.SetPageInfo(ErrorPageInfo);
                 await HtmlRenderer.RenderPage(bmwCtx.HttpContext);
                 BufferedLogger.LogInfo($"{routeKey}|405|{sourceIp}");
+                dispatchSw.Stop();
+                Metrics.RecordRouteDispatch(dispatchSw.Elapsed);
                 return;
             }
             bmwCtx.SetPageInfo(NotFoundPageInfo);
             await HtmlRenderer.RenderPage(bmwCtx.HttpContext); // Still nothing? 404
             BufferedLogger.LogInfo($"{routeKey}|404|{sourceIp}");
+            dispatchSw.Stop();
+            Metrics.RecordRouteDispatch(dispatchSw.Elapsed);
         }
         catch (OperationCanceledException oce)
         {

--- a/BareMetalWeb.Host/MetricsTracker.cs
+++ b/BareMetalWeb.Host/MetricsTracker.cs
@@ -28,6 +28,17 @@ public sealed class MetricsTracker : IMetricsTracker, IDisposable
     private long _requestsOther;
     private long _throttledRequests;
 
+    private long _routeDispatchTicks;
+    private long _routeDispatchCount;
+    private long _walReadTicks;
+    private long _walReadCount;
+    private long _uiRenderTicks;
+    private long _uiRenderCount;
+    private long _serializationTicks;
+    private long _serializationCount;
+    private long _gcPauseTicks;
+    private long _gcPauseCount;
+
     private readonly object _recentLock = new();
     private readonly Queue<ResponseSample> _recentSamples = new();
     private readonly Process _currentProcess = Process.GetCurrentProcess();
@@ -64,6 +75,36 @@ public sealed class MetricsTracker : IMetricsTracker, IDisposable
         RecordRequest(429, elapsed);
     }
 
+    public void RecordRouteDispatch(TimeSpan elapsed)
+    {
+        Interlocked.Increment(ref _routeDispatchCount);
+        Interlocked.Add(ref _routeDispatchTicks, elapsed.Ticks);
+    }
+
+    public void RecordWalRead(TimeSpan elapsed)
+    {
+        Interlocked.Increment(ref _walReadCount);
+        Interlocked.Add(ref _walReadTicks, elapsed.Ticks);
+    }
+
+    public void RecordUiRender(TimeSpan elapsed)
+    {
+        Interlocked.Increment(ref _uiRenderCount);
+        Interlocked.Add(ref _uiRenderTicks, elapsed.Ticks);
+    }
+
+    public void RecordSerialization(TimeSpan elapsed)
+    {
+        Interlocked.Increment(ref _serializationCount);
+        Interlocked.Add(ref _serializationTicks, elapsed.Ticks);
+    }
+
+    public void RecordGcPause(TimeSpan elapsed)
+    {
+        Interlocked.Increment(ref _gcPauseCount);
+        Interlocked.Add(ref _gcPauseTicks, elapsed.Ticks);
+    }
+
     public MetricsSnapshot GetSnapshot()
     {
         var total = Interlocked.Read(ref _totalRequests);
@@ -88,6 +129,19 @@ public sealed class MetricsTracker : IMetricsTracker, IDisposable
         var recentMetrics = ComputeRecentMetrics(recentSamples);
         var recent10s = ComputeRecentMetrics(FilterRecentSamples(recentSamples, nowUtc - RecentShortWindow));
 
+        var routeDispatchCount = Interlocked.Read(ref _routeDispatchCount);
+        var routeDispatchAvg = routeDispatchCount == 0 ? TimeSpan.Zero : TimeSpan.FromTicks(Interlocked.Read(ref _routeDispatchTicks) / routeDispatchCount);
+        var walReadCount = Interlocked.Read(ref _walReadCount);
+        var walReadAvg = walReadCount == 0 ? TimeSpan.Zero : TimeSpan.FromTicks(Interlocked.Read(ref _walReadTicks) / walReadCount);
+        var uiRenderCount = Interlocked.Read(ref _uiRenderCount);
+        var uiRenderAvg = uiRenderCount == 0 ? TimeSpan.Zero : TimeSpan.FromTicks(Interlocked.Read(ref _uiRenderTicks) / uiRenderCount);
+        var serializationCount = Interlocked.Read(ref _serializationCount);
+        var serializationAvg = serializationCount == 0 ? TimeSpan.Zero : TimeSpan.FromTicks(Interlocked.Read(ref _serializationTicks) / serializationCount);
+        var gcGen0 = GC.CollectionCount(0);
+        var gcGen1 = GC.CollectionCount(1);
+        var gcGen2 = GC.CollectionCount(2);
+        var gcAllocated = GC.GetTotalAllocatedBytes(precise: false);
+
         _currentProcess.Refresh();
 
         return new MetricsSnapshot(
@@ -108,7 +162,12 @@ public sealed class MetricsTracker : IMetricsTracker, IDisposable
             _currentProcess.Id,
             _currentProcess.WorkingSet64,
             _currentProcess.VirtualMemorySize64,
-            DateTime.UtcNow - _currentProcess.StartTime.ToUniversalTime()
+            DateTime.UtcNow - _currentProcess.StartTime.ToUniversalTime(),
+            routeDispatchCount, routeDispatchAvg,
+            walReadCount, walReadAvg,
+            uiRenderCount, uiRenderAvg,
+            serializationCount, serializationAvg,
+            gcGen0, gcGen1, gcGen2, gcAllocated
         );
     }
 
@@ -230,6 +289,18 @@ public sealed class MetricsTracker : IMetricsTracker, IDisposable
             new[] { "5xx Server Error", snapshot.Requests5xx.ToString("N0") },
             new[] { "Other", snapshot.RequestsOther.ToString("N0") },
             new[] { "429 Throttled", snapshot.ThrottledRequests.ToString("N0") },
+
+            new[] { "⏰ SUBSYSTEM TIMERS", "" },
+            new[] { "Route Dispatch (avg)", $"{snapshot.RouteDispatchAverage.TotalMicroseconds:F1} µs ({snapshot.RouteDispatchCount:N0} calls)" },
+            new[] { "WAL Read (avg)", $"{snapshot.WalReadAverage.TotalMicroseconds:F1} µs ({snapshot.WalReadCount:N0} calls)" },
+            new[] { "UI Render (avg)", $"{snapshot.UiRenderAverage.TotalMilliseconds:F2} ms ({snapshot.UiRenderCount:N0} calls)" },
+            new[] { "Serialization (avg)", $"{snapshot.SerializationAverage.TotalMicroseconds:F1} µs ({snapshot.SerializationCount:N0} calls)" },
+
+            new[] { "🗑️ GC STATISTICS", "" },
+            new[] { "Gen0 Collections", snapshot.GcGen0Collections.ToString("N0") },
+            new[] { "Gen1 Collections", snapshot.GcGen1Collections.ToString("N0") },
+            new[] { "Gen2 Collections", snapshot.GcGen2Collections.ToString("N0") },
+            new[] { "Total Allocated", FormatSizeBytes(snapshot.GcTotalAllocatedBytes) },
 
             new[] { "💻 MEMORY & PROCESS", "" },
             new[] { "Process ID (PID)", snapshot.ProcessId.ToString() },

--- a/BareMetalWeb.Rendering.Tests/HtmlRendererTests.cs
+++ b/BareMetalWeb.Rendering.Tests/HtmlRendererTests.cs
@@ -603,6 +603,11 @@ internal sealed class StubMetricsTracker : IMetricsTracker
 {
     public void RecordRequest(int statusCode, TimeSpan elapsed) { }
     public void RecordThrottled(TimeSpan elapsed) { }
+    public void RecordRouteDispatch(TimeSpan elapsed) { }
+    public void RecordWalRead(TimeSpan elapsed) { }
+    public void RecordUiRender(TimeSpan elapsed) { }
+    public void RecordSerialization(TimeSpan elapsed) { }
+    public void RecordGcPause(TimeSpan elapsed) { }
     public void GetMetricTable(out string[] tableColumns, out string[][] tableRows)
     {
         tableColumns = Array.Empty<string>();
@@ -610,5 +615,6 @@ internal sealed class StubMetricsTracker : IMetricsTracker
     }
     public MetricsSnapshot GetSnapshot() => new MetricsSnapshot(
         0, 0, TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero, TimeSpan.FromMilliseconds(1.5),
-        TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero, 0, 0, 0, 0, 0, 0, 0, 0, TimeSpan.Zero);
+        TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero, 0, 0, 0, 0, 0, 0, 0, 0, TimeSpan.Zero,
+        0, TimeSpan.Zero, 0, TimeSpan.Zero, 0, TimeSpan.Zero, 0, TimeSpan.Zero, 0, 0, 0, 0);
 }

--- a/BareMetalWeb.Rendering/HtmlRenderer.cs
+++ b/BareMetalWeb.Rendering/HtmlRenderer.cs
@@ -1,6 +1,6 @@
 using System.Buffers;
 using System.Collections.Generic;
-
+using System.Diagnostics;
 using System.IO.Pipelines;
 using System.Net;
 using System.Text;
@@ -16,6 +16,8 @@ namespace BareMetalWeb.Rendering;
 
 public class HtmlRenderer : IHtmlRenderer
 {
+    public static Action<TimeSpan>? OnRenderComplete;
+
     private static readonly Encoding Utf8 = Encoding.UTF8;
     private readonly IHtmlFragmentRenderer _fragments;
 
@@ -548,6 +550,7 @@ public class HtmlRenderer : IHtmlRenderer
 
     public async ValueTask RenderPage(HttpContext context, PageInfo page, IBareWebHost app)
     {
+        var renderSw = Stopwatch.StartNew();
         // Ensure CSP nonce is in page context — search without List allocation
         var pageContext = page.PageContext;
         var existingKeys = pageContext.PageMetaDataKeys;
@@ -638,6 +641,8 @@ public class HtmlRenderer : IHtmlRenderer
         CompressionHelper.ApplyHeaders(context.Response, encoding);
         context.Response.ContentLength = responseBytes.Length;
         await context.Response.BodyWriter.WriteAsync(responseBytes);
+        renderSw.Stop();
+        OnRenderComplete?.Invoke(renderSw.Elapsed);
 
     }
 


### PR DESCRIPTION
## New Metrics (#1066)

Adds 5 new subsystem timers and GC statistics to the metrics dashboard:

### ⏰ Subsystem Timers
- **Route Dispatch** — time to match and dispatch a request to a handler (µs avg)
- **WAL Read** — time for WAL data provider Load/QueryBinary operations (µs avg)
- **UI Render** — time to render HTML pages via HtmlRenderer (ms avg)
- **Serialization** — time for BmwJsonWriter entity/list serialization (µs avg)

### 🗑️ GC Statistics
- Gen0/Gen1/Gen2 collection counts
- Total bytes allocated

### Implementation
- Thread-safe \Interlocked\ counters in MetricsTracker (same pattern as existing metrics)
- Static \Action<TimeSpan>?\ callbacks on BmwJsonWriter, WalDataProvider, HtmlRenderer (wired at startup)
- Stopwatch instrumentation at dispatch, serialization, WAL read, and render sites
- All displayed in the \/stats\ metrics table

Fixes #1066