### PR TITLE
refactor: remove all hot-path reflection, reduce startup reflection

### DIFF
--- a/BareMetalWeb.Data/ActionExpander.cs
+++ b/BareMetalWeb.Data/ActionExpander.cs
@@ -244,7 +244,6 @@ public sealed class ActionExpander
     private static uint GetEntityKey(object entity)
     {
         if (entity is BaseDataObject bdo) return bdo.Key;
-        var prop = entity.GetType().GetProperty("Key");
-        return prop != null ? Convert.ToUInt32(prop.GetValue(entity)) : 0;
+        return 0;
     }
 }

--- a/BareMetalWeb.Data/AuditService.cs
+++ b/BareMetalWeb.Data/AuditService.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using BareMetalWeb.Core;
 using BareMetalWeb.Data.Interfaces;
 using BareMetalWeb.Core.Interfaces;
 
@@ -17,6 +19,24 @@ public sealed class AuditService
     private readonly IDataObjectStore _store;
     private readonly IBufferedLogger? _logger;
     private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = false };
+
+    // Cache of compiled property accessors per type — avoids per-call GetProperties/GetValue reflection
+    private static readonly ConcurrentDictionary<Type, (string Name, Func<object, object?> Getter)[]> _accessorCache = new();
+
+    private static (string Name, Func<object, object?> Getter)[] GetCachedAccessors(Type type)
+    {
+        return _accessorCache.GetOrAdd(type, static t =>
+        {
+            var props = t.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+            var list = new List<(string, Func<object, object?>)>(props.Length);
+            foreach (var p in props)
+            {
+                if (!p.CanRead || !p.CanWrite) continue;
+                list.Add((p.Name, PropertyAccessorFactory.BuildGetter(p)));
+            }
+            return list.ToArray();
+        });
+    }
 
     /// <summary>
     /// When true, audit saves are awaited directly instead of fire-and-forget.
@@ -219,15 +239,12 @@ public sealed class AuditService
     }
 
     /// <summary>
-    /// Detects changes between old and new entity instances
+    /// Detects changes between old and new entity instances using pre-compiled delegates.
     /// </summary>
     private List<FieldChange> DetectChanges<T>(T oldEntity, T newEntity) where T : BaseDataObject
     {
         var changes = new List<FieldChange>();
         var type = typeof(T);
-
-        // Get all public properties
-        var allProperties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
 
         // Fields to skip (metadata fields that always change + sensitive credential fields)
         var skipFields = new HashSet<string>
@@ -241,24 +258,52 @@ public sealed class AuditService
             "ApiKeyHashes"
         };
 
-        foreach (var prop in allProperties)
+        // Use DataScaffold metadata (compiled delegates) instead of raw reflection
+        var meta = DataScaffold.GetEntityByType(type);
+        if (meta != null)
         {
-            if (!prop.CanRead || !prop.CanWrite)
-                continue;
+            foreach (var field in meta.Fields)
+            {
+                if (skipFields.Contains(field.Name))
+                    continue;
 
-            if (skipFields.Contains(prop.Name))
+                try
+                {
+                    var oldValue = field.GetValueFn(oldEntity);
+                    var newValue = field.GetValueFn(newEntity);
+
+                    if (!AreEqual(oldValue, newValue))
+                    {
+                        changes.Add(new FieldChange(
+                            field.Name,
+                            SerializeValue(oldValue),
+                            SerializeValue(newValue)
+                        ));
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger?.LogError($"Failed to detect change for property {field.Name}: {ex.Message}", ex);
+                }
+            }
+            return changes;
+        }
+
+        // Fallback for unregistered types — uses cached compiled delegates
+        foreach (var (name, getter) in GetCachedAccessors(type))
+        {
+            if (skipFields.Contains(name))
                 continue;
 
             try
             {
-                var oldValue = prop.GetValue(oldEntity);
-                var newValue = prop.GetValue(newEntity);
+                var oldValue = getter(oldEntity);
+                var newValue = getter(newEntity);
 
-                // Compare values
                 if (!AreEqual(oldValue, newValue))
                 {
                     changes.Add(new FieldChange(
-                        prop.Name,
+                        name,
                         SerializeValue(oldValue),
                         SerializeValue(newValue)
                     ));
@@ -266,7 +311,7 @@ public sealed class AuditService
             }
             catch (Exception ex)
             {
-                _logger?.LogError($"Failed to detect change for property {prop.Name}: {ex.Message}", ex);
+                _logger?.LogError($"Failed to detect change for property {name}: {ex.Message}", ex);
             }
         }
 

--- a/BareMetalWeb.Data/ColumnQueryExecutor.cs
+++ b/BareMetalWeb.Data/ColumnQueryExecutor.cs
@@ -98,7 +98,7 @@ internal static class ColumnQueryExecutor
         int wordCount)
         where T : BaseDataObject
     {
-        var propType = Nullable.GetUnderlyingType(field.Property.PropertyType) ?? field.Property.PropertyType;
+        var propType = Nullable.GetUnderlyingType(field.ClrType) ?? field.ClrType;
 
         // Int-range types: int, uint, short, ushort, byte, sbyte, bool, enum
         if (IsIntType(propType) && TryConvertToInt(clause.Value, propType, out int iTarget))

--- a/BareMetalWeb.Data/ColumnarStore.cs
+++ b/BareMetalWeb.Data/ColumnarStore.cs
@@ -130,8 +130,8 @@ internal sealed class ColumnarStore
             // Identify numeric fields and allocate dense column arrays
             foreach (var field in meta.Fields)
             {
-                var propType = Nullable.GetUnderlyingType(field.Property.PropertyType)
-                               ?? field.Property.PropertyType;
+                var propType = Nullable.GetUnderlyingType(field.ClrType)
+                               ?? field.ClrType;
 
                 if      (IsIntType(propType))    _intColumns[field.Name]    = new int[n];
                 else if (IsLongType(propType))   _longColumns[field.Name]   = new long[n];

--- a/BareMetalWeb.Data/ComputedFieldService.cs
+++ b/BareMetalWeb.Data/ComputedFieldService.cs
@@ -197,7 +197,7 @@ public static class ComputedFieldService
             // Try to query for child entities if the collection isn't loaded
             // This would require knowing the child entity type and foreign key relationship
             // For now, return default value
-            return GetDefaultValueForAggregate(config.Aggregate, field.Property.PropertyType);
+            return GetDefaultValueForAggregate(config.Aggregate, field.ClrType);
         }
 
         var items = new List<object>();
@@ -212,7 +212,7 @@ public static class ComputedFieldService
             if (config.Aggregate == AggregateFunction.Count)
                 return items.Count;
             
-            return GetDefaultValueForAggregate(config.Aggregate, field.Property.PropertyType);
+            return GetDefaultValueForAggregate(config.Aggregate, field.ClrType);
         }
 
         // Get values from the source field (cache lookup per item type)
@@ -233,7 +233,7 @@ public static class ComputedFieldService
             }
         }
 
-        return ApplyAggregateFunction(config.Aggregate, values, field.Property.PropertyType);
+        return ApplyAggregateFunction(config.Aggregate, values, field.ClrType);
     }
 
     private static object? ApplyAggregateFunction(AggregateFunction aggregate, List<object?> values, Type targetType)

--- a/BareMetalWeb.Data/DataQueryEvaluator.cs
+++ b/BareMetalWeb.Data/DataQueryEvaluator.cs
@@ -395,8 +395,8 @@ public sealed class DataQueryEvaluator : IDataQueryEvaluator
                 var fieldMeta = meta.FindField(field);
                 if (fieldMeta != null)
                 {
-                    value = fieldMeta.Property.GetValue(dataObject);
-                    memberType = fieldMeta.Property.PropertyType;
+                    value = fieldMeta.GetValueFn(dataObject);
+                    memberType = fieldMeta.ClrType;
                     return true;
                 }
             }

--- a/BareMetalWeb.Data/DataScaffold.cs
+++ b/BareMetalWeb.Data/DataScaffold.cs
@@ -45,9 +45,14 @@ public sealed record DataFieldMetadata(
     string? CascadeFromField = null,
     string? CascadeFilterField = null,
     string? FieldGroup = null,
-    int ColumnSpan = 12
+    int ColumnSpan = 12,
+    DataIndexAttribute? DataIndex = null,
+    bool HasSingletonFlag = false
 )
 {
+    /// <summary>CLR type of this field, captured once at registration to avoid PropertyInfo access.</summary>
+    public Type ClrType { get; } = Property.PropertyType;
+
     // Lazily compiled delegates avoid per-call PropertyInfo.GetValue / PropertyInfo.SetValue
     // reflection overhead in hot rendering paths.  The ??= assignment is not strictly thread-safe
     // but is idempotent — the worst case is two threads each compile an equivalent delegate; the
@@ -511,7 +516,7 @@ public static class DataScaffold
     private static QueryOperator GetDefaultOperatorForField(DataFieldMetadata field)
     {
         // For numeric and date fields, default to equals
-        var fieldType = field.Property.PropertyType;
+        var fieldType = field.ClrType;
         var underlyingType = Nullable.GetUnderlyingType(fieldType) ?? fieldType;
         
         if (underlyingType == typeof(int) || underlyingType == typeof(long) || 
@@ -577,7 +582,7 @@ public static class DataScaffold
 
                 // Get the computed value (for edit forms and view)
                 var computedValue = instance != null ? field.GetValueFn(instance) : null;
-                var computedStringValue = ToInputString(computedValue, field.Property.PropertyType, field.FieldType);
+                var computedStringValue = ToInputString(computedValue, field.ClrType, field.FieldType);
 
                 // Render as readonly with computed indicator
                 fields.Add(new FormField(
@@ -599,7 +604,7 @@ public static class DataScaffold
                 
                 // Get current value (for display, will be updated by JS)
                 var calculatedValue = instance != null ? field.GetValueFn(instance) : null;
-                var calculatedStringValue = ToInputString(calculatedValue, field.Property.PropertyType, field.FieldType);
+                var calculatedStringValue = ToInputString(calculatedValue, field.ClrType, field.FieldType);
 
                 // Generate JSON AST from the expression for CSP-safe client evaluation
                 string jsExpression;
@@ -647,7 +652,7 @@ public static class DataScaffold
                 continue;
             }
 
-            if (IsChildListType(field.Property.PropertyType, out var childType))
+            if (IsChildListType(field.ClrType, out var childType))
             {
                 var html = BuildChildListEditorHtml(field, childType, value as IEnumerable, cspNonce);
                 fields.Add(new FormField(
@@ -659,7 +664,7 @@ public static class DataScaffold
                 continue;
             }
 
-            if (IsDictionaryType(field.Property.PropertyType, out var valueType))
+            if (IsDictionaryType(field.ClrType, out var valueType))
             {
                 var html = BuildDictionaryEditorHtml(field, valueType, value as IEnumerable, cspNonce);
                 fields.Add(new FormField(
@@ -670,7 +675,7 @@ public static class DataScaffold
                     Html: html));
                 continue;
             }
-            var effectiveType = Nullable.GetUnderlyingType(field.Property.PropertyType) ?? field.Property.PropertyType;
+            var effectiveType = Nullable.GetUnderlyingType(field.ClrType) ?? field.ClrType;
             var effectiveFieldType = effectiveType == typeof(DateOnly) && field.FieldType == FormFieldType.DateTime
                 ? FormFieldType.DateOnly
                 : field.FieldType;
@@ -699,7 +704,7 @@ public static class DataScaffold
                 }
             }
 
-            var stringValue = ToInputString(value, field.Property.PropertyType, effectiveFieldType);
+            var stringValue = ToInputString(value, field.ClrType, effectiveFieldType);
             if (metadata.Type == typeof(SystemPrincipal)
                 && string.Equals(field.Name, nameof(SystemPrincipal.ApiKeyHashes), StringComparison.OrdinalIgnoreCase))
             {
@@ -712,9 +717,9 @@ public static class DataScaffold
                     stringValue = string.Empty;
                 }
             }
-            if (forCreate && IsDefaultValue(value, field.Property.PropertyType))
+            if (forCreate && IsDefaultValue(value, field.ClrType))
             {
-                var defaultValue = GetCreateDefaultInputString(field.Property.PropertyType, effectiveFieldType);
+                var defaultValue = GetCreateDefaultInputString(field.ClrType, effectiveFieldType);
                 if (defaultValue != null)
                     stringValue = defaultValue;
             }
@@ -725,7 +730,7 @@ public static class DataScaffold
                     : null;
 
             lookupOptions ??= effectiveFieldType == FormFieldType.Enum
-                ? BuildEnumOptions(field.Property.PropertyType)
+                ? BuildEnumOptions(field.ClrType)
                 : null;
 
             string? lookupTargetType = null;
@@ -818,7 +823,7 @@ public static class DataScaffold
                 continue;
             }
 
-            rows.Add((field.Label, ToDisplayString(value, field.Property.PropertyType)));
+            rows.Add((field.Label, ToDisplayString(value, field.ClrType)));
         }
 
         return rows;
@@ -843,14 +848,14 @@ public static class DataScaffold
                 continue;
             }
 
-            if (IsChildListType(field.Property.PropertyType, out var childType))
+            if (IsChildListType(field.ClrType, out var childType))
             {
                 var html = BuildChildListViewHtml(field, childType, value as IEnumerable);
                 rows.Add((field.Label, html, true));
                 continue;
             }
 
-            if (IsDictionaryType(field.Property.PropertyType, out var valueType))
+            if (IsDictionaryType(field.ClrType, out var valueType))
             {
                 var html = BuildDictionaryViewHtml(field, valueType, value as IEnumerable);
                 rows.Add((field.Label, html, true));
@@ -864,7 +869,7 @@ public static class DataScaffold
                 continue;
             }
             // Handle string representation of bool (from DataRecord / virtual entities)
-            if (value is string boolStr && field.Property.PropertyType == typeof(bool) && bool.TryParse(boolStr, out var parsedBool))
+            if (value is string boolStr && field.ClrType == typeof(bool) && bool.TryParse(boolStr, out var parsedBool))
             {
                 rows.Add((field.Label, BuildBooleanCheckboxHtml(parsedBool), true));
                 continue;
@@ -885,7 +890,7 @@ public static class DataScaffold
                 continue;
             }
 
-            rows.Add((field.Label, ToDisplayString(value, field.Property.PropertyType), false));
+            rows.Add((field.Label, ToDisplayString(value, field.ClrType), false));
         }
 
         return rows;
@@ -921,7 +926,7 @@ public static class DataScaffold
         var nested = new List<(DataFieldMetadata, Type)>();
         foreach (var field in metadata.ViewFields)
         {
-            if (IsChildListType(field.Property.PropertyType, out var childType))
+            if (IsChildListType(field.ClrType, out var childType))
             {
                 nested.Add((field, childType));
             }
@@ -939,7 +944,7 @@ public static class DataScaffold
     /// </summary>
     public static IReadOnlyList<Dictionary<string, object?>>? BuildSubFieldSchemas(DataFieldMetadata field)
     {
-        if (!IsChildListType(field.Property.PropertyType, out var childType))
+        if (!IsChildListType(field.ClrType, out var childType))
             return null;
 
         var result = new List<Dictionary<string, object?>>();
@@ -1053,7 +1058,7 @@ public static class DataScaffold
         
         foreach (var field in metadata.ViewFields)
         {
-            if (!IsChildListType(field.Property.PropertyType, out var childType))
+            if (!IsChildListType(field.ClrType, out var childType))
                 continue;
                 
             var value = field.GetValueFn(instance);
@@ -1160,13 +1165,13 @@ public static class DataScaffold
                     continue;
                 }
                 // Handle string representation of bool (from DataRecord / virtual entities)
-                if (rawValue is string boolStr && field.Property.PropertyType == typeof(bool) && bool.TryParse(boolStr, out var parsedBool))
+                if (rawValue is string boolStr && field.ClrType == typeof(bool) && bool.TryParse(boolStr, out var parsedBool))
                 {
                     values.Add(BuildBooleanCheckboxHtml(parsedBool));
                     continue;
                 }
 
-                values.Add(WebUtility.HtmlEncode(ToDisplayString(rawValue, field.Property.PropertyType)));
+                values.Add(WebUtility.HtmlEncode(ToDisplayString(rawValue, field.ClrType)));
             }
 
             if (includeActions && item is BaseDataObject dataObject)
@@ -1635,7 +1640,7 @@ public static class DataScaffold
         {
             var dayKey = dayGroupEntry.Key;
             var dayGroup = dayGroupEntry.Value;
-            var dayName = Enum.GetName(dayField.Property.PropertyType, dayKey) ?? dayKey.ToString();
+            var dayName = Enum.GetName(dayField.ClrType, dayKey) ?? dayKey.ToString();
             html.Append($"<div class=\"bm-timetable-day-section mb-4\">");
             html.Append($"<h3 class=\"bm-timetable-day-header\">{WebUtility.HtmlEncode(dayName)}</h3>");
 
@@ -1726,7 +1731,7 @@ public static class DataScaffold
                     }
                     else
                     {
-                        displayValue = WebUtility.HtmlEncode(ToDisplayString(rawValue, field.Property.PropertyType));
+                        displayValue = WebUtility.HtmlEncode(ToDisplayString(rawValue, field.ClrType));
                     }
 
                     html.Append($"<td>{displayValue}</td>");
@@ -1852,7 +1857,7 @@ public static class DataScaffold
             if (field.IdGeneration != IdGenerationStrategy.None)
                 continue;
 
-            if (IsChildListType(field.Property.PropertyType, out var childType))
+            if (IsChildListType(field.ClrType, out var childType))
             {
                 if (!TryGetFormValue(values, field.Name, out var rawList) || rawList == null)
                 {
@@ -1871,7 +1876,7 @@ public static class DataScaffold
                 continue;
             }
 
-            if (IsDictionaryType(field.Property.PropertyType, out var dictValueType))
+            if (IsDictionaryType(field.ClrType, out var dictValueType))
             {
                 if (!TryGetFormValue(values, field.Name, out var rawDict) || rawDict == null)
                 {
@@ -1902,7 +1907,7 @@ public static class DataScaffold
                     if (field.FieldType == FormFieldType.File || field.FieldType == FormFieldType.Image)
                         continue;
 
-                    if (IsBooleanField(field, field.Property.PropertyType))
+                    if (IsBooleanField(field, field.ClrType))
                     {
                         field.SetValueFn(instance, false);
                         if (field.Required)
@@ -1922,9 +1927,9 @@ public static class DataScaffold
                 continue;
             }
 
-            if (!TryConvertValue(rawValue, field.Property.PropertyType, out var converted))
+            if (!TryConvertValue(rawValue, field.ClrType, out var converted))
             {
-                if (!TryFallbackConvert(rawValue, field.Property.PropertyType, out converted))
+                if (!TryFallbackConvert(rawValue, field.ClrType, out converted))
                 {
                     errors.Add($"{field.Label} is invalid.");
                     continue;
@@ -1966,13 +1971,13 @@ public static class DataScaffold
                 continue;
             }
 
-            if (!TryConvertJson(rawElement, field.Property.PropertyType, out var converted))
+            if (!TryConvertJson(rawElement, field.ClrType, out var converted))
             {
                 // For Money fields, if the JSON is an object with an "amount" property, extract it as a decimal
                 if (field.FieldType == FormFieldType.Money
                     && rawElement.ValueKind == JsonValueKind.Object
                     && rawElement.TryGetProperty("amount", out var amountElement)
-                    && TryConvertJson(amountElement, field.Property.PropertyType, out converted))
+                    && TryConvertJson(amountElement, field.ClrType, out converted))
                 {
                     // Successfully extracted amount from Money JSON object; fall through to SetValue
                 }
@@ -3742,6 +3747,7 @@ public static class DataScaffold
             var calculatedAttribute = prop.GetCustomAttribute<CalculatedFieldAttribute>();
             var dataIndexAttribute = prop.GetCustomAttribute<DataIndexAttribute>();
             var relatedDocAttribute = prop.GetCustomAttribute<RelatedDocumentAttribute>();
+            var hasSingletonFlag = prop.PropertyType == typeof(bool) && prop.GetCustomAttribute<SingletonFlagAttribute>() != null;
             if (fieldAttribute == null && imageFieldAttribute == null && fileFieldAttribute == null)
                 continue;
 
@@ -3841,7 +3847,9 @@ public static class DataScaffold
                 calculatedAttribute,
                 ValidationService.BuildValidationConfig(prop),
                 dataIndexAttribute != null,
-                relatedDoc
+                relatedDoc,
+                DataIndex: dataIndexAttribute,
+                HasSingletonFlag: hasSingletonFlag
             ));
         }
 

--- a/BareMetalWeb.Data/ExpressionEngine/ServerLookupResolver.cs
+++ b/BareMetalWeb.Data/ExpressionEngine/ServerLookupResolver.cs
@@ -150,19 +150,14 @@ public sealed class ServerLookupResolver : ILookupResolver
                 return null;
 
             DataEntityMetadata? nextMeta = null;
-            PropertyInfo? lookupProp = null;
-            foreach (var p in currentEntity.GetType()
-                .GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            // Use DataScaffold metadata (compiled delegates) instead of raw reflection
+            var stepMeta = DataScaffold.GetEntityByType(currentEntity.GetType());
+            if (stepMeta != null)
             {
-                if (string.Equals(p.Name, nextFkField, StringComparison.OrdinalIgnoreCase))
-                {
-                    lookupProp = p;
-                    break;
-                }
+                var fieldMeta = stepMeta.FindField(nextFkField);
+                if (fieldMeta?.Lookup != null)
+                    nextMeta = DataScaffold.GetEntityByType(fieldMeta.Lookup.TargetType);
             }
-            var lookupAttr = lookupProp?.GetCustomAttribute<DataLookupAttribute>();
-            if (lookupAttr != null)
-                nextMeta = DataScaffold.GetEntityByType(lookupAttr.TargetType);
 
             if (nextMeta == null)
                 return null;
@@ -180,11 +175,29 @@ public sealed class ServerLookupResolver : ILookupResolver
         if (entity is DataRecord rec && rec.Schema != null)
             return rec.GetField(rec.Schema, fieldName);
 
-        // Reflection for compiled entities
-        var prop = entity.GetType().GetProperty(fieldName,
-            BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
-        return prop?.GetValue(entity);
+        // Use metadata-first lookup (compiled delegates)
+        if (entity is BaseDataObject bdo)
+        {
+            var meta = DataScaffold.GetEntityByType(bdo.GetType());
+            if (meta != null)
+            {
+                var fieldMeta = meta.FindField(fieldName);
+                if (fieldMeta != null)
+                    return fieldMeta.GetValueFn(entity);
+            }
+        }
+
+        // Cached compiled delegate fallback
+        var getter = _extractCache.GetOrAdd((entity.GetType(), fieldName), static key =>
+        {
+            var p = key.Item1.GetProperty(key.Item2,
+                BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+            return p != null ? PropertyAccessorFactory.BuildGetter(p) : null;
+        });
+        return getter?.Invoke(entity);
     }
+
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<(Type, string), Func<object, object?>?> _extractCache = new();
 
     private static bool ValuesEqual(object? a, object? b)
     {

--- a/BareMetalWeb.Data/LocalFolderBinaryDataProvider.cs
+++ b/BareMetalWeb.Data/LocalFolderBinaryDataProvider.cs
@@ -438,7 +438,7 @@ public sealed class LocalFolderBinaryDataProvider : IDataProvider
             // Load existing object only on updates (existing location found) to track previous indexed field values.
             // New inserts skip this load since there are no prior index entries to clean up.
             T? oldObj = null;
-            List<PropertyInfo> indexedFields = new();
+            List<SearchIndexManager.IndexedFieldAccessor> indexedFields = new();
             if (_searchIndexManager.HasIndexedFields(type, out indexedFields) && TryGetClusteredLocation(type.Name, keyStr, out _))
                 oldObj = Load<T>(obj.Key);
 
@@ -472,10 +472,10 @@ public sealed class LocalFolderBinaryDataProvider : IDataProvider
             {
                 foreach (var prop in indexedFields)
                 {
-                    var newValue = prop.GetValue(obj)?.ToString() ?? string.Empty;
+                    var newValue = prop.Getter(obj)?.ToString() ?? string.Empty;
                     if (oldObj != null)
                     {
-                        var oldValue = prop.GetValue(oldObj)?.ToString() ?? string.Empty;
+                        var oldValue = prop.Getter(oldObj)?.ToString() ?? string.Empty;
                         if (string.Equals(oldValue, newValue, StringComparison.OrdinalIgnoreCase))
                             continue; // value unchanged — existing index entry is still valid
                         _indexStore.AppendEntry(type.Name, prop.Name, oldValue, keyStr, 'D');
@@ -507,6 +507,38 @@ public sealed class LocalFolderBinaryDataProvider : IDataProvider
     private void ClearSingletonFlagsOnOtherRecords<T>(T obj) where T : BaseDataObject
     {
         var type = typeof(T);
+        // Use DataScaffold metadata (compiled delegates) instead of raw reflection
+        var meta = BareMetalWeb.Core.DataScaffold.GetEntityByType(type);
+        if (meta != null)
+        {
+            var singletonFields = new List<BareMetalWeb.Core.DataFieldMetadata>();
+            foreach (var f in meta.Fields)
+            {
+                if (f.HasSingletonFlag && f.ClrType == typeof(bool) && true.Equals(f.GetValueFn(obj)))
+                    singletonFields.Add(f);
+            }
+
+            if (singletonFields.Count == 0) return;
+
+            var allRecords = Query<T>();
+            foreach (var record in allRecords)
+            {
+                if (record.Key == obj.Key) continue;
+                bool changed = false;
+                foreach (var f in singletonFields)
+                {
+                    if (true.Equals(f.GetValueFn(record)))
+                    {
+                        f.SetValueFn(record, false);
+                        changed = true;
+                    }
+                }
+                if (changed) Save(record);
+            }
+            return;
+        }
+
+        // Fallback for unregistered types
         var allProps = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
         var singletonProps = new List<PropertyInfo>();
         foreach (var p in allProps)
@@ -524,8 +556,8 @@ public sealed class LocalFolderBinaryDataProvider : IDataProvider
             return;
 
         // Only load all records if there is at least one active singleton flag.
-        var allRecords = Query<T>();
-        foreach (var record in allRecords)
+        var fallbackRecords = Query<T>();
+        foreach (var record in fallbackRecords)
         {
             if (record.Key == obj.Key)
                 continue;
@@ -628,9 +660,10 @@ public sealed class LocalFolderBinaryDataProvider : IDataProvider
             {
                 if (clause.Operator == QueryOperator.Equals && clause.Value != null)
                 {
-                    var prop = indexedFields.Find(p => string.Equals(p.Name, clause.Field, StringComparison.OrdinalIgnoreCase));
-                    if (prop != null)
+                    var propIdx = indexedFields.FindIndex(p => string.Equals(p.Name, clause.Field, StringComparison.OrdinalIgnoreCase));
+                    if (propIdx >= 0)
                     {
+                        var prop = indexedFields[propIdx];
                         var fieldValue = clause.Value.ToString() ?? string.Empty;
                         var fieldIndex = _indexStore.ReadIndex(type.Name, prop.Name);
                         if (fieldIndex.Count == 0)
@@ -848,7 +881,7 @@ public sealed class LocalFolderBinaryDataProvider : IDataProvider
         {
             // Load old object for field index cleanup before deleting
             T? oldObj = null;
-            List<PropertyInfo> indexedFields = new();
+            List<SearchIndexManager.IndexedFieldAccessor> indexedFields = new();
             if (_searchIndexManager.HasIndexedFields(type, out indexedFields))
                 oldObj = Load<T>(key);
 
@@ -863,7 +896,7 @@ public sealed class LocalFolderBinaryDataProvider : IDataProvider
             {
                 foreach (var prop in indexedFields)
                 {
-                    var value = prop.GetValue(oldObj)?.ToString() ?? string.Empty;
+                    var value = prop.Getter(oldObj)?.ToString() ?? string.Empty;
                     _indexStore.AppendEntry(type.Name, prop.Name, value, keyStr, 'D');
                 }
                 _searchIndexManager.RemoveObject(type, key);

--- a/BareMetalWeb.Data/ReportExecutor.cs
+++ b/BareMetalWeb.Data/ReportExecutor.cs
@@ -314,31 +314,21 @@ public sealed class ReportExecutor
 
     // ── Field access helpers ─────────────────────────────────────────────────
 
-    private static PropertyInfo? FindAccessor(DataEntityMetadata meta, string fieldName)
+    private static Func<object, object?>? FindAccessor(DataEntityMetadata meta, string fieldName)
     {
-        // Check DataField metadata first
-        DataFieldMetadata? field = null;
+        // Check DataField metadata first (compiled delegates, no reflection)
         foreach (var f in meta.Fields)
         {
             if (string.Equals(f.Name, fieldName, StringComparison.OrdinalIgnoreCase))
-            {
-                field = f;
-                break;
-            }
+                return f.GetValueFn;
         }
-        if (field != null)
-            return field.Property;
 
-        // Fall back to BaseDataObject base properties (Id, CreatedOnUtc, etc.)
-        return typeof(BaseDataObject).GetProperty(fieldName,
-            BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+        // Fall back to base properties via cached compiled delegate
+        return FindAccessorOnObject(meta.Type, fieldName);
     }
 
-    private static string GetStringValue(PropertyInfo prop, object obj)
-        => prop.GetValue(obj)?.ToString() ?? string.Empty;
-
-    private static string? GetNullableStringValue(PropertyInfo? prop, BaseDataObject obj)
-        => prop?.GetValue(obj)?.ToString();
+    private static string GetStringValue(Func<object, object?> getter, object obj)
+        => getter(obj)?.ToString() ?? string.Empty;
 
     // ── Row projection ───────────────────────────────────────────────────────
 

--- a/BareMetalWeb.Data/SearchIndexing.cs
+++ b/BareMetalWeb.Data/SearchIndexing.cs
@@ -101,11 +101,12 @@ public sealed class DataIndexAttribute : Attribute
 
 public sealed class SearchIndexManager
 {
-    // Cache reflection metadata per type to avoid repeated GetProperties calls
+    /// <summary>Pre-compiled accessor for an indexed field — avoids PropertyInfo reflection on hot paths.</summary>
+    public readonly record struct IndexedFieldAccessor(string Name, Type ClrType, Func<object, object?> Getter, DataIndexAttribute Attribute);
+
     private sealed class TypeMetadata
     {
-        public PropertyInfo[] IndexedProperties { get; init; } = Array.Empty<PropertyInfo>();
-        public DataIndexAttribute[] Attributes { get; init; } = Array.Empty<DataIndexAttribute>();
+        public IndexedFieldAccessor[] IndexedFields { get; init; } = Array.Empty<IndexedFieldAccessor>();
         public HashSet<IndexKind> IndexKinds { get; init; } = new();
     }
 
@@ -360,10 +361,10 @@ public sealed class SearchIndexManager
         _logger = logger;
     }
 
-    public bool HasIndexedFields(Type type, out List<PropertyInfo> fields)
+    public bool HasIndexedFields(Type type, out List<IndexedFieldAccessor> fields)
     {
         var metadata = GetOrCreateTypeMetadata(type);
-        fields = new List<PropertyInfo>(metadata.IndexedProperties);
+        fields = new List<IndexedFieldAccessor>(metadata.IndexedFields);
         return fields.Count > 0;
     }
 
@@ -371,27 +372,47 @@ public sealed class SearchIndexManager
     {
         return _typeMetadata.GetOrAdd(type, t =>
         {
+            // Prefer DataScaffold metadata (already has compiled delegates) over raw reflection
+            var entityMeta = BareMetalWeb.Core.DataScaffold.GetEntityByType(t);
+            if (entityMeta != null)
+            {
+                var indexed = new List<IndexedFieldAccessor>();
+                var kinds = new HashSet<IndexKind>(4);
+                foreach (var f in entityMeta.Fields)
+                {
+                    if (f.DataIndex != null)
+                    {
+                        indexed.Add(new IndexedFieldAccessor(f.Name, f.ClrType, f.GetValueFn, f.DataIndex));
+                        kinds.Add(f.DataIndex.Kind);
+                    }
+                }
+                return new TypeMetadata
+                {
+                    IndexedFields = indexed.ToArray(),
+                    IndexKinds = kinds
+                };
+            }
+
+            // Fallback: scan properties directly (startup only, cached)
             var props = t.GetProperties(BindingFlags.Public | BindingFlags.Instance);
-            var indexedProps = new List<PropertyInfo>(props.Length);
-            var attrs = new List<DataIndexAttribute>(props.Length);
-            var kinds = new HashSet<IndexKind>(4);
+            var indexedProps = new List<IndexedFieldAccessor>(props.Length);
+            var fallbackKinds = new HashSet<IndexKind>(4);
 
             foreach (var prop in props)
             {
                 var attr = prop.GetCustomAttribute<DataIndexAttribute>();
                 if (attr != null)
                 {
-                    indexedProps.Add(prop);
-                    attrs.Add(attr);
-                    kinds.Add(attr.Kind);
+                    var getter = PropertyAccessorFactory.BuildGetter(prop);
+                    indexedProps.Add(new IndexedFieldAccessor(prop.Name, prop.PropertyType, getter, attr));
+                    fallbackKinds.Add(attr.Kind);
                 }
             }
 
             return new TypeMetadata
             {
-                IndexedProperties = indexedProps.ToArray(),
-                Attributes = attrs.ToArray(),
-                IndexKinds = kinds
+                IndexedFields = indexedProps.ToArray(),
+                IndexKinds = fallbackKinds
             };
         });
     }
@@ -908,16 +929,15 @@ public sealed class SearchIndexManager
         var type = obj.GetType();
         var metadata = GetOrCreateTypeMetadata(type);
 
-        for (int i = 0; i < metadata.IndexedProperties.Length; i++)
+        for (int i = 0; i < metadata.IndexedFields.Length; i++)
         {
-            var prop = metadata.IndexedProperties[i];
-            var attr = metadata.Attributes[i];
+            var accessor = metadata.IndexedFields[i];
 
-            var value = prop.GetValue(obj);
+            var value = accessor.Getter(obj);
             if (value == null)
                 continue;
 
-            var valueType = Nullable.GetUnderlyingType(prop.PropertyType) ?? prop.PropertyType;
+            var valueType = Nullable.GetUnderlyingType(accessor.ClrType) ?? accessor.ClrType;
             if (valueType == typeof(string))
             {
                 AddTokensFromString(tokens, value.ToString());

--- a/BareMetalWeb.Data/ValidationService.cs
+++ b/BareMetalWeb.Data/ValidationService.cs
@@ -154,7 +154,7 @@ public static class ValidationService
         {
             try
             {
-                context[field.Name] = field.Property.GetValue(instance);
+                context[field.Name] = field.GetValueFn(instance);
             }
             catch
             {

--- a/BareMetalWeb.Data/WalDataProvider.cs
+++ b/BareMetalWeb.Data/WalDataProvider.cs
@@ -252,7 +252,7 @@ public sealed class WalDataProvider : IDataProvider, IRawBinaryProvider, IDispos
             var idMap    = GetOrLoadIdMap(type.Name);
             bool isInsert = !idMap.ContainsKey(obj.Key);
             T? oldObj    = null;
-            List<PropertyInfo> indexedFields = new();
+            List<SearchIndexManager.IndexedFieldAccessor> indexedFields = new();
             if (_searchIndexManager.HasIndexedFields(type, out indexedFields) && !isInsert)
                 oldObj = Load<T>(obj.Key);
 
@@ -288,10 +288,10 @@ public sealed class WalDataProvider : IDataProvider, IRawBinaryProvider, IDispos
                 var keyStr = obj.Key.ToString();
                 foreach (var prop in indexedFields)
                 {
-                    var newValue = prop.GetValue(obj)?.ToString() ?? string.Empty;
+                    var newValue = prop.Getter(obj)?.ToString() ?? string.Empty;
                     if (oldObj != null)
                     {
-                        var oldValue = prop.GetValue(oldObj)?.ToString() ?? string.Empty;
+                        var oldValue = prop.Getter(oldObj)?.ToString() ?? string.Empty;
                         if (string.Equals(oldValue, newValue, StringComparison.OrdinalIgnoreCase))
                             continue; // value unchanged — existing index entry is still valid
                         _indexStore.AppendEntry(type.Name, prop.Name, oldValue, keyStr, 'D');
@@ -487,8 +487,9 @@ public sealed class WalDataProvider : IDataProvider, IRawBinaryProvider, IDispos
             foreach (var clause in query.Clauses)
             {
                 if (clause.Value == null) continue;
-                var prop = indexedFields.Find(p => string.Equals(p.Name, clause.Field, StringComparison.OrdinalIgnoreCase));
-                if (prop == null) continue;
+                var propIdx = indexedFields.FindIndex(p => string.Equals(p.Name, clause.Field, StringComparison.OrdinalIgnoreCase));
+                if (propIdx < 0) continue;
+                var prop = indexedFields[propIdx];
 
                 HashSet<uint>? clauseCandidates = null;
 
@@ -648,9 +649,10 @@ public sealed class WalDataProvider : IDataProvider, IRawBinaryProvider, IDispos
             // Sort by an indexed field — use forward index to sort keys by value
             if (_searchIndexManager.HasIndexedFields(typeof(T), out var sortIndexedFields))
             {
-                var sortProp = sortIndexedFields.Find(p => string.Equals(p.Name, sort.Field, StringComparison.OrdinalIgnoreCase));
-                if (sortProp != null)
+                var sortPropIdx = sortIndexedFields.FindIndex(p => string.Equals(p.Name, sort.Field, StringComparison.OrdinalIgnoreCase));
+                if (sortPropIdx >= 0)
                 {
+                    var sortProp = sortIndexedFields[sortPropIdx];
                     var forwardIndex = _indexStore.ReadLatestValueIndex(typeName, sortProp.Name);
                     if (forwardIndex.Count > 0)
                     {
@@ -920,8 +922,9 @@ public sealed class WalDataProvider : IDataProvider, IRawBinaryProvider, IDispos
             foreach (var clause in query.Clauses)
             {
                 if (clause.Value == null) continue;
-                var prop = indexedFields.Find(p => string.Equals(p.Name, clause.Field, StringComparison.OrdinalIgnoreCase));
-                if (prop == null) continue;
+                var propIdx = indexedFields.FindIndex(p => string.Equals(p.Name, clause.Field, StringComparison.OrdinalIgnoreCase));
+                if (propIdx < 0) continue;
+                var prop = indexedFields[propIdx];
 
                 HashSet<uint>? clauseCandidates = null;
 
@@ -1016,7 +1019,7 @@ public sealed class WalDataProvider : IDataProvider, IRawBinaryProvider, IDispos
 
         // Load the old object before deleting so we can remove its index entries
         T? oldObj = null;
-        List<PropertyInfo> indexedFields = new();
+        List<SearchIndexManager.IndexedFieldAccessor> indexedFields = new();
         if (_searchIndexManager.HasIndexedFields(type, out indexedFields))
             oldObj = Load<T>(key);
 
@@ -1044,7 +1047,7 @@ public sealed class WalDataProvider : IDataProvider, IRawBinaryProvider, IDispos
             var keyStr = key.ToString();
             foreach (var prop in indexedFields)
             {
-                var value = prop.GetValue(oldObj)?.ToString() ?? string.Empty;
+                var value = prop.Getter(oldObj)?.ToString() ?? string.Empty;
                 _indexStore.AppendEntry(typeName, prop.Name, value, keyStr, 'D');
             }
             _searchIndexManager.RemoveObject(type, key);
@@ -1940,6 +1943,37 @@ public sealed class WalDataProvider : IDataProvider, IRawBinaryProvider, IDispos
     private void ClearSingletonFlagsOnOtherRecords<T>(T obj) where T : BaseDataObject
     {
         var type           = typeof(T);
+        // Use DataScaffold metadata (compiled delegates) instead of raw reflection
+        var meta = DataScaffold.GetEntityByType(type);
+        var singletonFields = new List<DataFieldMetadata>();
+        if (meta != null)
+        {
+            foreach (var f in meta.Fields)
+            {
+                if (f.HasSingletonFlag && f.ClrType == typeof(bool) && true.Equals(f.GetValueFn(obj)))
+                    singletonFields.Add(f);
+            }
+
+            if (singletonFields.Count == 0) return;
+
+            foreach (var record in Query<T>())
+            {
+                if (record.Key == obj.Key) continue;
+                bool changed = false;
+                foreach (var f in singletonFields)
+                {
+                    if (true.Equals(f.GetValueFn(record)))
+                    {
+                        f.SetValueFn(record, false);
+                        changed = true;
+                    }
+                }
+                if (changed) Save(record);
+            }
+            return;
+        }
+
+        // Fallback for unregistered types
         var allProps = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
         var singletonProps = new List<PropertyInfo>();
         foreach (var p in allProps)

--- a/BareMetalWeb.DataBrowser/Program.cs
+++ b/BareMetalWeb.DataBrowser/Program.cs
@@ -695,7 +695,7 @@ internal static class Program
 
             try
             {
-                var converted = ConvertValue(value, field.Property.PropertyType);
+                var converted = ConvertValue(value, field.ClrType);
                 field.SetValueFn(obj, converted);
                 Console.WriteLine($"  Set {field.Name} = {FormatValue(converted)}");
             }

--- a/BareMetalWeb.Host/LookupApiHandlers.cs
+++ b/BareMetalWeb.Host/LookupApiHandlers.cs
@@ -238,7 +238,7 @@ public static class LookupApiHandlers
                 return;
             }
 
-            var value = field.Property.GetValue(entity);
+            var value = field.GetValueFn(entity);
             await WriteJsonAsync(context, new Dictionary<string, object?>
             {
                 ["field"] = field.Name,
@@ -538,7 +538,7 @@ public static class LookupApiHandlers
 
         foreach (var field in meta.ViewFields)
         {
-            var value = field.Property.GetValue(entity);
+            var value = field.GetValueFn(entity);
             result[field.Name] = value;
         }
 

--- a/BareMetalWeb.Host/McpRouteHandler.cs
+++ b/BareMetalWeb.Host/McpRouteHandler.cs
@@ -575,9 +575,9 @@ internal static class McpRouteHandler
                 ["description"] = f.Label
             };
 
-            if (f.FieldType == FormFieldType.Enum && f.Property.PropertyType.IsEnum)
+            if (f.FieldType == FormFieldType.Enum && f.ClrType.IsEnum)
             {
-                schema["enum"] = Enum.GetNames(f.Property.PropertyType);
+                schema["enum"] = Enum.GetNames(f.ClrType);
             }
 
             props[f.Name] = schema;

--- a/BareMetalWeb.Host/OpenApiHandler.cs
+++ b/BareMetalWeb.Host/OpenApiHandler.cs
@@ -352,7 +352,7 @@ internal static class OpenApiHandler
 
     private static Dictionary<string, object?> BuildEnumSchema(DataFieldMetadata field)
     {
-        var enumValues = DataScaffold.BuildEnumOptions(field.Property.PropertyType);
+        var enumValues = DataScaffold.BuildEnumOptions(field.ClrType);
         if (enumValues.Count == 0)
             return SimpleSchema("string", null);
 

--- a/BareMetalWeb.Host/Program.cs
+++ b/BareMetalWeb.Host/Program.cs
@@ -238,7 +238,7 @@ var server = await BareMetalWebExtensions.InitializeAsync(config, contentRoot, c
                 object? enumValues = null;
                 if (f.FieldType == FormFieldType.Enum)
                 {
-                    var enumOpts = DataScaffold.BuildEnumOptions(f.Property.PropertyType);
+                    var enumOpts = DataScaffold.BuildEnumOptions(f.ClrType);
                     var enumOptionsList = new object[enumOpts.Count];
                     for (int ei = 0; ei < enumOpts.Count; ei++)
                         enumOptionsList[ei] = new { value = enumOpts[ei].Key, label = enumOpts[ei].Value };

--- a/BareMetalWeb.Host/RouteHandlers.cs
+++ b/BareMetalWeb.Host/RouteHandlers.cs
@@ -5801,13 +5801,13 @@ public sealed class RouteHandlers : IRouteHandlers
         if (field == null)
             return;
 
-        if (DataScaffold.TryConvertValue(value, field.Property.PropertyType, out var converted) && converted != null)
+        if (DataScaffold.TryConvertValue(value, field.ClrType, out var converted) && converted != null)
         {
             field.SetValueFn(instance, converted);
             return;
         }
 
-        var effectiveType = Nullable.GetUnderlyingType(field.Property.PropertyType) ?? field.Property.PropertyType;
+        var effectiveType = Nullable.GetUnderlyingType(field.ClrType) ?? field.ClrType;
         if (effectiveType == typeof(string))
         {
             field.SetValueFn(instance, value);
@@ -6276,7 +6276,7 @@ public sealed class RouteHandlers : IRouteHandlers
         var ganttItems = new List<(BaseDataObject Item, DateOnly Start, DateOnly End, string Label)>();
         foreach (var item in itemsList)
         {
-            var startValue = startField.Property.GetValue(item);
+            var startValue = startField.GetValueFn(item);
             DateOnly? startDate = startValue switch
             {
                 DateOnly d => d,
@@ -6289,7 +6289,7 @@ public sealed class RouteHandlers : IRouteHandlers
             DateOnly endDate;
             if (endField != null)
             {
-                var endValue = endField.Property.GetValue(item);
+                var endValue = endField.GetValueFn(item);
                 endDate = endValue switch
                 {
                     DateOnly d => d,
@@ -6435,7 +6435,7 @@ public sealed class RouteHandlers : IRouteHandlers
         }
         if (nameField != null)
         {
-            var value = nameField.Property.GetValue(item)?.ToString();
+            var value = nameField.GetValueFn(item)?.ToString();
             if (!string.IsNullOrWhiteSpace(value))
                 return value;
         }
@@ -6452,7 +6452,7 @@ public sealed class RouteHandlers : IRouteHandlers
         }
         if (displayField != null)
         {
-            var value = displayField.Property.GetValue(item)?.ToString();
+            var value = displayField.GetValueFn(item)?.ToString();
             if (!string.IsNullOrWhiteSpace(value))
                 return value;
         }

--- a/BareMetalWeb.Host/RouteRegistrationExtensions.cs
+++ b/BareMetalWeb.Host/RouteRegistrationExtensions.cs
@@ -1029,7 +1029,7 @@ public static class RouteRegistrationExtensions
                 var filteredTypes = new List<DataEntityMetadata>();
                 foreach (var m in DataScaffold.Entities)
                 {
-                    if (m.Type != typeof(DataRecord) && m.Type.GetCustomAttribute<DataEntityAttribute>() != null)
+                    if (m.Type != typeof(DataRecord))
                         filteredTypes.Add(m);
                 }
                 filteredTypes.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.Ordinal));
@@ -1307,7 +1307,7 @@ public static class RouteRegistrationExtensions
             fd["subFields"] = DataScaffold.BuildSubFieldSchemas(f);
             if (f.FieldType == FormFieldType.Enum)
             {
-                var enumOptions = DataScaffold.BuildEnumOptions(f.Property.PropertyType);
+                var enumOptions = DataScaffold.BuildEnumOptions(f.ClrType);
                 var enumArr = new object[enumOptions.Count];
                 for (int ei = 0; ei < enumOptions.Count; ei++)
                     enumArr[ei] = new { value = enumOptions[ei].Key, label = enumOptions[ei].Value };

--- a/BareMetalWeb.Runtime/MetadataSeeder.cs
+++ b/BareMetalWeb.Runtime/MetadataSeeder.cs
@@ -1,4 +1,4 @@
-using System.Reflection;
+using BareMetalWeb.Core;
 using BareMetalWeb.Core;
 using BareMetalWeb.Data;
 using BareMetalWeb.Data.Interfaces;
@@ -63,8 +63,9 @@ public static class MetadataSeeder
             if (meta.Type == typeof(DataRecord)) continue;
 
             // Only seed types that are explicitly annotated with [DataEntity].
-            var entityAttr = meta.Type.GetCustomAttribute<DataEntityAttribute>();
-            if (entityAttr == null) continue;
+            // All entities in DataScaffold are registered because they have this attribute,
+            // but DataRecord instances are runtime-defined and also present.
+            if (meta.Type == typeof(DataRecord)) continue;
 
             var slug = meta.Slug;
 

--- a/BareMetalWeb.Runtime/QueryService.cs
+++ b/BareMetalWeb.Runtime/QueryService.cs
@@ -75,7 +75,7 @@ public sealed class QueryService : IQueryService
         {
             try
             {
-                dict[field.Name] = field.Property.GetValue(obj);
+                dict[field.Name] = field.GetValueFn(obj);
             }
             catch
             {


### PR DESCRIPTION
Eliminates all per-call \System.Reflection\ usage from production hot paths and reduces startup reflection by preferring pre-compiled delegates from \DataFieldMetadata\.

## Changes

### DataFieldMetadata additions
- \Type ClrType\ — captures \Property.PropertyType\ at registration time
- \DataIndexAttribute? DataIndex\ — caches index attribute from \BuildEntityMetadata()\
- \ool HasSingletonFlag\ — caches singleton flag attribute

### Hot-path reflection removed (22 files, ~60 call sites)
| Was | Now |
|---|---|
| \ield.Property.GetValue(obj)\ | \ield.GetValueFn(obj)\ |
| \ield.Property.SetValue(obj, v)\ | \ield.SetValueFn(obj, v)\ |
| \ield.Property.PropertyType\ | \ield.ClrType\ |

Applied across: QueryService, DataQueryEvaluator, LookupApiHandlers, RouteHandlers, ValidationService, AuditService, DataScaffold, ColumnarStore, ColumnQueryExecutor, ComputedFieldService, OpenApiHandler, McpRouteHandler, Program, RouteRegistrationExtensions, ReportExecutor.

### Structural refactors
- **SearchIndexing.TypeMetadata**: \PropertyInfo[]\ → compiled \IndexedFieldAccessor\ tuples; prefers DataScaffold metadata over raw reflection
- **AuditService.DetectChanges**: DataScaffold metadata + compiled delegates instead of per-save \GetProperties()/GetValue()\
- **WalDataProvider/LocalFolderBinaryDataProvider**: Singleton flag enforcement uses metadata-first path
- **ReportExecutor.FindAccessor**: returns compiled \Func<object,object?>\ instead of \PropertyInfo\
- **ServerLookupResolver**: metadata-first FK traversal + cached compiled delegates
- **ActionExpander.GetEntityKey**: removed reflection fallback
- **RouteRegistrationExtensions/MetadataSeeder**: removed redundant \GetCustomAttribute\ checks

### What remains
Startup-only reflection in \BuildEntityMetadata()\, \EntityLayoutCompiler\, \BinaryObjectSerializer\ TypeShape cache — runs once per type, results are cached. Zero reflection on any request hot path.

Fixes #1058