### PR TITLE
fix: plug memory leaks in 3 static caches

### DIFF
--- a/BareMetalWeb.Data/ComputedFieldService.cs
+++ b/BareMetalWeb.Data/ComputedFieldService.cs
@@ -17,6 +17,8 @@ public static class ComputedFieldService
 {
     private static readonly ConcurrentDictionary<string, ComputedValueCacheEntry> _cache = new();
     private static readonly ConcurrentDictionary<(Type, string), Func<object, object?>?> _getterCache = new();
+    private static DateTime _lastCacheScavenge = DateTime.UtcNow;
+    private const int MaxCacheEntries = 10_000;
 
     private sealed record ComputedValueCacheEntry(object? Value, DateTime ExpiresUtc);
 
@@ -78,6 +80,7 @@ public static class ComputedFieldService
 
         if (config.Strategy == ComputedStrategy.CachedLive)
         {
+            ScavengeExpiredEntries();
             var cacheKey = $"{metadata.Type.FullName}.{instance.Key}.{field.Name}";
             if (_cache.TryGetValue(cacheKey, out var cached) && cached.ExpiresUtc > DateTime.UtcNow)
             {
@@ -113,6 +116,24 @@ public static class ComputedFieldService
     public static void ClearAllCache()
     {
         _cache.Clear();
+    }
+
+    /// <summary>Evict expired entries and enforce max size. Runs at most once per 30 seconds.</summary>
+    private static void ScavengeExpiredEntries()
+    {
+        var now = DateTime.UtcNow;
+        if ((now - _lastCacheScavenge).TotalSeconds < 30) return;
+        _lastCacheScavenge = now;
+
+        foreach (var kvp in _cache)
+        {
+            if (kvp.Value.ExpiresUtc < now)
+                _cache.TryRemove(kvp.Key, out _);
+        }
+
+        // Hard cap: if still over limit, remove oldest entries
+        if (_cache.Count > MaxCacheEntries)
+            _cache.Clear();
     }
 
     private static async ValueTask<object?> ComputeValueAsync(

--- a/BareMetalWeb.Data/PermissionResolver.cs
+++ b/BareMetalWeb.Data/PermissionResolver.cs
@@ -31,7 +31,12 @@ public static class PermissionResolver
     }
 
     /// <summary>Invalidate all cached permission sets (call on group/role/permission save).</summary>
-    public static void Invalidate() => Interlocked.Increment(ref _generation);
+    public static void Invalidate()
+    {
+        Interlocked.Increment(ref _generation);
+        // Clear all stale entries to prevent unbounded growth from inactive users
+        _cache.Clear();
+    }
 
     /// <summary>Invalidate a specific principal's cache.</summary>
     public static void Invalidate(uint principalKey) => _cache.TryRemove(principalKey, out _);

--- a/BareMetalWeb.Host/RouteHandlers.cs
+++ b/BareMetalWeb.Host/RouteHandlers.cs
@@ -42,6 +42,7 @@ public sealed class RouteHandlers : IRouteHandlers
     private static readonly TimeSpan MfaAttemptWindow = TimeSpan.FromMinutes(5);
     private static readonly TimeSpan MfaBaseBlockDuration = TimeSpan.FromSeconds(10);
     private static readonly ConcurrentDictionary<string, AttemptTracker> MfaAttempts = new(StringComparer.Ordinal);
+    private static DateTime _lastMfaScavenge = DateTime.UtcNow;
     private const int LoginIpMaxAttempts = 10;
     private const int LoginUserMaxAttempts = 5;
     private const int SsoCallbackIpMaxAttempts = 10;
@@ -1586,6 +1587,7 @@ public sealed class RouteHandlers : IRouteHandlers
     private static bool IsThrottled(string key, int maxAttempts, out TimeSpan? retryAfter)
     {
         retryAfter = null;
+        ScavengeMfaAttempts();
         var tracker = MfaAttempts.GetOrAdd(key, _ => new AttemptTracker());
         return tracker.IsBlocked(MfaAttemptWindow, maxAttempts, MfaBaseBlockDuration, out retryAfter);
     }
@@ -1598,8 +1600,22 @@ public sealed class RouteHandlers : IRouteHandlers
 
     private static void RegisterSuccess(string key)
     {
-        if (MfaAttempts.TryGetValue(key, out var tracker))
-            tracker.Reset();
+        if (MfaAttempts.TryRemove(key, out _)) { }
+    }
+
+    /// <summary>Evict MFA attempt trackers idle for longer than the attempt window (5 min). Runs at most once per minute.</summary>
+    private static void ScavengeMfaAttempts()
+    {
+        var now = DateTime.UtcNow;
+        if ((now - _lastMfaScavenge).TotalSeconds < 60) return;
+        _lastMfaScavenge = now;
+
+        var cutoff = now - MfaAttemptWindow - MfaAttemptWindow; // 2x window = 10 min stale
+        foreach (var kvp in MfaAttempts)
+        {
+            if (kvp.Value.LastActivityUtc < cutoff)
+                MfaAttempts.TryRemove(kvp.Key, out _);
+        }
     }
 
     private static string FormatThrottleMessage(TimeSpan? retryAfter)
@@ -1647,12 +1663,14 @@ public sealed class RouteHandlers : IRouteHandlers
         private DateTime _windowStartUtc = DateTime.UtcNow;
         private DateTime? _blockedUntilUtc;
         private int _count;
+        public DateTime LastActivityUtc = DateTime.UtcNow;
 
         public bool IsBlocked(TimeSpan window, int maxAttempts, TimeSpan baseBlock, out TimeSpan? retryAfter)
         {
             lock (_sync)
             {
                 var now = DateTime.UtcNow;
+                LastActivityUtc = now;
                 if (_blockedUntilUtc.HasValue && _blockedUntilUtc.Value > now)
                 {
                     retryAfter = _blockedUntilUtc.Value - now;
@@ -1676,6 +1694,7 @@ public sealed class RouteHandlers : IRouteHandlers
             lock (_sync)
             {
                 var now = DateTime.UtcNow;
+                LastActivityUtc = now;
                 if (now - _windowStartUtc > window)
                 {
                     _windowStartUtc = now;


### PR DESCRIPTION
## Problem
Three static `ConcurrentDictionary` caches grow unbounded in long-running server instances:

1. **MfaAttempts** (RouteHandlers.cs) — keyed by IP/user string, never evicted. DoS vector: attacker can flood unique MFA keys to exhaust memory.
2. **ComputedFieldService._cache** — keyed by entity instance+field, expired entries never removed from dictionary (TTL only checked on read, but stale keys persist forever).
3. **PermissionResolver._cache** — keyed by user ID (uint), stale entries for inactive users accumulate indefinitely since `Invalidate()` only bumps a generation counter without clearing old entries.

## Fix
- **MfaAttempts**: Added `LastActivityUtc` to `AttemptTracker`. Lazy scavenge runs at most once/minute, evicts entries idle >10 min. `RegisterSuccess()` now removes the key entirely via `TryRemove`.
- **ComputedFieldService**: Lazy scavenge runs at most once/30s, removes all expired entries. Hard cap at 10k entries with full clear on overflow.
- **PermissionResolver**: `Invalidate()` now calls `_cache.Clear()` in addition to incrementing the generation. All entries re-built lazily on next access.

## Impact
Prevents gradual memory growth on long-running instances (weeks/months uptime). No behavioral changes — all caches rebuild transparently on next access.