### PR TITLE
security: fix markdown XSS + add missing security headers

### DIFF
--- a/BareMetalWeb.Core/wwwroot/static/js/vnext-app.js
+++ b/BareMetalWeb.Core/wwwroot/static/js/vnext-app.js
@@ -343,8 +343,8 @@
         html = html.replace(/\*\*\*(.+?)\*\*\*/g, '<strong><em>$1</em></strong>');
         html = html.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
         html = html.replace(/\*(.+?)\*/g, '<em>$1</em>');
-        // Links
-        html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" target="_blank">$1</a>');
+        // Links (only http/https/mailto — block javascript: URIs)
+        html = html.replace(/\[([^\]]+)\]\(((?:https?:\/\/|mailto:)[^)]+)\)/g, '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>');
         // Unordered lists
         html = html.replace(/^\- (.+)$/gm, '<li>$1</li>');
         html = html.replace(/(<li>.*<\/li>\n?)+/g, '<ul>$&</ul>');

--- a/BareMetalWeb.Host/BareMetalWebServer.cs
+++ b/BareMetalWeb.Host/BareMetalWebServer.cs
@@ -798,6 +798,10 @@ public class BareMetalWebServer : IBareWebHost
     {
         var nonce = context.GenerateCspNonce();
         context.Response.Headers["Content-Security-Policy"] = string.Format(ContentSecurityPolicyTemplate, nonce);
+        context.Response.Headers["X-Content-Type-Options"] = "nosniff";
+        context.Response.Headers["X-Frame-Options"] = "DENY";
+        context.Response.Headers["Referrer-Policy"] = "strict-origin-when-cross-origin";
+        context.Response.Headers["Permissions-Policy"] = "camera=(), microphone=(), geolocation=()";
         if (isHttps)
             context.Response.Headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains";
         // HTTP/1.x keep-alive hint so clients reuse TCP connections across requests


### PR DESCRIPTION
## OWASP Security Sweep

### Fixes

**1. Markdown XSS via javascript: URI (HIGH)**
The client-side markdown renderer accepted arbitrary URLs in link syntax: `[click me](javascript:alert(1))`. Since `escHtml()` runs first, HTML entities are escaped, but `javascript:` doesn't contain characters that get entity-encoded — the crafted URL passes through to `href` intact.

**Fix:** Restrict the link regex to only match `https?://` and `mailto:` protocols. Also added `rel="noopener noreferrer"` on rendered links.

**2. Missing Security Headers (MEDIUM)**
Added standard OWASP-recommended response headers:
- `X-Content-Type-Options: nosniff` — prevents MIME-type sniffing
- `X-Frame-Options: DENY` — prevents clickjacking (supplements CSP frame-ancestors)
- `Referrer-Policy: strict-origin-when-cross-origin` — limits referrer leakage
- `Permissions-Policy: camera=(), microphone=(), geolocation=()` — disables unused browser APIs

### Audit Results (no action needed)
- ✅ **No SQL injection** — parameterized queries throughout
- ✅ **No path traversal** — all file paths validated with `Path.GetFullPath()` + boundary check
- ✅ **Sensitive fields NOT exposed** — User password/MFA fields lack `[DataField]` so are excluded from API/UI
- ✅ **Strong auth** — PBKDF2-SHA256 100k iterations, cryptographic session tokens, HttpOnly+Secure+SameSite cookies
- ✅ **CSRF protection** — double-submit cookie with fixed-time comparison
- ✅ **CSP** — nonce-based, no unsafe-inline/unsafe-eval
- ✅ **CORS** — defaults to disabled, whitelist validation when enabled