### PR TITLE
perf: add capacity hints to List allocations in hot paths

### DIFF
--- a/BareMetalWeb.Data/WalDataProvider.cs
+++ b/BareMetalWeb.Data/WalDataProvider.cs
@@ -434,10 +434,10 @@ public sealed class WalDataProvider : IDataProvider, IRawBinaryProvider, IDispos
         var idMap = GetOrLoadIdMap(typeName);
         if (idMap.Count == 0) { sw.Stop(); OnWalReadComplete?.Invoke(sw.Elapsed); return Array.Empty<ReadOnlyMemory<byte>>(); }
 
-        var results = new List<ReadOnlyMemory<byte>>();
-
         int skip = query?.Skip ?? 0;
         int top  = query?.Top  ?? DefaultQueryLimit;
+
+        var results = new List<ReadOnlyMemory<byte>>(Math.Min(top, idMap.Count));
         int skipped = 0;
         int taken = 0;
 
@@ -570,7 +570,7 @@ public sealed class WalDataProvider : IDataProvider, IRawBinaryProvider, IDispos
                 {
                     filtered = loaded;
                 }
-                var sortedList = new List<T>();
+                var sortedList = new List<T>(filtered.Count);
                 foreach (var item in _queryEvaluator.ApplySorts(filtered, query))
                     sortedList.Add(item);
                 if (skip > 0 || top != DefaultQueryLimit)
@@ -869,7 +869,7 @@ public sealed class WalDataProvider : IDataProvider, IRawBinaryProvider, IDispos
 
         if (!canShortCircuit)
         {
-            var sortedList = new List<T>();
+            var sortedList = new List<T>(scanResults.Count);
             foreach (var item in _queryEvaluator.ApplySorts(scanResults, query))
                 sortedList.Add(item);
             if (skip > 0 || top != int.MaxValue)
@@ -1278,7 +1278,7 @@ public sealed class WalDataProvider : IDataProvider, IRawBinaryProvider, IDispos
         if (skip < 0) skip = 0;
         if (top <= 0) return Array.Empty<DataRecord>();
 
-        var results = new List<DataRecord>();
+        var results = new List<DataRecord>(Math.Min(top, idMap.Count));
         foreach (var kvp in idMap)
         {
             var record = LoadRecord(kvp.Key, schema);

--- a/BareMetalWeb.Host/BinaryApiHandlers.cs
+++ b/BareMetalWeb.Host/BinaryApiHandlers.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Collections;
 using System.Collections.Concurrent;
 using System.Text.Json;
 using Microsoft.AspNetCore.Http;
@@ -247,7 +248,7 @@ public static class BinaryApiHandlers
 
             // Standard path: load CLR objects
             var entities = await meta.Handlers.QueryAsync(queryDef, context.RequestAborted);
-            var list = new List<object>();
+            var list = new List<object>(entities is ICollection entColl ? entColl.Count : 32);
             foreach (var e in entities)
                 list.Add((object)e);
             await WriteListResponse(context, list, plan);
@@ -274,7 +275,7 @@ public static class BinaryApiHandlers
         {
             var queryDef = LookupApiHandlers.BuildQueryFromRequest(context, meta);
             var entities = await meta.Handlers.QueryAsync(queryDef, context.RequestAborted);
-            var list = new List<object>();
+            var list = new List<object>(entities is ICollection rawColl ? rawColl.Count : 32);
             foreach (var e in entities)
                 list.Add((object)e);
             var plan = GetOrBuildPlan(meta);
@@ -366,9 +367,10 @@ public static class BinaryApiHandlers
             {
                 Clauses = { new QueryClause { Field = "EntityId", Operator = QueryOperator.Equals, Value = entityDef.EntityId } }
             };
-            var aggs = new List<BareMetalWeb.Runtime.AggregationDefinition>();
-            foreach (var a in await DataStoreProvider.Current
-                .QueryAsync<BareMetalWeb.Runtime.AggregationDefinition>(aggQuery, context.RequestAborted))
+            var aggResults = await DataStoreProvider.Current
+                .QueryAsync<BareMetalWeb.Runtime.AggregationDefinition>(aggQuery, context.RequestAborted);
+            var aggs = new List<BareMetalWeb.Runtime.AggregationDefinition>(aggResults is ICollection aggColl ? aggColl.Count : 8);
+            foreach (var a in aggResults)
                 aggs.Add(a);
 
             context.Response.StatusCode = 200;

--- a/BareMetalWeb.Host/LookupApiHandlers.cs
+++ b/BareMetalWeb.Host/LookupApiHandlers.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 
 using System.Text.Json;
@@ -97,7 +98,7 @@ public static class LookupApiHandlers
         {
             var queryDef = BuildQueryFromRequest(context, meta);
             var entities = await meta.Handlers.QueryAsync(queryDef, context.RequestAborted);
-            var results = new List<Dictionary<string, object?>>();
+            var results = new List<Dictionary<string, object?>>(entities is ICollection entColl ? entColl.Count : 16);
             foreach (var e in entities)
                 results.Add(await EntityToJsonAsync(e, meta, traverse, context.RequestAborted));
 
@@ -139,8 +140,8 @@ public static class LookupApiHandlers
                 return;
             }
 
-            ids = new List<string>();
-            var seen = new HashSet<string>(StringComparer.Ordinal);
+            ids = new List<string>(Math.Min(idsElement.GetArrayLength(), 500));
+            var seen = new HashSet<string>(Math.Min(idsElement.GetArrayLength(), 500), StringComparer.Ordinal);
             foreach (var e in idsElement.EnumerateArray())
             {
                 if (ids.Count >= 500) break;

--- a/BareMetalWeb.Host/RouteHandlers.cs
+++ b/BareMetalWeb.Host/RouteHandlers.cs
@@ -1767,7 +1767,7 @@ public sealed class RouteHandlers : IRouteHandlers
 
             if (format == "csv" || acceptCsv)
             {
-                var resultsList = new List<object?>();
+                var resultsList = new List<object?>(results is ICollection csvCol ? csvCol.Count : 32);
                 foreach (var item in results)
                     resultsList.Add((object?)item);
                 var rows = BuildListPlainRowsWithId(meta, resultsList, out var headers);
@@ -1805,7 +1805,7 @@ public sealed class RouteHandlers : IRouteHandlers
 
         if (format == "csv" || acceptCsv)
         {
-            var resultsList = new List<object?>();
+            var resultsList = new List<object?>(allResults is ICollection csvCol2 ? csvCol2.Count : 32);
             foreach (var item in allResults)
                 resultsList.Add((object?)item);
             var rows = BuildListPlainRowsWithId(meta, resultsList, out var headers);


### PR DESCRIPTION
Pre-size List<T> allocations in per-request handlers to avoid internal array resizing:

- **WalDataProvider**: capacity from `Math.Min(top, idMap.Count)` for query results, source collection count for sorted lists
- **LookupApiHandlers**: `ICollection` check for query result capacity, `GetArrayLength()` for batch ID lists (capped at 500)
- **BinaryApiHandlers**: `ICollection` check for entity lists, capacity for aggregation defs
- **RouteHandlers**: `ICollection` check for CSV export result lists