### PR TITLE
feat: optimize CI test suite for speed

### DIFF
--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -150,6 +150,7 @@ jobs:
       - name: Unit tests (.NET)
         run: |
           dotnet test BareMetalWeb.sln --no-build --configuration Release --verbosity minimal \
+            --blame-hang-timeout 60s \
             --filter "FullyQualifiedName!~IntegrationTests&FullyQualifiedName!~PerformanceTests&Category!=Integration" \
             --results-directory TestResults --logger "trx"
           if find TestResults -name '*.trx' -exec grep -l 'outcome="Failed"' {} + 2>/dev/null | head -1 | grep -q .; then
@@ -324,6 +325,7 @@ jobs:
         run: |
           dotnet test BareMetalWeb.IntegrationTests/BareMetalWeb.IntegrationTests.csproj \
             --no-build --configuration Release --verbosity normal \
+            --blame-hang-timeout 120s \
             --filter "Category=Integration|FullyQualifiedName~IntegrationTests" \
             --results-directory TestResults --logger "trx"
 
@@ -377,12 +379,12 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────────────
   # L1.4 – Performance CI (large dataset)
   # Heavier stress test with an auto-generated large volume data set.
-  # Runs after L1.3 so that large runs don't mask small-dataset regressions.
+  # Runs in parallel with L1.3 — both only need the upgrade instance deployed.
   # ─────────────────────────────────────────────────────────────────────────────
   l1-4-performance-big-ci:
     name: "L1.4 · Performance CI (Large Dataset)"
     runs-on: ubuntu-latest
-    needs: l1-3-performance-ci
+    needs: l1-1-upgrade-ci
     steps:
       - uses: actions/checkout@v4
 
@@ -422,7 +424,7 @@ jobs:
   l1-5-playwright-ci:
     name: "L1.5 · Playwright CI (UI Tests on Upgrade)"
     runs-on: ubuntu-latest
-    needs: [l1-2-integration-ci, l1-4-performance-big-ci]
+    needs: [l1-2-integration-ci, l1-3-performance-ci, l1-4-performance-big-ci]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -113,7 +113,7 @@ jobs:
           name: build-debug
           path: .
       - name: Run Data tests
-        run: dotnet test BareMetalWeb.Data.Tests/BareMetalWeb.Data.Tests.csproj --configuration Debug --no-build --verbosity minimal --filter "FullyQualifiedName!~PerformanceTests&Category!=Integration"
+        run: dotnet test BareMetalWeb.Data.Tests/BareMetalWeb.Data.Tests.csproj --configuration Debug --no-build --verbosity minimal --blame-hang-timeout 60s --filter "FullyQualifiedName!~PerformanceTests&Category!=Integration"
 
   test-host:
     needs: build-debug
@@ -134,7 +134,7 @@ jobs:
           name: build-debug
           path: .
       - name: Run Host tests
-        run: dotnet test BareMetalWeb.Host.Tests/BareMetalWeb.Host.Tests.csproj --configuration Debug --no-build --verbosity minimal --filter "FullyQualifiedName!~PerformanceTests&Category!=Integration"
+        run: dotnet test BareMetalWeb.Host.Tests/BareMetalWeb.Host.Tests.csproj --configuration Debug --no-build --verbosity minimal --blame-hang-timeout 60s --filter "FullyQualifiedName!~PerformanceTests&Category!=Integration"
 
   test-rendering:
     needs: build-debug
@@ -156,10 +156,10 @@ jobs:
           path: .
       - name: Run Rendering + Runtime + API + Core tests
         run: |
-          dotnet test BareMetalWeb.Rendering.Tests/BareMetalWeb.Rendering.Tests.csproj --configuration Debug --no-build --verbosity minimal --filter "FullyQualifiedName!~PerformanceTests&Category!=Integration"
-          dotnet test BareMetalWeb.Runtime.Tests/BareMetalWeb.Runtime.Tests.csproj --configuration Debug --no-build --verbosity minimal --filter "FullyQualifiedName!~PerformanceTests&Category!=Integration"
-          dotnet test BareMetalWeb.Core.Tests/BareMetalWeb.Core.Tests.csproj --configuration Debug --no-build --verbosity minimal 2>/dev/null || true
-          dotnet test BareMetalWeb.API.Tests/BareMetalWeb.API.Tests.csproj --configuration Debug --no-build --verbosity minimal 2>/dev/null || true
+          dotnet test BareMetalWeb.Rendering.Tests/BareMetalWeb.Rendering.Tests.csproj --configuration Debug --no-build --verbosity minimal --blame-hang-timeout 60s --filter "FullyQualifiedName!~PerformanceTests&Category!=Integration"
+          dotnet test BareMetalWeb.Runtime.Tests/BareMetalWeb.Runtime.Tests.csproj --configuration Debug --no-build --verbosity minimal --blame-hang-timeout 60s --filter "FullyQualifiedName!~PerformanceTests&Category!=Integration"
+          dotnet test BareMetalWeb.Core.Tests/BareMetalWeb.Core.Tests.csproj --configuration Debug --no-build --verbosity minimal --blame-hang-timeout 60s 2>/dev/null || true
+          dotnet test BareMetalWeb.API.Tests/BareMetalWeb.API.Tests.csproj --configuration Debug --no-build --verbosity minimal --blame-hang-timeout 60s 2>/dev/null || true
 
   # ── Stage 2b: Jest tests (no .NET build dependency) ────────────────────
   test-jest:

--- a/BareMetalWeb.API.Tests/BareMetalWeb.API.Tests.csproj
+++ b/BareMetalWeb.API.Tests/BareMetalWeb.API.Tests.csproj
@@ -22,4 +22,8 @@
     <ProjectReference Include="..\BareMetalWeb.API\BareMetalWeb.API.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
 </Project>

--- a/BareMetalWeb.API.Tests/xunit.runner.json
+++ b/BareMetalWeb.API.Tests/xunit.runner.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "parallelizeAssembly": false,
+  "parallelizeTestCollections": true,
+  "maxParallelThreads": -1,
+  "methodDisplay": "method",
+  "diagnosticMessages": false,
+  "longRunningTestSeconds": 30
+}

--- a/BareMetalWeb.Core.Tests/BareMetalWeb.Core.Tests.csproj
+++ b/BareMetalWeb.Core.Tests/BareMetalWeb.Core.Tests.csproj
@@ -22,4 +22,8 @@
     <ProjectReference Include="..\BareMetalWeb.Core\BareMetalWeb.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
 </Project>

--- a/BareMetalWeb.Core.Tests/xunit.runner.json
+++ b/BareMetalWeb.Core.Tests/xunit.runner.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "parallelizeAssembly": false,
+  "parallelizeTestCollections": true,
+  "maxParallelThreads": -1,
+  "methodDisplay": "method",
+  "diagnosticMessages": false,
+  "longRunningTestSeconds": 30
+}

--- a/BareMetalWeb.Data.Tests/BareMetalWeb.Data.Tests.csproj
+++ b/BareMetalWeb.Data.Tests/BareMetalWeb.Data.Tests.csproj
@@ -23,4 +23,8 @@
     <ProjectReference Include="..\BareMetalWeb.Runtime\BareMetalWeb.Runtime.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
 </Project>

--- a/BareMetalWeb.Data.Tests/xunit.runner.json
+++ b/BareMetalWeb.Data.Tests/xunit.runner.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "parallelizeAssembly": false,
+  "parallelizeTestCollections": false,
+  "maxParallelThreads": -1,
+  "methodDisplay": "method",
+  "diagnosticMessages": false,
+  "longRunningTestSeconds": 30
+}

--- a/BareMetalWeb.Host.Tests/BareMetalWeb.Host.Tests.csproj
+++ b/BareMetalWeb.Host.Tests/BareMetalWeb.Host.Tests.csproj
@@ -17,4 +17,8 @@
   <ItemGroup>
     <ProjectReference Include="..\BareMetalWeb.Host\BareMetalWeb.Host.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
 </Project>

--- a/BareMetalWeb.Host.Tests/xunit.runner.json
+++ b/BareMetalWeb.Host.Tests/xunit.runner.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "parallelizeAssembly": false,
+  "parallelizeTestCollections": false,
+  "maxParallelThreads": -1,
+  "methodDisplay": "method",
+  "diagnosticMessages": false,
+  "longRunningTestSeconds": 30
+}

--- a/BareMetalWeb.Rendering.Tests/BareMetalWeb.Rendering.Tests.csproj
+++ b/BareMetalWeb.Rendering.Tests/BareMetalWeb.Rendering.Tests.csproj
@@ -23,4 +23,8 @@
     <ProjectReference Include="..\BareMetalWeb.Host\BareMetalWeb.Host.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
 </Project>

--- a/BareMetalWeb.Rendering.Tests/xunit.runner.json
+++ b/BareMetalWeb.Rendering.Tests/xunit.runner.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "parallelizeAssembly": false,
+  "parallelizeTestCollections": true,
+  "maxParallelThreads": -1,
+  "methodDisplay": "method",
+  "diagnosticMessages": false,
+  "longRunningTestSeconds": 30
+}

--- a/BareMetalWeb.Runtime.Tests/BareMetalWeb.Runtime.Tests.csproj
+++ b/BareMetalWeb.Runtime.Tests/BareMetalWeb.Runtime.Tests.csproj
@@ -21,4 +21,8 @@
     <ProjectReference Include="..\BareMetalWeb.Data\BareMetalWeb.Data.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
 </Project>

--- a/BareMetalWeb.Runtime.Tests/xunit.runner.json
+++ b/BareMetalWeb.Runtime.Tests/xunit.runner.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "parallelizeAssembly": false,
+  "parallelizeTestCollections": true,
+  "maxParallelThreads": -1,
+  "methodDisplay": "method",
+  "diagnosticMessages": false,
+  "longRunningTestSeconds": 30
+}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,4 +4,13 @@
     <!-- Tests show minimal output by default: only failures and summary -->
     <VSTestVerbosity>minimal</VSTestVerbosity>
   </PropertyGroup>
+
+  <!-- Test-project optimizations: applied only to *.Tests projects -->
+  <PropertyGroup Condition="$(MSBuildProjectName.EndsWith('.Tests'))">
+    <!-- Deterministic builds improve caching; avoid unnecessary rebuilds -->
+    <Deterministic>true</Deterministic>
+    <!-- Disable analyzers during test builds for faster compilation -->
+    <RunAnalyzers>false</RunAnalyzers>
+    <RunAnalyzersDuringBuild>false</RunAnalyzersDuringBuild>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Fixes #1067

## Changes

### xunit.runner.json (all 6 test projects)
- **Data/Host tests**: \parallelizeTestCollections: false\ (respects SharedState collection serialization)
- **API/Core/Rendering/Runtime tests**: \parallelizeTestCollections: true\ (safe to parallelize)
- Long-running test detection at 30s threshold
- Method-level display for clearer test output

### CI workflow optimizations
- **blame-hang-timeout**: 60s for unit tests, 120s for integration tests — kills hung tests
- **L1.4 parallelized** with L1.3: both perf test jobs now run in parallel (only need upgrade instance)
- **L1.5 dependency** updated to wait for L1.2 + L1.3 + L1.4

### Build optimizations
- Disabled analyzers during test builds (\Directory.Build.props\) — faster compilation
- Deterministic builds for test projects — better caching