### PR TITLE
perf: CompressionHelper ReadOnlySpan + SynchronousEncryption Span

### DIFF
--- a/BareMetalWeb.Core/CompressionHelper.cs
+++ b/BareMetalWeb.Core/CompressionHelper.cs
@@ -78,20 +78,20 @@ public static class CompressionHelper
         => SelectEncoding(context.HttpRequest.Headers.AcceptEncoding.ToString());
 
     /// <summary>Compresses <paramref name="data"/> using Brotli at Fastest level.</summary>
-    public static byte[] CompressBrotli(byte[] data)
+    public static byte[] CompressBrotli(ReadOnlySpan<byte> data)
     {
         using var ms = new MemoryStream(data.Length);
         using (var bs = new BrotliStream(ms, CompressionLevel.Fastest, leaveOpen: true))
-            bs.Write(data, 0, data.Length);
+            bs.Write(data);
         return ms.ToArray();
     }
 
     /// <summary>Compresses <paramref name="data"/> using GZip at Fastest level.</summary>
-    public static byte[] CompressGzip(byte[] data)
+    public static byte[] CompressGzip(ReadOnlySpan<byte> data)
     {
         using var ms = new MemoryStream(data.Length);
         using (var gz = new GZipStream(ms, CompressionLevel.Fastest, leaveOpen: true))
-            gz.Write(data, 0, data.Length);
+            gz.Write(data);
         return ms.ToArray();
     }
 

--- a/BareMetalWeb.Data/SynchronousEncryption.cs
+++ b/BareMetalWeb.Data/SynchronousEncryption.cs
@@ -60,20 +60,20 @@ public sealed class SynchronousEncryption : ISynchronousEncryption
     {
         if (plaintext is null) throw new ArgumentNullException(nameof(plaintext));
 
-        var nonce = new byte[NonceSize];
+        Span<byte> nonce = stackalloc byte[NonceSize];
         RandomNumberGenerator.Fill(nonce);
 
         var ciphertext = new byte[plaintext.Length];
-        var tag = new byte[TagSize];
+        Span<byte> tag = stackalloc byte[TagSize];
 
         using var aes = new AesGcm(_key, TagSize);
         aes.Encrypt(nonce, plaintext, ciphertext, tag, associatedData);
 
         var payload = new byte[1 + NonceSize + TagSize + ciphertext.Length];
         payload[0] = FormatVersion;
-        Buffer.BlockCopy(nonce, 0, payload, 1, NonceSize);
-        Buffer.BlockCopy(tag, 0, payload, 1 + NonceSize, TagSize);
-        Buffer.BlockCopy(ciphertext, 0, payload, 1 + NonceSize + TagSize, ciphertext.Length);
+        nonce.CopyTo(payload.AsSpan(1));
+        tag.CopyTo(payload.AsSpan(1 + NonceSize));
+        ciphertext.AsSpan().CopyTo(payload.AsSpan(1 + NonceSize + TagSize));
         return payload;
     }
 
@@ -87,13 +87,10 @@ public sealed class SynchronousEncryption : ISynchronousEncryption
         if (version != FormatVersion)
             throw new InvalidOperationException($"Unsupported payload version {version}.");
 
-        var nonce = new byte[NonceSize];
-        var tag = new byte[TagSize];
-        var ciphertext = new byte[payload.Length - 1 - NonceSize - TagSize];
-
-        Buffer.BlockCopy(payload, 1, nonce, 0, NonceSize);
-        Buffer.BlockCopy(payload, 1 + NonceSize, tag, 0, TagSize);
-        Buffer.BlockCopy(payload, 1 + NonceSize + TagSize, ciphertext, 0, ciphertext.Length);
+        var span = payload.AsSpan();
+        var nonce = span.Slice(1, NonceSize);
+        var tag = span.Slice(1 + NonceSize, TagSize);
+        var ciphertext = span.Slice(1 + NonceSize + TagSize);
 
         var plaintext = new byte[ciphertext.Length];
         using var aes = new AesGcm(_key, TagSize);


### PR DESCRIPTION
- CompressBrotli/CompressGzip: accept ReadOnlySpan<byte>, use Span Write overload
- Encrypt: stackalloc nonce/tag, Span.CopyTo for payload assembly
- Decrypt: slice payload span, eliminate 3 array allocations

Fixes #1120, Fixes #1122