### PR TITLE
fix: error handling for fire-and-forget tasks and bare catch blocks

### DIFF
--- a/BareMetalWeb.AI/AdminAssistantService.cs
+++ b/BareMetalWeb.AI/AdminAssistantService.cs
@@ -149,7 +149,7 @@ public static class CrudTools
                     var converted = Convert.ChangeType(value, field.ClrType);
                     field.Setter(instance, converted);
                 }
-                catch { /* skip invalid values */ }
+                catch (Exception) { /* skip invalid values */ }
             }
         }
 

--- a/BareMetalWeb.AI/QueryTools.cs
+++ b/BareMetalWeb.AI/QueryTools.cs
@@ -77,7 +77,7 @@ public static class QueryTools
             foreach (var field in layout.Fields)
             {
                 try { dict[field.Name] = field.Getter(entity); }
-                catch { dict[field.Name] = null; }
+                catch (Exception) { dict[field.Name] = null; }
             }
             rowsList.Add(dict);
         }
@@ -129,7 +129,7 @@ public static class QueryTools
         foreach (var field in layout.Fields)
         {
             try { dict[field.Name] = field.Getter(entity); }
-            catch { dict[field.Name] = null; }
+            catch (Exception) { dict[field.Name] = null; }
         }
         return dict;
     }

--- a/BareMetalWeb.Data/ClusterState.cs
+++ b/BareMetalWeb.Data/ClusterState.cs
@@ -239,7 +239,7 @@ public sealed class CompactorState : IDisposable
                 if (!await _lease.TryRenewAsync(ct)) { Demote(); return; }
             }
             catch (OperationCanceledException) { return; }
-            catch { Demote(); return; }
+            catch (Exception) { Demote(); return; }
         }
     }
 

--- a/BareMetalWeb.Data/ColumnQueryExecutor.cs
+++ b/BareMetalWeb.Data/ColumnQueryExecutor.cs
@@ -489,7 +489,7 @@ internal static class ColumnQueryExecutor
             result = Convert.ToInt32(value);
             return true;
         }
-        catch { result = 0; return false; }
+        catch (Exception) { result = 0; return false; }
     }
 
     private static bool TryConvertToLong(object? value, Type targetType, out long result)
@@ -510,7 +510,7 @@ internal static class ColumnQueryExecutor
             result = Convert.ToInt64(value);
             return true;
         }
-        catch { result = 0; return false; }
+        catch (Exception) { result = 0; return false; }
     }
 
     private static bool TryConvertToDouble(object? value, out double result)
@@ -522,14 +522,14 @@ internal static class ColumnQueryExecutor
             result = Convert.ToDouble(value);
             return true;
         }
-        catch { result = 0; return false; }
+        catch (Exception) { result = 0; return false; }
     }
 
     private static bool TryConvertToFloat(object? value, out float result)
     {
         if (value == null) { result = 0; return false; }
         try { result = Convert.ToSingle(value); return true; }
-        catch { result = 0; return false; }
+        catch (Exception) { result = 0; return false; }
     }
 
     // ── Row-value unboxing ─────────────────────────────────────────────────
@@ -540,7 +540,7 @@ internal static class ColumnQueryExecutor
         if (v is int i)    return i;
         if (v is bool b)   return b ? 1 : 0;
         if (v == null)     return 0;
-        try { return Convert.ToInt32(v); } catch { return 0; }
+        try { return Convert.ToInt32(v); } catch (Exception) { return 0; }
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -553,7 +553,7 @@ internal static class ColumnQueryExecutor
         if (v is TimeSpan ts)      return ts.Ticks;
         if (v is DateTimeOffset dto) return dto.UtcTicks;
         if (v == null)             return 0;
-        try { return Convert.ToInt64(v); } catch { return 0; }
+        try { return Convert.ToInt64(v); } catch (Exception) { return 0; }
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -563,7 +563,7 @@ internal static class ColumnQueryExecutor
         if (v is decimal dec) return (double)dec;
         if (v is float f)    return f;
         if (v == null)       return 0;
-        try { return Convert.ToDouble(v); } catch { return 0; }
+        try { return Convert.ToDouble(v); } catch (Exception) { return 0; }
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -571,7 +571,7 @@ internal static class ColumnQueryExecutor
     {
         if (v is float f) return f;
         if (v == null)    return 0;
-        try { return Convert.ToSingle(v); } catch { return 0; }
+        try { return Convert.ToSingle(v); } catch (Exception) { return 0; }
     }
 
     // ── Utility ────────────────────────────────────────────────────────────

--- a/BareMetalWeb.Data/DataScaffold.cs
+++ b/BareMetalWeb.Data/DataScaffold.cs
@@ -2723,7 +2723,7 @@ public static class DataScaffold
                 var parsed = DataJsonWriter.ParseListOfStringDicts(jsonValue);
                 if (parsed != null) rows = parsed;
             }
-            catch { /* ignore corrupt JSON */ }
+            catch (Exception) { /* ignore corrupt JSON */ }
         }
 
         return RenderChildListEditorHtml(field, childFields, rows, cspNonce);

--- a/BareMetalWeb.Data/QueryPlanner.cs
+++ b/BareMetalWeb.Data/QueryPlanner.cs
@@ -201,7 +201,7 @@ public sealed class QueryPlanner
             if (count.IsCompleted)
                 return (int)Math.Min(count.Result, int.MaxValue);
         }
-        catch { /* fall through */ }
+        catch (Exception) { /* fall through */ }
 
         return 10_000; // default estimate
     }

--- a/BareMetalWeb.Data/WalDataProvider.cs
+++ b/BareMetalWeb.Data/WalDataProvider.cs
@@ -1659,7 +1659,11 @@ public sealed class WalDataProvider : IDataProvider, IRawBinaryProvider, IDispos
 
             // Re-persist without tombstoned entries so future loads are clean
             if (needsCompaction)
-                Task.Run(() => PersistIdMap(typeName));
+                Task.Run(() =>
+                {
+                    try { PersistIdMap(typeName); }
+                    catch (Exception ex) { _logger?.LogError($"Background id-map compaction failed for {typeName}.", ex); }
+                });
         }
         catch (IOException) { /* treat file as missing */ }
 

--- a/BareMetalWeb.Host/GraphQLHandler.cs
+++ b/BareMetalWeb.Host/GraphQLHandler.cs
@@ -335,7 +335,7 @@ public static class GraphQLHandler
             }
 
             try { row[camel] = f.GetValueFn(item)?.ToString(); }
-            catch { row[camel] = null; }
+            catch (Exception) { row[camel] = null; }
         }
 
         return row;

--- a/BareMetalWeb.Host/StaticAssetCache.cs
+++ b/BareMetalWeb.Host/StaticAssetCache.cs
@@ -163,7 +163,7 @@ public static class StaticAssetCache
 
             FileInfo fi;
             try { fi = new FileInfo(filePath); }
-            catch { continue; }
+            catch (Exception) { continue; }
 
             if (!fi.Exists)
                 continue;
@@ -178,7 +178,7 @@ public static class StaticAssetCache
 
             byte[] raw;
             try { raw = File.ReadAllBytes(filePath); }
-            catch { continue; }
+            catch (Exception) { continue; }
 
             var lastModified = fi.LastWriteTimeUtc.ToString("R");
             var isVersioned  = IsVersionedPath(relativePath);


### PR DESCRIPTION
## Summary

- **#1143**: Wrap fire-and-forget `Task.Run()` in `WalDataProvider.cs` with try-catch + logging. (AuditService already had the fix in place.)
- **#1182**: Replace all bare `catch { }` blocks with explicit `catch (Exception) { }` across 8 files (AdminAssistantService, QueryTools, StaticAssetCache, GraphQLHandler, ColumnQueryExecutor, DataScaffold, ClusterState, QueryPlanner).

Closes #1143, closes #1182