### PR TITLE
Fix concurrency and float-equality bugs

### DIFF
--- a/BareMetalWeb.Data/DataScaffold.cs
+++ b/BareMetalWeb.Data/DataScaffold.cs
@@ -2471,7 +2471,7 @@ public static class DataScaffold
         if (effectiveType == typeof(long)) return (long)value == 0L;
         if (effectiveType == typeof(decimal)) return (decimal)value == 0m;
         if (effectiveType == typeof(double)) return (double)value == 0.0;
-        if (effectiveType == typeof(float)) return (float)value == 0f;
+        if (effectiveType == typeof(float)) return MathF.Abs((float)value) < 1e-7f;
         if (effectiveType == typeof(bool)) return (bool)value == false;
         if (effectiveType == typeof(DateTime)) return (DateTime)value == default;
         if (effectiveType == typeof(DateTimeOffset)) return (DateTimeOffset)value == default;

--- a/BareMetalWeb.Data/ModuleRegistry.cs
+++ b/BareMetalWeb.Data/ModuleRegistry.cs
@@ -10,8 +10,8 @@ namespace BareMetalWeb.Data;
 public static class ModuleRegistry
 {
     private static volatile int _generation;
-    private static int _cachedGeneration = -1;
-    private static IReadOnlyList<ModuleInfo> _cachedModules = Array.Empty<ModuleInfo>();
+    private static volatile int _cachedGeneration = -1;
+    private static volatile IReadOnlyList<ModuleInfo> _cachedModules = Array.Empty<ModuleInfo>();
     private static readonly object _cacheLock = new();
 
     /// <summary>Invalidate the module cache (call after module entity save).</summary>

--- a/BareMetalWeb.Data/SimdVectorMath.cs
+++ b/BareMetalWeb.Data/SimdVectorMath.cs
@@ -64,7 +64,7 @@ internal static class SimdVectorMath
         float dot   = DotProduct(a, b);
         float normA = DotProduct(a, a);
         float normB = DotProduct(b, b);
-        if (normA == 0f || normB == 0f) return 1f;
+        if (MathF.Abs(normA) < 1e-7f || MathF.Abs(normB) < 1e-7f) return 1f;
         return 1f - dot / MathF.Sqrt(normA * normB);
     }
 

--- a/BareMetalWeb.Host/McpRouteHandler.cs
+++ b/BareMetalWeb.Host/McpRouteHandler.cs
@@ -29,10 +29,10 @@ internal static class McpRouteHandler
     private const string ProtocolVersion = "2024-11-05";
     private const string ServerName = "BareMetalWeb";
 
-    private static volatile object? _cachedToolsList;
+    private static object? _cachedToolsList;
 
     /// <summary>Invalidates the cached tools list so the next request rebuilds it.</summary>
-    internal static void InvalidateToolsCache() => _cachedToolsList = null;
+    internal static void InvalidateToolsCache() => Volatile.Write(ref _cachedToolsList, null);
 
     // ── Entry point ───────────────────────────────────────────────────────────
 
@@ -158,11 +158,7 @@ internal static class McpRouteHandler
 
     private static object GetOrBuildToolsList()
     {
-        var cached = _cachedToolsList;
-        if (cached != null) return cached;
-        var tools = BuildToolsList();
-        _cachedToolsList = tools;
-        return tools;
+        return LazyInitializer.EnsureInitialized(ref _cachedToolsList, () => BuildToolsList())!;
     }
 
     private static object BuildToolsList()


### PR DESCRIPTION
- **#1183**: McpRouteHandler — replace racy double-checked locking with `LazyInitializer.EnsureInitialized`
- **#1184**: ModuleRegistry — make `_cachedGeneration` and `_cachedModules` volatile for ARM memory-ordering safety
- **#1191**: SimdVectorMath & DataScaffold — use epsilon comparison instead of `== 0f` for float checks

Closes #1183, closes #1184, closes #1191