### PR TITLE
fix: buffer/overflow safety checks across data layer

### DIFF
--- a/BareMetalWeb.Data/BinaryObjectSerializer.cs
+++ b/BareMetalWeb.Data/BinaryObjectSerializer.cs
@@ -1964,25 +1964,26 @@ public sealed class BinaryObjectSerializer : ISchemaAwareObjectSerializer
 
     private static void WritePrimitiveOrStruct(byte[] buffer, ref int offset, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.NonPublicFields)] Type fieldType, object? value)
     {
-        if (fieldType == typeof(byte))   { buffer[offset++] = (byte)(value ?? (byte)0); return; }
-        if (fieldType == typeof(sbyte))  { buffer[offset++] = unchecked((byte)(sbyte)(value ?? (sbyte)0)); return; }
-        if (fieldType == typeof(bool))   { buffer[offset++] = (bool)(value ?? false) ? (byte)1 : (byte)0; return; }
-        if (fieldType == typeof(short))  { BinaryPrimitives.WriteInt16LittleEndian(buffer.AsSpan(offset), (short)(value ?? (short)0)); offset += 2; return; }
-        if (fieldType == typeof(ushort)) { BinaryPrimitives.WriteUInt16LittleEndian(buffer.AsSpan(offset), (ushort)(value ?? (ushort)0)); offset += 2; return; }
-        if (fieldType == typeof(char))   { BinaryPrimitives.WriteUInt16LittleEndian(buffer.AsSpan(offset), (ushort)(char)(value ?? '\0')); offset += 2; return; }
-        if (fieldType == typeof(int))    { BinaryPrimitives.WriteInt32LittleEndian(buffer.AsSpan(offset), (int)(value ?? 0)); offset += 4; return; }
-        if (fieldType == typeof(uint))   { BinaryPrimitives.WriteUInt32LittleEndian(buffer.AsSpan(offset), (uint)(value ?? 0u)); offset += 4; return; }
-        if (fieldType == typeof(float))  { BinaryPrimitives.WriteInt32LittleEndian(buffer.AsSpan(offset), BitConverter.SingleToInt32Bits((float)(value ?? 0f))); offset += 4; return; }
-        if (fieldType == typeof(long))   { BinaryPrimitives.WriteInt64LittleEndian(buffer.AsSpan(offset), (long)(value ?? 0L)); offset += 8; return; }
-        if (fieldType == typeof(ulong))  { BinaryPrimitives.WriteUInt64LittleEndian(buffer.AsSpan(offset), (ulong)(value ?? 0UL)); offset += 8; return; }
-        if (fieldType == typeof(double)) { BinaryPrimitives.WriteInt64LittleEndian(buffer.AsSpan(offset), BitConverter.DoubleToInt64Bits((double)(value ?? 0.0))); offset += 8; return; }
+        if (fieldType == typeof(byte))   { if (offset + 1 > buffer.Length) throw new InvalidOperationException("Buffer overflow in blittable write"); buffer[offset++] = (byte)(value ?? (byte)0); return; }
+        if (fieldType == typeof(sbyte))  { if (offset + 1 > buffer.Length) throw new InvalidOperationException("Buffer overflow in blittable write"); buffer[offset++] = unchecked((byte)(sbyte)(value ?? (sbyte)0)); return; }
+        if (fieldType == typeof(bool))   { if (offset + 1 > buffer.Length) throw new InvalidOperationException("Buffer overflow in blittable write"); buffer[offset++] = (bool)(value ?? false) ? (byte)1 : (byte)0; return; }
+        if (fieldType == typeof(short))  { if (offset + 2 > buffer.Length) throw new InvalidOperationException("Buffer overflow in blittable write"); BinaryPrimitives.WriteInt16LittleEndian(buffer.AsSpan(offset), (short)(value ?? (short)0)); offset += 2; return; }
+        if (fieldType == typeof(ushort)) { if (offset + 2 > buffer.Length) throw new InvalidOperationException("Buffer overflow in blittable write"); BinaryPrimitives.WriteUInt16LittleEndian(buffer.AsSpan(offset), (ushort)(value ?? (ushort)0)); offset += 2; return; }
+        if (fieldType == typeof(char))   { if (offset + 2 > buffer.Length) throw new InvalidOperationException("Buffer overflow in blittable write"); BinaryPrimitives.WriteUInt16LittleEndian(buffer.AsSpan(offset), (ushort)(char)(value ?? '\0')); offset += 2; return; }
+        if (fieldType == typeof(int))    { if (offset + 4 > buffer.Length) throw new InvalidOperationException("Buffer overflow in blittable write"); BinaryPrimitives.WriteInt32LittleEndian(buffer.AsSpan(offset), (int)(value ?? 0)); offset += 4; return; }
+        if (fieldType == typeof(uint))   { if (offset + 4 > buffer.Length) throw new InvalidOperationException("Buffer overflow in blittable write"); BinaryPrimitives.WriteUInt32LittleEndian(buffer.AsSpan(offset), (uint)(value ?? 0u)); offset += 4; return; }
+        if (fieldType == typeof(float))  { if (offset + 4 > buffer.Length) throw new InvalidOperationException("Buffer overflow in blittable write"); BinaryPrimitives.WriteInt32LittleEndian(buffer.AsSpan(offset), BitConverter.SingleToInt32Bits((float)(value ?? 0f))); offset += 4; return; }
+        if (fieldType == typeof(long))   { if (offset + 8 > buffer.Length) throw new InvalidOperationException("Buffer overflow in blittable write"); BinaryPrimitives.WriteInt64LittleEndian(buffer.AsSpan(offset), (long)(value ?? 0L)); offset += 8; return; }
+        if (fieldType == typeof(ulong))  { if (offset + 8 > buffer.Length) throw new InvalidOperationException("Buffer overflow in blittable write"); BinaryPrimitives.WriteUInt64LittleEndian(buffer.AsSpan(offset), (ulong)(value ?? 0UL)); offset += 8; return; }
+        if (fieldType == typeof(double)) { if (offset + 8 > buffer.Length) throw new InvalidOperationException("Buffer overflow in blittable write"); BinaryPrimitives.WriteInt64LittleEndian(buffer.AsSpan(offset), BitConverter.DoubleToInt64Bits((double)(value ?? 0.0))); offset += 8; return; }
 
         // Nested blittable struct
         if (value is null)
         {
             var sz = ComputeBlittableSize(fieldType);
+            if (offset + sz > buffer.Length) throw new InvalidOperationException("Buffer overflow in blittable write");
             buffer.AsSpan(offset, sz).Clear();
-            offset += sz;
+            offset = checked(offset + sz);
             return;
         }
         var nestedFields = fieldType.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
@@ -2018,18 +2019,18 @@ public sealed class BinaryObjectSerializer : ISchemaAwareObjectSerializer
             var ft = fields[i].FieldType;
             object fieldValue;
 
-            if (ft == typeof(byte))        { fieldValue = buffer[offset++]; }
-            else if (ft == typeof(sbyte))  { fieldValue = unchecked((sbyte)buffer[offset++]); }
-            else if (ft == typeof(bool))   { fieldValue = buffer[offset++] != 0; }
-            else if (ft == typeof(short))  { fieldValue = BinaryPrimitives.ReadInt16LittleEndian(buffer.AsSpan(offset)); offset += 2; }
-            else if (ft == typeof(ushort)) { fieldValue = BinaryPrimitives.ReadUInt16LittleEndian(buffer.AsSpan(offset)); offset += 2; }
-            else if (ft == typeof(char))   { fieldValue = (char)BinaryPrimitives.ReadUInt16LittleEndian(buffer.AsSpan(offset)); offset += 2; }
-            else if (ft == typeof(int))    { fieldValue = BinaryPrimitives.ReadInt32LittleEndian(buffer.AsSpan(offset)); offset += 4; }
-            else if (ft == typeof(uint))   { fieldValue = BinaryPrimitives.ReadUInt32LittleEndian(buffer.AsSpan(offset)); offset += 4; }
-            else if (ft == typeof(float))  { fieldValue = BitConverter.Int32BitsToSingle(BinaryPrimitives.ReadInt32LittleEndian(buffer.AsSpan(offset))); offset += 4; }
-            else if (ft == typeof(long))   { fieldValue = BinaryPrimitives.ReadInt64LittleEndian(buffer.AsSpan(offset)); offset += 8; }
-            else if (ft == typeof(ulong))  { fieldValue = BinaryPrimitives.ReadUInt64LittleEndian(buffer.AsSpan(offset)); offset += 8; }
-            else if (ft == typeof(double)) { fieldValue = BitConverter.Int64BitsToDouble(BinaryPrimitives.ReadInt64LittleEndian(buffer.AsSpan(offset))); offset += 8; }
+            if (ft == typeof(byte))        { if (offset + 1 > buffer.Length) throw new InvalidOperationException("Buffer overflow in blittable read"); fieldValue = buffer[offset++]; }
+            else if (ft == typeof(sbyte))  { if (offset + 1 > buffer.Length) throw new InvalidOperationException("Buffer overflow in blittable read"); fieldValue = unchecked((sbyte)buffer[offset++]); }
+            else if (ft == typeof(bool))   { if (offset + 1 > buffer.Length) throw new InvalidOperationException("Buffer overflow in blittable read"); fieldValue = buffer[offset++] != 0; }
+            else if (ft == typeof(short))  { if (offset + 2 > buffer.Length) throw new InvalidOperationException("Buffer overflow in blittable read"); fieldValue = BinaryPrimitives.ReadInt16LittleEndian(buffer.AsSpan(offset)); offset += 2; }
+            else if (ft == typeof(ushort)) { if (offset + 2 > buffer.Length) throw new InvalidOperationException("Buffer overflow in blittable read"); fieldValue = BinaryPrimitives.ReadUInt16LittleEndian(buffer.AsSpan(offset)); offset += 2; }
+            else if (ft == typeof(char))   { if (offset + 2 > buffer.Length) throw new InvalidOperationException("Buffer overflow in blittable read"); fieldValue = (char)BinaryPrimitives.ReadUInt16LittleEndian(buffer.AsSpan(offset)); offset += 2; }
+            else if (ft == typeof(int))    { if (offset + 4 > buffer.Length) throw new InvalidOperationException("Buffer overflow in blittable read"); fieldValue = BinaryPrimitives.ReadInt32LittleEndian(buffer.AsSpan(offset)); offset += 4; }
+            else if (ft == typeof(uint))   { if (offset + 4 > buffer.Length) throw new InvalidOperationException("Buffer overflow in blittable read"); fieldValue = BinaryPrimitives.ReadUInt32LittleEndian(buffer.AsSpan(offset)); offset += 4; }
+            else if (ft == typeof(float))  { if (offset + 4 > buffer.Length) throw new InvalidOperationException("Buffer overflow in blittable read"); fieldValue = BitConverter.Int32BitsToSingle(BinaryPrimitives.ReadInt32LittleEndian(buffer.AsSpan(offset))); offset += 4; }
+            else if (ft == typeof(long))   { if (offset + 8 > buffer.Length) throw new InvalidOperationException("Buffer overflow in blittable read"); fieldValue = BinaryPrimitives.ReadInt64LittleEndian(buffer.AsSpan(offset)); offset += 8; }
+            else if (ft == typeof(ulong))  { if (offset + 8 > buffer.Length) throw new InvalidOperationException("Buffer overflow in blittable read"); fieldValue = BinaryPrimitives.ReadUInt64LittleEndian(buffer.AsSpan(offset)); offset += 8; }
+            else if (ft == typeof(double)) { if (offset + 8 > buffer.Length) throw new InvalidOperationException("Buffer overflow in blittable read"); fieldValue = BitConverter.Int64BitsToDouble(BinaryPrimitives.ReadInt64LittleEndian(buffer.AsSpan(offset))); offset += 8; }
             else
             {
                 // Nested blittable struct

--- a/BareMetalWeb.Data/BmwJsonReader.cs
+++ b/BareMetalWeb.Data/BmwJsonReader.cs
@@ -456,9 +456,11 @@ public static class BmwJsonReader
         {
             strEnd = ReadJsonString(json, pos, out var str);
             var byteCount = str.Length;
+            if (byteCount < 0 || byteCount > 100_000_000)
+                throw new InvalidOperationException("String length exceeds limit");
 
             // Encode: [nullable indicator?] + [int32 length] + [utf8 bytes]
-            var resultLen = (isNullable ? 1 : 0) + 4 + byteCount;
+            var resultLen = checked((isNullable ? 1 : 0) + 4 + byteCount);
             var result = new byte[resultLen];
             int off = 0;
             if (isNullable) result[off++] = 1;
@@ -472,7 +474,9 @@ public static class BmwJsonReader
         var valEnd = SkipJsonValue(json, pos);
         var raw = json[pos..valEnd];
         var rawLen = raw.Length;
-        var res = new byte[(isNullable ? 1 : 0) + 4 + rawLen];
+        if (rawLen < 0 || rawLen > 100_000_000)
+            throw new InvalidOperationException("String length exceeds limit");
+        var res = new byte[checked((isNullable ? 1 : 0) + 4 + rawLen)];
         int o = 0;
         if (isNullable) res[o++] = 1;
         BinaryPrimitives.WriteInt32LittleEndian(res.AsSpan(o), rawLen);

--- a/BareMetalWeb.Data/IndexStore.cs
+++ b/BareMetalWeb.Data/IndexStore.cs
@@ -638,6 +638,7 @@ public sealed class IndexStore
         if (hasFifth)
         {
             p3 += p2 + 1;
+            if (p3 + 1 > span.Length) return false;
             if (span[(p3 + 1)..].IndexOf('|') >= 0) return false; // too many parts
         }
 
@@ -651,8 +652,12 @@ public sealed class IndexStore
             return false;
         key = Decode(span[(p1 + 1)..p2].ToString());
         id = Decode(span[(p2 + 1)..(hasFifth ? p3 : span.Length)].ToString());
-        if (hasFifth && long.TryParse(span[(p3 + 1)..], out var exp))
-            expiresAtUtcTicks = exp;
+        if (hasFifth)
+        {
+            if (p3 + 1 > span.Length) return false;
+            if (long.TryParse(span[(p3 + 1)..], out var exp))
+                expiresAtUtcTicks = exp;
+        }
         return true;
     }
 
@@ -874,6 +879,7 @@ public sealed class IndexStore
         var span = line.AsSpan();
         int sep = span.IndexOf('|');
         if (sep < 0) return false;
+        if (sep + 1 > span.Length) return false;
         if (span[(sep + 1)..].IndexOf('|') >= 0) return false;
 
         entityName = Decode(span[..sep].ToString());
@@ -1013,13 +1019,17 @@ public sealed class IndexStore
         if (hasThird)
         {
             sep2 += sep1 + 1;
+            if (sep2 + 1 > span.Length) return false;
             if (span[(sep2 + 1)..].IndexOf('|') >= 0) return false;
         }
 
         key = Decode(span[..sep1].ToString());
         id = Decode(span[(sep1 + 1)..(hasThird ? sep2 : span.Length)].ToString());
         if (hasThird)
+        {
+            if (sep2 + 1 > span.Length) return false;
             long.TryParse(span[(sep2 + 1)..], out expiresAtUtcTicks);
+        }
         return true;
     }
     private static string Encode(string value)

--- a/BareMetalWeb.Data/SynchronousEncryption.cs
+++ b/BareMetalWeb.Data/SynchronousEncryption.cs
@@ -69,7 +69,8 @@ public sealed class SynchronousEncryption : ISynchronousEncryption
         using var aes = new AesGcm(_key, TagSize);
         aes.Encrypt(nonce, plaintext, ciphertext, tag, associatedData);
 
-        var payload = new byte[1 + NonceSize + TagSize + ciphertext.Length];
+        int payloadSize = checked(1 + NonceSize + TagSize + ciphertext.Length);
+        var payload = new byte[payloadSize];
         payload[0] = FormatVersion;
         nonce.CopyTo(payload.AsSpan(1));
         tag.CopyTo(payload.AsSpan(1 + NonceSize));

--- a/BareMetalWeb.Data/WalDataProvider.cs
+++ b/BareMetalWeb.Data/WalDataProvider.cs
@@ -1625,7 +1625,9 @@ public sealed class WalDataProvider : IDataProvider, IRawBinaryProvider, IDispos
             if (BinaryPrimitives.ReadUInt32LittleEndian(span)        != IdMapMagic)   return map;
             if (BinaryPrimitives.ReadUInt16LittleEndian(span[4..])   != IdMapVersion) return map;
 
-            int entryCount = (int)BinaryPrimitives.ReadUInt32LittleEndian(span[8..]);
+            uint rawCount = BinaryPrimitives.ReadUInt32LittleEndian(span[8..]);
+            if (rawCount > (uint)((bytes.Length - 16) / 12)) return map;
+            int entryCount = (int)rawCount;
 
             // Verify CRC over everything except the trailing 4-byte CRC field
             uint storedCrc   = BinaryPrimitives.ReadUInt32LittleEndian(span[^4..]);

--- a/BareMetalWeb.Data/WalSegmentReader.cs
+++ b/BareMetalWeb.Data/WalSegmentReader.cs
@@ -159,11 +159,12 @@ internal static class WalSegmentReader
 
                         ulong key           = BinaryPrimitives.ReadUInt64LittleEndian(span[off..]);
                         uint  compressedLen = BinaryPrimitives.ReadUInt32LittleEndian(span[(off + 32)..]);
+                        if (compressedLen > int.MaxValue - 44) { corrupt = true; break; }
                         off += 44;
 
                         result[key] = (uint)recordStart;
 
-                        off += (int)compressedLen;
+                        off = checked(off + (int)compressedLen);
                         if (off > span.Length) { corrupt = true; break; }
                     }
                     if (corrupt) break;

--- a/BareMetalWeb.Data/WalStore.cs
+++ b/BareMetalWeb.Data/WalStore.cs
@@ -28,6 +28,9 @@ public sealed class WalStore : IDisposable
     /// <summary>Default maximum segment size before rotating to a new segment (64 MiB).</summary>
     public const uint DefaultMaxSegmentBytes = 64u * 1024u * 1024u;
 
+    /// <summary>Maximum allowed compressed payload size (100 MB) to prevent OOM from corrupt data.</summary>
+    private const int MaxPayloadSize = 100_000_000;
+
     private readonly string _directory;
     private readonly uint   _maxSegmentBytes;
     private readonly object _writeLock = new();
@@ -759,6 +762,7 @@ public sealed class WalStore : IDisposable
                 }
                 else
                 {
+                    if (compressedLen > MaxPayloadSize) return false;
                     if (off + compressedLen > span.Length) return false;
                     // Keep raw compressed payload — avoids decompress/recompress round-trip
                     payload = span.Slice(off, (int)compressedLen).ToArray();
@@ -834,10 +838,12 @@ public sealed class WalStore : IDisposable
                 uint   uncompressedLen = BinaryPrimitives.ReadUInt32LittleEndian(span[(off + 28)..]);
                 uint   compressedLen  = BinaryPrimitives.ReadUInt32LittleEndian(span[(off + 32)..]);
                 uint   flags          = BinaryPrimitives.ReadUInt32LittleEndian(span[(off + 36)..]);
+                if (compressedLen > int.MaxValue - 44) return false;
                 off += 44;
 
                 if (key == targetKey)
                 {
+                    if (compressedLen > MaxPayloadSize) return false;
                     if (off + compressedLen > span.Length) return false;
 
                     byte[] rawPayload = compressedLen > 0
@@ -858,7 +864,7 @@ public sealed class WalStore : IDisposable
                     return true;
                 }
 
-                off += (int)compressedLen;
+                off = checked(off + (int)compressedLen);
                 if (off > span.Length) return false;
             }
 
@@ -950,6 +956,7 @@ public sealed class WalStore : IDisposable
                         $"Unknown WAL op codec 0x{codec:X4} for key 0x{key:X16}.");
 
                 if (compressedLen == 0) { payload = ReadOnlyMemory<byte>.Empty; return true; }
+                if (compressedLen > MaxPayloadSize) return false;
                 if (off + compressedLen > span.Length) return false;
 
                 var raw = span.Slice(off, (int)compressedLen).ToArray();
@@ -957,7 +964,8 @@ public sealed class WalStore : IDisposable
                 return true;
             }
 
-            off += 44 + (int)compressedLen;
+            if (compressedLen > int.MaxValue - 44) return false;
+            off = checked(off + 44 + (int)compressedLen);
             if (off > span.Length) return false;
         }
 


### PR DESCRIPTION
## Summary

Adds bounds checks, overflow validation, and payload size limits across 7 files in BareMetalWeb.Data to prevent buffer overflows and OOM attacks from malformed data.

### Changes
- **WalSegmentReader.cs** (#1153): Validate `compressedLen` before `uint→int` cast, use `checked` arithmetic
- **WalStore.cs** (#1153, #1159): Add `MaxPayloadSize` (100MB) limit before `.ToArray()`, validate `compressedLen` overflow on offset arithmetic
- **IndexStore.cs** (#1154): Add bounds checks before span slicing in `TryParseRawEntry`, `TryParseSnapshotLine`, `TryParseRegistryEntry`
- **SynchronousEncryption.cs** (#1155): Use `checked()` for payload buffer size calculation
- **BinaryObjectSerializer.cs** (#1156): Add bounds checks before every blittable struct read/write
- **BmwJsonReader.cs** (#1157): Validate string length limit (100MB) and use `checked()` in `ParseStringValue`
- **WalDataProvider.cs** (#1158): Validate `entryCount` against actual file size in `LoadIdMapCore`

Closes #1153, closes #1154, closes #1155, closes #1156, closes #1157, closes #1158, closes #1159