### PR TITLE
fix: consolidate HttpClient, add LookupCache size limit, cache reflection

### DIFF
--- a/BareMetalWeb.Data/DataScaffold.cs
+++ b/BareMetalWeb.Data/DataScaffold.cs
@@ -166,6 +166,8 @@ public static class DataScaffold
 
     // Max number of entries in LookupCache before expired entries are pruned.
     private const int LookupCacheMaxSize = 500;
+    // Hard upper bound — if the cache exceeds this after pruning, clear it entirely.
+    private const int MaxLookupCacheEntries = 10_000;
     // Minimum ticks between successive LookupCache prune sweeps (60 seconds).
     private static readonly long LookupCachePruneCooldownTicks = TimeSpan.FromSeconds(60).Ticks;
     private static long _lastLookupCachePruneTicks;
@@ -2205,6 +2207,11 @@ public static class DataScaffold
             if (kv.Value.ExpiresUtc <= now)
                 LookupCache.TryRemove(kv.Key, out _);
         }
+
+        // Hard size limit — if still over capacity after expiry pruning, clear entirely.
+        // The cache will repopulate on demand.
+        if (LookupCache.Count > MaxLookupCacheEntries)
+            LookupCache.Clear();
     }
 
     /// <summary>

--- a/BareMetalWeb.Host/NotificationService.cs
+++ b/BareMetalWeb.Host/NotificationService.cs
@@ -10,6 +10,12 @@ using BareMetalWeb.Runtime;
 
 namespace BareMetalWeb.Host;
 
+/// <summary>Shared HttpClient for webhook-based notification channels.</summary>
+internal static class SharedWebhookHttpClient
+{
+    internal static readonly HttpClient Instance = new() { Timeout = TimeSpan.FromSeconds(30) };
+}
+
 /// <summary>
 /// Pluggable notification channel interface. Implementations deliver
 /// messages via Email, SMS, or other transports.
@@ -55,8 +61,6 @@ public sealed class WebhookSmsChannel : INotificationChannel
     private readonly string _endpoint;
     private readonly string _apiKey;
     private readonly string _from;
-    private static readonly HttpClient _http = new() { Timeout = TimeSpan.FromSeconds(30) };
-
     public WebhookSmsChannel(string endpoint, string apiKey, string from)
     {
         _endpoint = endpoint;
@@ -77,7 +81,7 @@ public sealed class WebhookSmsChannel : INotificationChannel
             Content = new StringContent(payload, Encoding.UTF8, "application/json")
         };
         request.Headers.TryAddWithoutValidation("Authorization", $"Bearer {_apiKey}");
-        await _http.SendAsync(request, ct);
+        await SharedWebhookHttpClient.Instance.SendAsync(request, ct);
     }
 }
 
@@ -89,8 +93,6 @@ public sealed class WebhookNotificationChannel : INotificationChannel
 {
     private readonly string _endpoint;
     private readonly string _secret;
-    private static readonly HttpClient _http = new() { Timeout = TimeSpan.FromSeconds(30) };
-
     public WebhookNotificationChannel(string endpoint, string secret)
     {
         _endpoint = endpoint;
@@ -112,7 +114,7 @@ public sealed class WebhookNotificationChannel : INotificationChannel
         };
         if (!string.IsNullOrEmpty(_secret))
             request.Headers.TryAddWithoutValidation("X-Webhook-Secret", _secret);
-        await _http.SendAsync(request, ct);
+        await SharedWebhookHttpClient.Instance.SendAsync(request, ct);
     }
 }
 

--- a/BareMetalWeb.Runtime/MetadataExtractor.cs
+++ b/BareMetalWeb.Runtime/MetadataExtractor.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Reflection;
 using BareMetalWeb.Core;
 using BareMetalWeb.Data;
@@ -29,6 +30,7 @@ public static class MetadataExtractor
     };
 
     private static readonly NullabilityInfoContext _nullabilityCtx = new();
+    private static readonly ConcurrentDictionary<Type, PropertyInfo[]> _propertyCache = new();
 
     /// <summary>
     /// Extracts an <see cref="EntityDefinition"/>, its <see cref="FieldDefinition"/>s,
@@ -82,7 +84,7 @@ public static class MetadataExtractor
         var indexes = new List<IndexDefinition>();
         var nullabilityCtx = new NullabilityInfoContext();
 
-        var properties = type.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+        var properties = _propertyCache.GetOrAdd(type, t => t.GetProperties(BindingFlags.Public | BindingFlags.Instance));
         Array.Sort(properties, (a, b) => string.CompareOrdinal(a.Name, b.Name));
 
         int ordinal = 1;


### PR DESCRIPTION
## Resource management improvements

**#1142 — NotificationService: consolidate static HttpClient instances**
Replaced two identical `HttpClient` fields in `WebhookSmsChannel` and `WebhookNotificationChannel` with a single shared `SharedWebhookHttpClient.Instance`.

**#1144 — DataScaffold: LookupCache hard size limit**
Added `MaxLookupCacheEntries = 10_000` constant. After expired-entry pruning, if the cache still exceeds this limit, it is cleared entirely (safe — repopulates on demand).

**#1146 — MetadataExtractor: cache GetProperties reflection**
Added a static `ConcurrentDictionary<Type, PropertyInfo[]>` cache so `GetProperties(BindingFlags.Public | BindingFlags.Instance)` is called at most once per type.

Closes #1142, closes #1144, closes #1146