### PR TITLE
Fix XML docs, JSON comments, epoch atomicity, and async blocking

### DIFF
--- a/BareMetalWeb.Data/BmwJsonReader.cs
+++ b/BareMetalWeb.Data/BmwJsonReader.cs
@@ -226,7 +226,7 @@ public static class BmwJsonReader
     /// </summary>
     private static (byte[] value, int endPos) ParseFieldValue(ReadOnlySpan<byte> json, int pos, FieldPlan fp)
     {
-        // Handle null
+        // Match JSON "null" literal byte-by-byte (avoids allocation)
         if (pos + 4 <= json.Length && json[pos] == (byte)'n' &&
             json[pos + 1] == (byte)'u' && json[pos + 2] == (byte)'l' && json[pos + 3] == (byte)'l')
         {
@@ -295,12 +295,14 @@ public static class BmwJsonReader
         bool val;
         int endPos;
 
+        // Match JSON "true" literal byte-by-byte
         if (pos + 4 <= json.Length && json[pos] == (byte)'t' &&
             json[pos + 1] == (byte)'r' && json[pos + 2] == (byte)'u' && json[pos + 3] == (byte)'e')
         {
             val = true;
             endPos = pos + 4;
         }
+        // Match JSON "false" literal byte-by-byte
         else if (pos + 5 <= json.Length && json[pos] == (byte)'f' &&
                  json[pos + 1] == (byte)'a' && json[pos + 2] == (byte)'l' &&
                  json[pos + 3] == (byte)'s' && json[pos + 4] == (byte)'e')
@@ -900,6 +902,7 @@ public static class BmwJsonReader
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static int SkipWhitespace(ReadOnlySpan<byte> json, int pos)
     {
+        // Skip JSON whitespace: space, tab, CR, LF
         while (pos < json.Length && (json[pos] == (byte)' ' || json[pos] == (byte)'\t' ||
                json[pos] == (byte)'\r' || json[pos] == (byte)'\n'))
             pos++;

--- a/BareMetalWeb.Data/CodecTable.cs
+++ b/BareMetalWeb.Data/CodecTable.cs
@@ -64,6 +64,7 @@ internal static class BoxedValues
 
 // ── Concrete Codecs ──
 
+/// <summary>Codec for <see cref="bool"/> values.</summary>
 public sealed class BoolCodec : IFieldCodec
 {
     public int FixedSize => 1;
@@ -77,6 +78,7 @@ public sealed class BoolCodec : IFieldCodec
     public string Format(object? value) => value?.ToString() ?? "";
 }
 
+/// <summary>Codec for <see cref="byte"/> values.</summary>
 public sealed class ByteCodec : IFieldCodec
 {
     public int FixedSize => 1;
@@ -88,6 +90,7 @@ public sealed class ByteCodec : IFieldCodec
     public string Format(object? value) => value?.ToString() ?? "";
 }
 
+/// <summary>Codec for <see cref="sbyte"/> values.</summary>
 public sealed class SByteCodec : IFieldCodec
 {
     public int FixedSize => 1;
@@ -99,6 +102,7 @@ public sealed class SByteCodec : IFieldCodec
     public string Format(object? value) => value?.ToString() ?? "";
 }
 
+/// <summary>Codec for <see cref="short"/> values.</summary>
 public sealed class Int16Codec : IFieldCodec
 {
     public int FixedSize => 2;
@@ -110,6 +114,7 @@ public sealed class Int16Codec : IFieldCodec
     public string Format(object? value) => value?.ToString() ?? "";
 }
 
+/// <summary>Codec for <see cref="ushort"/> values.</summary>
 public sealed class UInt16Codec : IFieldCodec
 {
     public int FixedSize => 2;
@@ -121,6 +126,7 @@ public sealed class UInt16Codec : IFieldCodec
     public string Format(object? value) => value?.ToString() ?? "";
 }
 
+/// <summary>Codec for <see cref="int"/> values.</summary>
 public sealed class Int32Codec : IFieldCodec
 {
     public int FixedSize => 4;
@@ -132,6 +138,7 @@ public sealed class Int32Codec : IFieldCodec
     public string Format(object? value) => value?.ToString() ?? "";
 }
 
+/// <summary>Codec for <see cref="uint"/> values.</summary>
 public sealed class UInt32Codec : IFieldCodec
 {
     public int FixedSize => 4;
@@ -143,6 +150,7 @@ public sealed class UInt32Codec : IFieldCodec
     public string Format(object? value) => value?.ToString() ?? "";
 }
 
+/// <summary>Codec for <see cref="long"/> values.</summary>
 public sealed class Int64Codec : IFieldCodec
 {
     public int FixedSize => 8;
@@ -154,6 +162,7 @@ public sealed class Int64Codec : IFieldCodec
     public string Format(object? value) => value?.ToString() ?? "";
 }
 
+/// <summary>Codec for <see cref="ulong"/> values.</summary>
 public sealed class UInt64Codec : IFieldCodec
 {
     public int FixedSize => 8;
@@ -165,6 +174,7 @@ public sealed class UInt64Codec : IFieldCodec
     public string Format(object? value) => value?.ToString() ?? "";
 }
 
+/// <summary>Codec for <see cref="float"/> values.</summary>
 public sealed class Float32Codec : IFieldCodec
 {
     public int FixedSize => 4;
@@ -176,6 +186,7 @@ public sealed class Float32Codec : IFieldCodec
     public string Format(object? value) => value?.ToString() ?? "";
 }
 
+/// <summary>Codec for <see cref="double"/> values.</summary>
 public sealed class Float64Codec : IFieldCodec
 {
     public int FixedSize => 8;
@@ -187,6 +198,7 @@ public sealed class Float64Codec : IFieldCodec
     public string Format(object? value) => value?.ToString() ?? "";
 }
 
+/// <summary>Codec for <see cref="decimal"/> values.</summary>
 public sealed class DecimalCodec : IFieldCodec
 {
     public int FixedSize => 16;
@@ -213,6 +225,7 @@ public sealed class DecimalCodec : IFieldCodec
     public string Format(object? value) => value?.ToString() ?? "";
 }
 
+/// <summary>Codec for <see cref="char"/> values.</summary>
 public sealed class CharCodec : IFieldCodec
 {
     public int FixedSize => 2;
@@ -224,6 +237,7 @@ public sealed class CharCodec : IFieldCodec
     public string Format(object? value) => value?.ToString() ?? "";
 }
 
+/// <summary>Codec for <see cref="DateOnly"/> values.</summary>
 public sealed class DateOnlyCodec : IFieldCodec
 {
     public int FixedSize => 4;
@@ -235,6 +249,7 @@ public sealed class DateOnlyCodec : IFieldCodec
     public string Format(object? value) => value is DateOnly d ? d.ToString("O") : "";
 }
 
+/// <summary>Codec for <see cref="DateTime"/> values.</summary>
 public sealed class DateTimeCodec : IFieldCodec
 {
     public int FixedSize => 8;
@@ -246,6 +261,7 @@ public sealed class DateTimeCodec : IFieldCodec
     public string Format(object? value) => value is DateTime dt ? dt.ToString("O") : "";
 }
 
+/// <summary>Codec for <see cref="DateTimeOffset"/> values.</summary>
 public sealed class DateTimeOffsetCodec : IFieldCodec
 {
     public int FixedSize => 10; // 8 ticks + 2 offset minutes
@@ -268,6 +284,7 @@ public sealed class DateTimeOffsetCodec : IFieldCodec
     public string Format(object? value) => value is DateTimeOffset dto ? dto.ToString("O") : "";
 }
 
+/// <summary>Codec for <see cref="TimeOnly"/> values.</summary>
 public sealed class TimeOnlyCodec : IFieldCodec
 {
     public int FixedSize => 8;
@@ -279,6 +296,7 @@ public sealed class TimeOnlyCodec : IFieldCodec
     public string Format(object? value) => value is TimeOnly t ? t.ToString("O") : "";
 }
 
+/// <summary>Codec for <see cref="TimeSpan"/> values.</summary>
 public sealed class TimeSpanCodec : IFieldCodec
 {
     public int FixedSize => 8;
@@ -290,6 +308,7 @@ public sealed class TimeSpanCodec : IFieldCodec
     public string Format(object? value) => value is TimeSpan ts ? ts.ToString() : "";
 }
 
+/// <summary>Codec for <see cref="Guid"/> values.</summary>
 public sealed class GuidCodec : IFieldCodec
 {
     public int FixedSize => 16;
@@ -301,6 +320,7 @@ public sealed class GuidCodec : IFieldCodec
     public string Format(object? value) => value is Guid g ? g.ToString("D") : "";
 }
 
+/// <summary>Codec for <see cref="IdentifierValue"/> values.</summary>
 public sealed class IdentifierCodec : IFieldCodec
 {
     public int FixedSize => 16;
@@ -323,6 +343,7 @@ public sealed class IdentifierCodec : IFieldCodec
     public string Format(object? value) => value is IdentifierValue id ? id.ToString() : "";
 }
 
+/// <summary>Codec for <see cref="string"/> values (UTF-8 encoded).</summary>
 public sealed class StringCodec : IFieldCodec
 {
     public int FixedSize => 0; // variable-length
@@ -343,6 +364,7 @@ public sealed class StringCodec : IFieldCodec
     public string Format(object? value) => value?.ToString() ?? "";
 }
 
+/// <summary>Codec for <see cref="T:byte[]"/> values.</summary>
 public sealed class BytesCodec : IFieldCodec
 {
     public int FixedSize => 0; // variable-length
@@ -362,6 +384,7 @@ public sealed class BytesCodec : IFieldCodec
     public string Format(object? value) => value is byte[] b ? Convert.ToBase64String(b) : "";
 }
 
+/// <summary>Codec for enum values stored as <see cref="int"/>.</summary>
 public sealed class EnumInt32Codec : IFieldCodec
 {
     public int FixedSize => 4;

--- a/BareMetalWeb.Data/ComposableQueryPipeline.cs
+++ b/BareMetalWeb.Data/ComposableQueryPipeline.cs
@@ -142,6 +142,7 @@ public sealed class ComposableQueryPipeline
     private static IEnumerable<BaseDataObject> LoadAll(DataEntityMetadata meta, CancellationToken ct)
     {
         var task = meta.Handlers.QueryAsync(null, ct);
+        // TODO: convert to async
         var result = task.IsCompleted ? task.Result : task.AsTask().GetAwaiter().GetResult();
         return result.Cast<BaseDataObject>();
     }

--- a/BareMetalWeb.Data/DataScaffold.cs
+++ b/BareMetalWeb.Data/DataScaffold.cs
@@ -2271,6 +2271,7 @@ public static class DataScaffold
         if (meta != null)
         {
             var vt = meta.Handlers.QueryAsync(query, CancellationToken.None);
+            // TODO: convert to async
             return vt.IsCompleted ? (IEnumerable)vt.Result : (IEnumerable)vt.AsTask().GetAwaiter().GetResult();
         }
 
@@ -2285,6 +2286,7 @@ public static class DataScaffold
         if (meta != null)
         {
             var vt = meta.Handlers.CountAsync(query, CancellationToken.None);
+            // TODO: convert to async
             return vt.IsCompleted ? vt.Result : vt.AsTask().GetAwaiter().GetResult();
         }
 
@@ -2299,6 +2301,7 @@ public static class DataScaffold
         {
             var key = uint.Parse(id);
             var vt = meta.Handlers.LoadAsync(key, CancellationToken.None);
+            // TODO: convert to async
             return vt.IsCompleted ? vt.Result : vt.AsTask().GetAwaiter().GetResult();
         }
 

--- a/BareMetalWeb.Data/LeaseAuthority.cs
+++ b/BareMetalWeb.Data/LeaseAuthority.cs
@@ -60,6 +60,7 @@ public sealed class FileLeaseAuthority : ILeaseAuthority, IDisposable
     private readonly string _leaseFilePath;
     private readonly string _epochFilePath;
     private readonly TimeSpan _leaseDuration;
+    private readonly Lock _epochLock = new();
     private FileStream? _leaseFile;
     private long _epoch;
     private DateTime _leaseExpiryUtc;
@@ -75,7 +76,7 @@ public sealed class FileLeaseAuthority : ILeaseAuthority, IDisposable
     }
 
     public bool IsLeader => _leaseFile != null && DateTime.UtcNow < _leaseExpiryUtc;
-    public long CurrentEpoch => _epoch;
+    public long CurrentEpoch => Interlocked.Read(ref _epoch);
     public string InstanceId { get; }
 
     public ValueTask<bool> TryAcquireAsync(CancellationToken ct)
@@ -93,8 +94,8 @@ public sealed class FileLeaseAuthority : ILeaseAuthority, IDisposable
             writer.Write(InstanceId);
             writer.Flush();
 
-            // Increment epoch atomically (write to temp, then rename)
-            _epoch = IncrementEpoch();
+            // Increment epoch under lock to ensure atomic read-modify-write
+            Interlocked.Exchange(ref _epoch, IncrementEpoch());
             _leaseExpiryUtc = DateTime.UtcNow + _leaseDuration;
 
             return ValueTask.FromResult(true);
@@ -119,7 +120,7 @@ public sealed class FileLeaseAuthority : ILeaseAuthority, IDisposable
                         using var w = new StreamWriter(_leaseFile, leaveOpen: true);
                         w.Write(InstanceId);
                         w.Flush();
-                        _epoch = IncrementEpoch();
+                        Interlocked.Exchange(ref _epoch, IncrementEpoch());
                         _leaseExpiryUtc = DateTime.UtcNow + _leaseDuration;
                         return ValueTask.FromResult(true);
                     }
@@ -179,19 +180,22 @@ public sealed class FileLeaseAuthority : ILeaseAuthority, IDisposable
 
     private long IncrementEpoch()
     {
-        long epoch = 1;
-        try
+        lock (_epochLock)
         {
-            if (File.Exists(_epochFilePath))
-                epoch = long.Parse(File.ReadAllText(_epochFilePath).Trim()) + 1;
-        }
-        catch { /* start at 1 */ }
+            long epoch = 1;
+            try
+            {
+                if (File.Exists(_epochFilePath))
+                    epoch = long.Parse(File.ReadAllText(_epochFilePath).Trim()) + 1;
+            }
+            catch { /* start at 1 */ }
 
-        // Atomic write: temp file then rename (atomic on POSIX, near-atomic on Windows)
-        var tempPath = _epochFilePath + ".tmp";
-        File.WriteAllText(tempPath, epoch.ToString());
-        File.Move(tempPath, _epochFilePath, overwrite: true);
-        return epoch;
+            // Atomic write: temp file then rename (atomic on POSIX, near-atomic on Windows)
+            var tempPath = _epochFilePath + ".tmp";
+            File.WriteAllText(tempPath, epoch.ToString());
+            File.Move(tempPath, _epochFilePath, overwrite: true);
+            return epoch;
+        }
     }
 
     public void Dispose() => Demote();

--- a/BareMetalWeb.Host/ReportHtmlRenderer.cs
+++ b/BareMetalWeb.Host/ReportHtmlRenderer.cs
@@ -343,6 +343,7 @@ public static class ReportHtmlRenderer
         // Use capped query to avoid loading entire table; async-safe via Task.Run
         var distinct = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
         var queryDef = new BareMetalWeb.Data.QueryDefinition { Top = 10000 };
+        // TODO: convert to async
         var allItems = Task.Run(async () => await meta.Handlers.QueryAsync(queryDef, CancellationToken.None)).GetAwaiter().GetResult();
         foreach (var item in allItems)
         {

--- a/BareMetalWeb.Host/RouteRegistrationExtensions.cs
+++ b/BareMetalWeb.Host/RouteRegistrationExtensions.cs
@@ -782,7 +782,7 @@ public static class RouteRegistrationExtensions
                 var entitiesList = new List<object>();
                 foreach (var e in DataScaffold.Entities)
                 {
-                    if (!IsEntityAccessible(e, user, userPermissions)) continue;
+                    if (!await IsEntityAccessibleAsync(e, user, userPermissions).ConfigureAwait(false)) continue;
                     entitiesList.Add(new Dictionary<string, object?>
                     {
                         ["slug"]         = e.Slug,
@@ -1170,7 +1170,7 @@ public static class RouteRegistrationExtensions
 
     // ─── Private helpers ────────────────────────────────────────────────────────
 
-    private static bool IsEntityAccessible(DataEntityMetadata entity, User? user, string[] userPermissions)
+    private static async ValueTask<bool> IsEntityAccessibleAsync(DataEntityMetadata entity, User? user, string[] userPermissions)
     {
         var perms = entity.Permissions ?? string.Empty;
         if (string.IsNullOrWhiteSpace(perms) || string.Equals(perms, "Public", StringComparison.OrdinalIgnoreCase))
@@ -1205,8 +1205,8 @@ public static class RouteRegistrationExtensions
         // RBAC check via resolved permission set
         if (user != null)
         {
-            var resolved = PermissionResolver.ResolveAsync(user, CancellationToken.None)
-                .AsTask().GetAwaiter().GetResult();
+            var resolved = await PermissionResolver.ResolveAsync(user, CancellationToken.None)
+                .ConfigureAwait(false);
             if (resolved.CanAccess(entity.Slug))
                 return true;
         }
@@ -1812,7 +1812,7 @@ public static class RouteRegistrationExtensions
         var userPermissions = user?.Permissions ?? Array.Empty<string>();
 
         // Inline /meta/objects (and optionally /meta/{slug}) to eliminate client-side round-trips
-        var metaObjectsScript = TryBuildMetaObjectsScript(user, userPermissions, safeNonce);
+        var metaObjectsScript = await TryBuildMetaObjectsScriptAsync(user, userPermissions, safeNonce).ConfigureAwait(false);
         // For any /{slug}[/...] path, inline /meta/{slug} to eliminate the schema round-trip
         string? metaSlugScript = null;
         string? initialDataScript = null;
@@ -1889,14 +1889,14 @@ public static class RouteRegistrationExtensions
     /// list of entities accessible to the current user.
     /// Returns <c>null</c> on any error so the client falls back to normal API calls.
     /// </summary>
-    private static string? TryBuildMetaObjectsScript(User? user, string[] userPermissions, string safeNonce)
+    private static async Task<string?> TryBuildMetaObjectsScriptAsync(User? user, string[] userPermissions, string safeNonce)
     {
         try
         {
             var entitiesMetaList = new List<object>();
             foreach (var e in DataScaffold.Entities)
             {
-                if (!IsEntityAccessible(e, user, userPermissions)) continue;
+                if (!await IsEntityAccessibleAsync(e, user, userPermissions).ConfigureAwait(false)) continue;
                 entitiesMetaList.Add(new Dictionary<string, object?>
                 {
                     ["slug"]         = e.Slug,
@@ -1914,8 +1914,8 @@ public static class RouteRegistrationExtensions
             bool hasElevated = false;
             if (user != null)
             {
-                var resolved = PermissionResolver.ResolveAsync(user, CancellationToken.None)
-                    .AsTask().GetAwaiter().GetResult();
+                var resolved = await PermissionResolver.ResolveAsync(user, CancellationToken.None)
+                    .ConfigureAwait(false);
                 hasElevated = resolved.HasElevatedPermissions;
             }
 

--- a/BareMetalWeb.Host/ScheduledActionService.cs
+++ b/BareMetalWeb.Host/ScheduledActionService.cs
@@ -163,7 +163,7 @@ public sealed class ScheduledActionService
             new QueryDefinition
             {
                 Clauses = { new QueryClause { Field = "EntityId", Operator = QueryOperator.Equals, Value = entityId } }
-            }, CancellationToken.None).GetAwaiter().GetResult();
+            }, CancellationToken.None).GetAwaiter().GetResult(); // TODO: convert to async
 
         BareMetalWeb.Runtime.EntityDefinition? def = null;
         foreach (var d in defs)


### PR DESCRIPTION
## Summary

Addresses four issues in a single batch:

- **#1135**: Added XML doc summaries to all 24 codec classes in `CodecTable.cs`
- **#1137**: Added inline comments to byte-by-byte JSON literal comparisons in `BmwJsonReader.cs`
- **#1139**: Made `FileLeaseAuthority.IncrementEpoch()` atomic with a `Lock` and `Interlocked` for the `_epoch` field
- **#1188**: Converted `IsEntityAccessible` and `TryBuildMetaObjectsScript` to async, eliminating `.GetAwaiter().GetResult()` from hot-path `PermissionResolver` calls. Added TODO markers for remaining sync-over-async sites.

Closes #1135, closes #1137, closes #1139, closes #1188