### PR TITLE
Fix SIMD alignment bug, perf enhancements, and JS cleanup

### DIFF
--- a/BareMetalWeb.Core/wwwroot/static/js/form-validation.js
+++ b/BareMetalWeb.Core/wwwroot/static/js/form-validation.js
@@ -4,25 +4,32 @@
     'use strict';
 
     function initFormValidation() {
-        var forms = document.querySelectorAll('form');
-        forms.forEach(function (form) {
+        // Use event delegation on document to avoid per-element listener accumulation
+        document.addEventListener('input', function (e) {
+            var input = e.target;
+            if (input.matches('form input, form select, form textarea')) {
+                validateField(input);
+            }
+        });
+        document.addEventListener('change', function (e) {
+            var input = e.target;
+            if (input.matches('form input, form select, form textarea')) {
+                validateField(input);
+            }
+        });
+        document.addEventListener('submit', function (e) {
+            var form = e.target;
+            if (!form.matches('form')) return;
+            var valid = true;
             var inputs = form.querySelectorAll('input, select, textarea');
             inputs.forEach(function (input) {
-                input.addEventListener('input', function () { validateField(input); });
-                input.addEventListener('change', function () { validateField(input); });
+                if (!validateField(input)) valid = false;
             });
-
-            form.addEventListener('submit', function (e) {
-                var valid = true;
-                inputs.forEach(function (input) {
-                    if (!validateField(input)) valid = false;
-                });
-                if (!valid) {
-                    e.preventDefault();
-                    e.stopPropagation();
-                }
-                form.classList.add('was-validated');
-            });
+            if (!valid) {
+                e.preventDefault();
+                e.stopPropagation();
+            }
+            form.classList.add('was-validated');
         });
     }
 

--- a/BareMetalWeb.Core/wwwroot/static/js/lookup-helper.js
+++ b/BareMetalWeb.Core/wwwroot/static/js/lookup-helper.js
@@ -30,10 +30,11 @@
             alert('Please allow popups for this site, or the create form will open in the same window.');
             window.location.href = createUrl;
         } else {
+            var attempts = 0;
             var checkWindow = setInterval(function() {
-                if (newWindow.closed) {
+                if (newWindow.closed || ++attempts > 120) {
                     clearInterval(checkWindow);
-                    refreshLookup(fieldName);
+                    if (newWindow.closed) refreshLookup(fieldName);
                 }
             }, 500);
         }

--- a/BareMetalWeb.Data/JsonWriterHelper.cs
+++ b/BareMetalWeb.Data/JsonWriterHelper.cs
@@ -6,6 +6,7 @@ internal static class DataJsonWriter
 {
     internal static string ToJsonString(object? value)
     {
+        // TODO: consider pooling MemoryStream via RecyclableMemoryStreamManager
         using var buffer = new MemoryStream();
         using (var w = new Utf8JsonWriter(buffer))
         {

--- a/BareMetalWeb.Data/SimdByteScanner.cs
+++ b/BareMetalWeb.Data/SimdByteScanner.cs
@@ -319,7 +319,8 @@ public static class SimdByteScanner
         int length = data.Length;
         if (length == 0) return -1;
 
-        var vecs = MemoryMarshal.Cast<byte, Vector128<byte>>(data);
+        int vectorizableLength = length & ~0xF; // Round down to 16-byte boundary
+        var vecs = MemoryMarshal.Cast<byte, Vector128<byte>>(data[..vectorizableLength]);
         Vector128<byte> needle = Vector128.Create(target);
 
         for (int k = 0; k < vecs.Length; k++)
@@ -338,7 +339,8 @@ public static class SimdByteScanner
             }
         }
 
-        for (int i = vecs.Length * 16; i < length; i++)
+        // Process remaining bytes beyond the 16-byte-aligned region
+        for (int i = vectorizableLength; i < length; i++)
         {
             if (data[i] == target) return i;
         }
@@ -351,7 +353,8 @@ public static class SimdByteScanner
         int length = data.Length;
         if (length == 0) return -1;
 
-        var vecs = MemoryMarshal.Cast<byte, Vector128<byte>>(data);
+        int vectorizableLength = length & ~0xF; // Round down to 16-byte boundary
+        var vecs = MemoryMarshal.Cast<byte, Vector128<byte>>(data[..vectorizableLength]);
         Vector128<byte> needleA = Vector128.Create(a);
         Vector128<byte> needleB = Vector128.Create(b);
 
@@ -373,7 +376,8 @@ public static class SimdByteScanner
             }
         }
 
-        for (int i = vecs.Length * 16; i < length; i++)
+        // Process remaining bytes beyond the 16-byte-aligned region
+        for (int i = vectorizableLength; i < length; i++)
         {
             byte v = data[i];
             if (v == a || v == b) return i;
@@ -388,7 +392,8 @@ public static class SimdByteScanner
         if (length == 0) return 0;
 
         int count = 0;
-        var vecs = MemoryMarshal.Cast<byte, Vector128<byte>>(data);
+        int vectorizableLength = length & ~0xF; // Round down to 16-byte boundary
+        var vecs = MemoryMarshal.Cast<byte, Vector128<byte>>(data[..vectorizableLength]);
         Vector128<byte> needle = Vector128.Create(target);
         // Each matching lane is 0xFF. We use subtraction from a zero accumulator:
         // 0 - 0xFF = wraps, so instead we just sum each chunk's scalar count.
@@ -405,7 +410,8 @@ public static class SimdByteScanner
             count += laneSum / 255;
         }
 
-        for (int i = vecs.Length * 16; i < length; i++)
+        // Process remaining bytes beyond the 16-byte-aligned region
+        for (int i = vectorizableLength; i < length; i++)
         {
             if (data[i] == target) count++;
         }

--- a/BareMetalWeb.Host/BareMetalWebExtensions.cs
+++ b/BareMetalWeb.Host/BareMetalWebExtensions.cs
@@ -69,7 +69,6 @@ public static class BareMetalWebExtensions
         DataScaffold.RegisterEntity<ViewDefinition>();
         DataScaffold.RegisterEntity<FileAttachment>();
         DataScaffold.RegisterEntity<RecordComment>();
-        DataScaffold.RegisterEntity<NotificationDefinition>();
         DataScaffold.RegisterEntity<InboxMessage>();
 
         IDataObjectStore dataStore = ProgramSetup.CreateDataStore(config, contentRoot, serializer, queryEvaluator, logger);
@@ -257,10 +256,10 @@ public static class BareMetalWebExtensions
         // disk I/O and per-request compression entirely.
         if (appInfo.StaticFiles.EnableInMemoryCache)
         {
-            StaticAssetCache.Build(
+            _ = Task.Run(() => StaticAssetCache.Build(
                 appInfo.StaticFiles.RootPathFull,
                 appInfo.StaticFiles,
-                msg => logger.LogInfo(msg));
+                msg => logger.LogInfo(msg)));
         }
 
         ProgramSetup.ConfigureCors(config, appInfo);

--- a/BareMetalWeb.Host/ProxyRouteHandler.cs
+++ b/BareMetalWeb.Host/ProxyRouteHandler.cs
@@ -1,4 +1,5 @@
 using BareMetalWeb.Core;
+using System.Buffers;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Security.Cryptography;
@@ -498,21 +499,28 @@ public sealed class ProxyRouteHandler
             ? (int)Math.Min(context.HttpRequest.ContentLength.Value, maxBytes)
             : 0);
 
-        var temp = new byte[81920];
-        int read;
-        int total = 0;
-        while ((read = await context.HttpRequest.Body.ReadAsync(temp, 0, temp.Length, context.RequestAborted)) > 0)
+        var temp = ArrayPool<byte>.Shared.Rent(81920);
+        try
         {
-            total += read;
-            if (total > maxBytes)
+            int read;
+            int total = 0;
+            while ((read = await context.HttpRequest.Body.ReadAsync(temp, 0, temp.Length, context.RequestAborted)) > 0)
             {
-                return null;
+                total += read;
+                if (total > maxBytes)
+                {
+                    return null;
+                }
+
+                buffer.Write(temp, 0, read);
             }
 
-            buffer.Write(temp, 0, read);
+            return buffer.ToArray();
         }
-
-        return buffer.ToArray();
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(temp);
+        }
     }
 
     private static List<ProxyTargetState> BuildTargetStates(ProxyRouteConfig route)

--- a/BareMetalWeb.Rendering/StaticHTMLFragments.cs
+++ b/BareMetalWeb.Rendering/StaticHTMLFragments.cs
@@ -386,7 +386,8 @@ public sealed class HtmlFragmentRenderer : IHtmlFragmentRenderer
 
             var groupLabel = WebUtility.HtmlEncode(option.Group);
             var menuAlignmentClass = rightAligned ? "dropdown-menu dropdown-menu-end" : "dropdown-menu";
-            var dropdownHtml = $"<li class=\"nav-item dropdown\"><a class=\"nav-link dropdown-toggle\" href=\"#\" role=\"button\" data-bs-toggle=\"dropdown\" aria-expanded=\"false\">{groupLabel}</a><ul class=\"{menuAlignmentClass}\">";
+            var sb = new StringBuilder();
+            sb.Append($"<li class=\"nav-item dropdown\"><a class=\"nav-link dropdown-toggle\" href=\"#\" role=\"button\" data-bs-toggle=\"dropdown\" aria-expanded=\"false\">{groupLabel}</a><ul class=\"{menuAlignmentClass}\">");
 
             string? lastSubGroup = null;
             foreach (var item in groupItems)
@@ -396,16 +397,17 @@ public sealed class HtmlFragmentRenderer : IHtmlFragmentRenderer
                     !string.Equals(item.SubGroup, lastSubGroup, StringComparison.OrdinalIgnoreCase))
                 {
                     if (lastSubGroup != null)
-                        dropdownHtml += "<li><hr class=\"dropdown-divider\"></li>";
-                    dropdownHtml += $"<li><h6 class=\"dropdown-header\">{WebUtility.HtmlEncode(item.SubGroup)}</h6></li>";
+                        sb.Append("<li><hr class=\"dropdown-divider\"></li>");
+                    sb.Append($"<li><h6 class=\"dropdown-header\">{WebUtility.HtmlEncode(item.SubGroup)}</h6></li>");
                     lastSubGroup = item.SubGroup;
                 }
                 var itemLabel = WebUtility.HtmlEncode(item.Label);
                 var itemHref = WebUtility.HtmlEncode(item.Href);
-                dropdownHtml += $"<li><a class=\"dropdown-item\" href=\"{itemHref}\">{itemLabel}</a></li>";
+                sb.Append($"<li><a class=\"dropdown-item\" href=\"{itemHref}\">{itemLabel}</a></li>");
             }
 
-            dropdownHtml += "</ul></li>";
+            sb.Append("</ul></li>");
+            var dropdownHtml = sb.ToString();
             buffer.Write(Encoding.UTF8.GetBytes(dropdownHtml));
         }
 

--- a/BareMetalWeb.Runtime/RuntimeEntityRegistry.cs
+++ b/BareMetalWeb.Runtime/RuntimeEntityRegistry.cs
@@ -164,7 +164,19 @@ public sealed class RuntimeEntityRegistry
         var registry = new RuntimeEntityRegistry();
 
         // Load all schema records in parallel
-        var entityDefs = new List<EntityDefinition>(await store.QueryAsync<EntityDefinition>().ConfigureAwait(false));
+        var entityDefsTask = store.QueryAsync<EntityDefinition>();
+        var fieldsTask = store.QueryAsync<FieldDefinition>();
+        var indexesTask = store.QueryAsync<IndexDefinition>();
+        var actionsTask = store.QueryAsync<ActionDefinition>();
+        var actionCommandsTask = store.QueryAsync<ActionCommandDefinition>();
+        await Task.WhenAll(
+            entityDefsTask.AsTask(),
+            fieldsTask.AsTask(),
+            indexesTask.AsTask(),
+            actionsTask.AsTask(),
+            actionCommandsTask.AsTask()).ConfigureAwait(false);
+
+        var entityDefs = new List<EntityDefinition>(entityDefsTask.Result);
         if (entityDefs.Count == 0)
         {
             registry.Freeze();
@@ -172,10 +184,10 @@ public sealed class RuntimeEntityRegistry
             return registry;
         }
 
-        var allFields = new List<FieldDefinition>(await store.QueryAsync<FieldDefinition>().ConfigureAwait(false));
-        var allIndexes = new List<IndexDefinition>(await store.QueryAsync<IndexDefinition>().ConfigureAwait(false));
-        var allActions = new List<ActionDefinition>(await store.QueryAsync<ActionDefinition>().ConfigureAwait(false));
-        var allActionCommands = new List<ActionCommandDefinition>(await store.QueryAsync<ActionCommandDefinition>().ConfigureAwait(false));
+        var allFields = new List<FieldDefinition>(fieldsTask.Result);
+        var allIndexes = new List<IndexDefinition>(indexesTask.Result);
+        var allActions = new List<ActionDefinition>(actionsTask.Result);
+        var allActionCommands = new List<ActionCommandDefinition>(actionCommandsTask.Result);
 
         foreach (var entityDef in entityDefs)
         {


### PR DESCRIPTION
## Changes

**Bug #1162** — SimdByteScanner: round data to 16-byte boundary before `MemoryMarshal.Cast<byte, Vector128<byte>>` to prevent alignment faults on unaligned tails; scalar fallback for remaining bytes.

**Enhancement #1145** — StaticHTMLFragments: replace `dropdownHtml +=` in loop with `StringBuilder`.

**Enhancement #1147** — ProxyRouteHandler: pool 80 KB buffer via `ArrayPool<byte>.Shared`; JsonWriterHelper: TODO for MemoryStream pooling.

**Enhancement #1148** — BareMetalWebExtensions: defer `StaticAssetCache.Build()` to `Task.Run` fire-and-forget.

**Enhancement #1149** — RuntimeEntityRegistry: parallelize 5 sequential `QueryAsync` calls with `Task.WhenAll`; remove duplicate `NotificationDefinition` registration.

**Enhancement #1189** — lookup-helper.js: add max-attempt counter (120 × 500ms = 60s) to `setInterval`.

**Enhancement #1190** — form-validation.js: replace per-element listeners with document-level event delegation.

Closes #1162, closes #1145, closes #1147, closes #1148, closes #1149, closes #1189, closes #1190