### PR TITLE
fix: CSRF validation and binary deserializer type resolution

### DIFF
--- a/BareMetalWeb.Data/BinaryObjectSerializer.cs
+++ b/BareMetalWeb.Data/BinaryObjectSerializer.cs
@@ -1311,6 +1311,15 @@ public sealed class BinaryObjectSerializer : ISchemaAwareObjectSerializer
             return resolved;
         }
 
+        // Cross-assembly resolution for core BCL types (e.g. System.String)
+        // Type.GetType handles assembly-qualified names across loaded assemblies.
+        resolved = Type.GetType(typeName, throwOnError: false, ignoreCase: false);
+        if (resolved != null)
+        {
+            KnownTypes.TryAdd(typeName, resolved);
+            return resolved;
+        }
+
         throw new InvalidOperationException($"Unable to resolve type '{typeName}'. Register it with BinaryObjectSerializer.RegisterKnownType<T>() at startup.");
     }
 

--- a/BareMetalWeb.Host/CsrfProtection.cs
+++ b/BareMetalWeb.Host/CsrfProtection.cs
@@ -92,24 +92,11 @@ public static class CsrfProtection
 
     private static bool FixedTimeEquals(string left, string right)
     {
-        // #1243: Use stackalloc to avoid per-request heap allocations
-        const int MaxStackSize = 256;
-        int leftByteCount = Encoding.UTF8.GetByteCount(left);
-        int rightByteCount = Encoding.UTF8.GetByteCount(right);
-        if (leftByteCount != rightByteCount)
+        var leftBytes = Encoding.UTF8.GetBytes(left);
+        var rightBytes = Encoding.UTF8.GetBytes(right);
+        if (leftBytes.Length != rightBytes.Length)
             return false;
 
-        if (leftByteCount > MaxStackSize)
-        {
-            var leftBytes = Encoding.UTF8.GetBytes(left);
-            var rightBytes = Encoding.UTF8.GetBytes(right);
-            return CryptographicOperations.FixedTimeEquals(leftBytes, rightBytes);
-        }
-
-        Span<byte> leftSpan = stackalloc byte[leftByteCount];
-        Span<byte> rightSpan = stackalloc byte[rightByteCount];
-        Encoding.UTF8.GetBytes(left, leftSpan);
-        Encoding.UTF8.GetBytes(right, rightSpan);
-        return CryptographicOperations.FixedTimeEquals(leftSpan, rightSpan);
+        return CryptographicOperations.FixedTimeEquals(leftBytes, rightBytes);
     }
 }


### PR DESCRIPTION
## Summary

Two critical bugs fixed that prevented setup from working:

### 1. CSRF FixedTimeEquals stackalloc regression
The stackalloc optimization from #1243 broke CSRF token validation, causing all form POSTs (including initial setup) to fail with 'Invalid security token'. Reverted to heap-based `Encoding.UTF8.GetBytes()` which works correctly.

### 2. BinaryObjectSerializer.ResolveType cross-assembly failure
`ResolveType` couldn't resolve types from other assemblies (e.g. `System.String` from `System.Private.CoreLib`). This caused ALL `Load<T>` calls to silently return null, making saved data invisible to queries. The setup form would 'succeed' (302 redirect) but the user was never findable.

Added `Type.GetType()` fallback for cross-assembly type resolution after the existing assembly-local check.

### Testing
- End-to-end: POST /setup → 302, GET / → 200 (no redirect), GET /health → healthy
- Data.Tests: 1373 passed (12 pre-existing failures, 2 fewer than before this fix)