### PR TITLE
feat: add ARM SVE/SVE2 SIMD tier to dictionary column filter

### DIFF
--- a/BareMetalWeb.Data/DictionaryColumnFilter.cs
+++ b/BareMetalWeb.Data/DictionaryColumnFilter.cs
@@ -2,6 +2,11 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.X86;
+#if NET9_0_OR_GREATER
+#pragma warning disable SYSLIB5003 // Sve is experimental
+using System.Runtime.Intrinsics.Arm;
+#pragma warning restore SYSLIB5003
+#endif
 
 namespace BareMetalWeb.Data;
 
@@ -11,10 +16,11 @@ namespace BareMetalWeb.Data;
 /// <para>Filters compare encoded dictionary indexes (small ints) instead of full values,
 /// enabling tens of millions of rows per second throughput.</para>
 ///
-/// <para>Pipeline tiers:
-///   1. <b>AVX2</b> — 8 × int32 per cycle via <c>Avx2.CompareEqual</c> + <c>Avx2.MoveMask</c>
-///   2. <b>Portable SIMD</b> — <c>Vector&lt;int&gt;</c> fallback (width auto-detected)
-///   3. <b>Scalar</b> — branchless loop for platforms without hardware SIMD
+/// <para>Pipeline tiers (dispatched at runtime based on CPU capabilities):
+///   1. <b>AVX2</b> (x86)  — 8 × int32 per cycle via <c>Avx2.CompareEqual</c> + <c>Avx2.MoveMask</c>
+///   2. <b>SVE</b>  (ARM)  — scalable-width vectors (128–2048 bit) with predicated tail handling
+///   3. <b>Portable SIMD</b> — <c>Vector&lt;int&gt;</c> fallback (width auto-detected)
+///   4. <b>Scalar</b> — branchless loop for platforms without hardware SIMD
 /// </para>
 /// </summary>
 public static class DictionaryColumnFilter
@@ -23,9 +29,6 @@ public static class DictionaryColumnFilter
     /// Scans <paramref name="encodedColumn"/> for entries equal to <paramref name="dictionaryIndex"/>
     /// and writes matching row positions into <paramref name="outputIndexes"/>.
     /// Returns the number of matches written.
-    ///
-    /// <para>Uses AVX2 when available (8 ints per cycle), then falls back to portable
-    /// <c>Vector&lt;int&gt;</c>, then scalar loop.</para>
     /// </summary>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int FilterEquals(
@@ -35,6 +38,13 @@ public static class DictionaryColumnFilter
     {
         if (Avx2.IsSupported)
             return FilterEqualsAvx2(encodedColumn, dictionaryIndex, outputIndexes);
+
+#if NET9_0_OR_GREATER
+#pragma warning disable SYSLIB5003
+        if (Sve.IsSupported)
+            return FilterEqualsSve(encodedColumn, dictionaryIndex, outputIndexes);
+#pragma warning restore SYSLIB5003
+#endif
 
         if (Vector.IsHardwareAccelerated && Vector<int>.Count >= 4)
             return FilterEqualsVector(encodedColumn, dictionaryIndex, outputIndexes);
@@ -53,6 +63,13 @@ public static class DictionaryColumnFilter
     {
         if (Avx2.IsSupported)
             return FilterNotEqualsAvx2(encodedColumn, dictionaryIndex, outputIndexes);
+
+#if NET9_0_OR_GREATER
+#pragma warning disable SYSLIB5003
+        if (Sve.IsSupported)
+            return FilterNotEqualsSve(encodedColumn, dictionaryIndex, outputIndexes);
+#pragma warning restore SYSLIB5003
+#endif
 
         if (Vector.IsHardwareAccelerated && Vector<int>.Count >= 4)
             return FilterNotEqualsVector(encodedColumn, dictionaryIndex, outputIndexes);
@@ -179,6 +196,92 @@ public static class DictionaryColumnFilter
 
         return count;
     }
+
+    // ── SVE path: scalable-width vectors with predicated tail handling ────
+
+#if NET9_0_OR_GREATER
+#pragma warning disable SYSLIB5003
+
+    /// <summary>
+    /// ARM SVE filter path. Processes a hardware-dependent number of int32 elements per
+    /// iteration (128–2048 bit vectors). Uses <c>CreateWhileLessThanMask32Bit</c> for
+    /// predicated tail handling, eliminating the scalar remainder loop entirely.
+    /// </summary>
+    private static unsafe int FilterEqualsSve(
+        ReadOnlySpan<int> encodedColumn,
+        int dictionaryIndex,
+        Span<int> outputIndexes)
+    {
+        int n = encodedColumn.Length;
+        int count = 0;
+        int vLen = (int)Sve.Count32BitElements();
+        var target = new Vector<int>(dictionaryIndex);
+
+        fixed (int* pCol = encodedColumn)
+        {
+            for (int i = 0; i < n; i += vLen)
+            {
+                // Predicate mask: active lanes where (i + lane) < n.
+                // Naturally handles the tail — no separate scalar loop needed.
+                var loopMask = Sve.CreateWhileLessThanMask32Bit(i, n);
+
+                // Reinterpret uint mask → int mask for signed LoadVector.
+                var intMask = Unsafe.As<Vector<uint>, Vector<int>>(ref loopMask);
+
+                // Predicated load: only active lanes read from memory.
+                var chunk = Sve.LoadVector(intMask, pCol + i);
+
+                // Compare each lane against the target dictionary index.
+                // Sve.CompareEqual returns a mask vector; AND with intMask
+                // to exclude inactive tail lanes.
+                var cmp = Sve.CompareEqual(chunk, target);
+                var matchMask = Vector.BitwiseAnd(intMask, cmp);
+
+                // Extract matching row positions by walking active lanes.
+                int end = Math.Min(vLen, n - i);
+                for (int j = 0; j < end; j++)
+                    if (Unsafe.Add(ref Unsafe.As<Vector<int>, int>(ref matchMask), j) != 0)
+                        outputIndexes[count++] = i + j;
+            }
+        }
+
+        return count;
+    }
+
+    private static unsafe int FilterNotEqualsSve(
+        ReadOnlySpan<int> encodedColumn,
+        int dictionaryIndex,
+        Span<int> outputIndexes)
+    {
+        int n = encodedColumn.Length;
+        int count = 0;
+        int vLen = (int)Sve.Count32BitElements();
+        var target = new Vector<int>(dictionaryIndex);
+
+        fixed (int* pCol = encodedColumn)
+        {
+            for (int i = 0; i < n; i += vLen)
+            {
+                var loopMask = Sve.CreateWhileLessThanMask32Bit(i, n);
+                var intMask = Unsafe.As<Vector<uint>, Vector<int>>(ref loopMask);
+                var chunk = Sve.LoadVector(intMask, pCol + i);
+
+                // CompareNotEqualTo returns mask of lanes where chunk != target.
+                var cmp = Sve.CompareNotEqualTo(chunk, target);
+                var matchMask = Vector.BitwiseAnd(intMask, cmp);
+
+                int end = Math.Min(vLen, n - i);
+                for (int j = 0; j < end; j++)
+                    if (Unsafe.Add(ref Unsafe.As<Vector<int>, int>(ref matchMask), j) != 0)
+                        outputIndexes[count++] = i + j;
+            }
+        }
+
+        return count;
+    }
+
+#pragma warning restore SYSLIB5003
+#endif
 
     // ── Portable Vector<int> path ──────────────────────────────────────────
 

--- a/BareMetalWeb.Data/SimdCapabilities.cs
+++ b/BareMetalWeb.Data/SimdCapabilities.cs
@@ -38,6 +38,8 @@ public sealed class SimdCapabilities
     public bool ArmAes      { get; }
     public bool ArmSha256   { get; }
     public bool ArmDp       { get; }
+    public bool Sve         { get; }
+    public bool Sve2        { get; }
 
     /// <summary>
     /// Highest-performance SIMD tier available on this CPU/OS combination.
@@ -70,6 +72,12 @@ public sealed class SimdCapabilities
         ArmAes       = System.Runtime.Intrinsics.Arm.Aes.IsSupported;
         ArmSha256    = System.Runtime.Intrinsics.Arm.Sha256.IsSupported;
         ArmDp        = System.Runtime.Intrinsics.Arm.Dp.IsSupported;
+#if NET9_0_OR_GREATER
+#pragma warning disable SYSLIB5003
+        Sve          = System.Runtime.Intrinsics.Arm.Sve.IsSupported;
+        Sve2         = Sve && IsSve2Supported();
+#pragma warning restore SYSLIB5003
+#endif
 
         BestTier = DetermineBestTier();
 #else
@@ -103,6 +111,8 @@ public sealed class SimdCapabilities
         if (Bmi2) x86Parts.Append("BMI2 ");
 
         var armParts = new System.Text.StringBuilder();
+        if (Sve2) armParts.Append("SVE2 ");
+        else if (Sve) armParts.Append("SVE ");
         if (AdvSimdArm64) armParts.Append("AdvSimd/ARM64 ");
         else if (AdvSimd) armParts.Append("AdvSimd ");
         if (ArmCrc32) armParts.Append("CRC32 ");
@@ -123,6 +133,8 @@ public sealed class SimdCapabilities
         if (Fma && Avx2)      return "AVX2+FMA";
         if (Avx2)             return "AVX2";
         if (Avx)              return "AVX";
+        if (Sve2)             return "SVE2";
+        if (Sve)              return "SVE";
         if (AdvSimdArm64)     return "AdvSimd-ARM64";
         if (AdvSimd)          return "AdvSimd";
         if (Sse42)            return "SSE4.2";
@@ -131,4 +143,14 @@ public sealed class SimdCapabilities
 #endif
         return "Scalar";
     }
+
+#if NET9_0_OR_GREATER
+#pragma warning disable SYSLIB5003
+    private static bool IsSve2Supported()
+    {
+        try { return System.Runtime.Intrinsics.Arm.Sve2.IsSupported; }
+        catch { return false; }
+    }
+#pragma warning restore SYSLIB5003
+#endif
 }


### PR DESCRIPTION
Adds ARM SVE as a new SIMD tier to DictionaryColumnFilter, slotting between AVX2 and portable Vector<int>.

**DictionaryColumnFilter** - New SVE path using predicated loads (CreateWhileLessThanMask32Bit), CompareEqual/CompareNotEqualTo for filtering. Scalable vectors (128-2048 bit) with automatic tail handling - no scalar remainder loop.

**SimdCapabilities** - Detects SVE/SVE2 support, reports in BestTier and log output.

Dispatch: AVX2 > SVE > Vector<int> > Scalar. All 28 tests pass.