### PR TITLE
feat: BMW binary transport router with branch-free jump table dispatch

### DIFF
--- a/BareMetalWeb.Host.Tests/BmwBinaryTransportTests.cs
+++ b/BareMetalWeb.Host.Tests/BmwBinaryTransportTests.cs
@@ -1,0 +1,295 @@
+using System.Buffers.Binary;
+using BareMetalWeb.Host;
+
+namespace BareMetalWeb.Host.Tests;
+
+public class BmwBinaryTransportTests
+{
+    // ── Frame encoding/decoding ────────────────────────────────────────────
+
+    [Fact]
+    public void EncodeFrame_GET_Route0_Id0_ProducesCorrectBytes()
+    {
+        var buf = new byte[6];
+        BmwBinaryTransport.EncodeFrame(buf, BmwBinaryTransport.MethodGet, 0, 0);
+        BmwBinaryTransport.DecodeFrame(buf, out int opcode, out uint id);
+        Assert.Equal(0, opcode);
+        Assert.Equal(0u, id);
+    }
+
+    [Fact]
+    public void EncodeFrame_POST_Route42_Id12345_RoundTrips()
+    {
+        var buf = new byte[6];
+        BmwBinaryTransport.EncodeFrame(buf, BmwBinaryTransport.MethodPost, 42, 12345u);
+        BmwBinaryTransport.DecodeFrame(buf, out int opcode, out uint id);
+
+        Assert.Equal(BmwBinaryTransport.MethodPost, BmwBinaryTransport.GetMethod(opcode));
+        Assert.Equal(42, BmwBinaryTransport.GetRoute(opcode));
+        Assert.Equal(12345u, id);
+    }
+
+    [Fact]
+    public void EncodeFrame_AllMethods_RoundTrip()
+    {
+        for (int m = 0; m < 6; m++)
+        {
+            var buf = new byte[6];
+            BmwBinaryTransport.EncodeFrame(buf, m, 100, 999u);
+            BmwBinaryTransport.DecodeFrame(buf, out int opcode, out uint id);
+
+            Assert.Equal(m, BmwBinaryTransport.GetMethod(opcode));
+            Assert.Equal(100, BmwBinaryTransport.GetRoute(opcode));
+            Assert.Equal(999u, id);
+        }
+    }
+
+    [Fact]
+    public void EncodeFrame_MaxRoute_RoundTrips()
+    {
+        var buf = new byte[6];
+        int maxRoute = BmwBinaryTransport.MaxRoutes - 1; // 2047
+        BmwBinaryTransport.EncodeFrame(buf, BmwBinaryTransport.MethodGet, maxRoute, uint.MaxValue);
+        BmwBinaryTransport.DecodeFrame(buf, out int opcode, out uint id);
+
+        Assert.Equal(BmwBinaryTransport.MethodGet, BmwBinaryTransport.GetMethod(opcode));
+        Assert.Equal(maxRoute, BmwBinaryTransport.GetRoute(opcode));
+        Assert.Equal(uint.MaxValue, id);
+    }
+
+    [Fact]
+    public void DecodeFrame_ExactlySixBytes()
+    {
+        var buf = new byte[6];
+        BmwBinaryTransport.EncodeFrame(buf, BmwBinaryTransport.MethodDelete, 7, 42u);
+        // Should not throw with exactly 6 bytes
+        BmwBinaryTransport.DecodeFrame(buf.AsSpan(0, 6), out int opcode, out uint id);
+        Assert.Equal(7, BmwBinaryTransport.GetRoute(opcode));
+        Assert.Equal(42u, id);
+    }
+
+    // ── Payload length encoding ────────────────────────────────────────────
+
+    [Fact]
+    public void PayloadLength_Zero_RoundTrips()
+    {
+        var buf = new byte[3];
+        BmwBinaryTransport.EncodePayloadLength(buf, 0);
+        Assert.Equal(0, BmwBinaryTransport.DecodePayloadLength(buf));
+    }
+
+    [Fact]
+    public void PayloadLength_Max24Bit_RoundTrips()
+    {
+        var buf = new byte[3];
+        int maxLen = (1 << 24) - 1; // 16,777,215
+        BmwBinaryTransport.EncodePayloadLength(buf, maxLen);
+        Assert.Equal(maxLen, BmwBinaryTransport.DecodePayloadLength(buf));
+    }
+
+    [Fact]
+    public void PayloadLength_MidRange_RoundTrips()
+    {
+        var buf = new byte[3];
+        BmwBinaryTransport.EncodePayloadLength(buf, 65535);
+        Assert.Equal(65535, BmwBinaryTransport.DecodePayloadLength(buf));
+    }
+
+    // ── Method helpers ─────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(BmwBinaryTransport.MethodGet, false)]
+    [InlineData(BmwBinaryTransport.MethodHead, false)]
+    [InlineData(BmwBinaryTransport.MethodDelete, false)]
+    [InlineData(BmwBinaryTransport.MethodPost, true)]
+    [InlineData(BmwBinaryTransport.MethodPut, true)]
+    [InlineData(BmwBinaryTransport.MethodPatch, true)]
+    public void IsWriteMethod_CorrectForAllMethods(int method, bool expected)
+    {
+        Assert.Equal(expected, BmwBinaryTransport.IsWriteMethod(method));
+    }
+
+    // ── ParseMethodOrdinal ─────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("GET /foo", BmwBinaryTransport.MethodGet)]
+    [InlineData("HEAD /foo", BmwBinaryTransport.MethodHead)]
+    [InlineData("DELETE /foo", BmwBinaryTransport.MethodDelete)]
+    [InlineData("POST /foo", BmwBinaryTransport.MethodPost)]
+    [InlineData("PUT /foo", BmwBinaryTransport.MethodPut)]
+    [InlineData("PATCH /foo", BmwBinaryTransport.MethodPatch)]
+    [InlineData("ALL /foo", -1)]
+    [InlineData("", -1)]
+    [InlineData("X", -1)]
+    public void ParseMethodOrdinal_ReturnsCorrectOrdinal(string routeKey, int expected)
+    {
+        Assert.Equal(expected, BmwBinaryTransport.ParseMethodOrdinal(routeKey));
+    }
+
+    // ── Jump table registration ────────────────────────────────────────────
+
+    [Fact]
+    public void Register_HandlerIsAccessibleViaJumpTable()
+    {
+        var transport = new BmwBinaryTransport();
+        bool handlerCalled = false;
+
+        transport.Register(BmwBinaryTransport.MethodGet, 1,
+            (ctx, id, payload) => { handlerCalled = true; return ValueTask.CompletedTask; },
+            "GET /test");
+
+        Assert.True(transport.RegisteredHandlerCount >= 1);
+    }
+
+    [Fact]
+    public void Constructor_AllSlotsDefault404()
+    {
+        var transport = new BmwBinaryTransport();
+        Assert.Equal(0, transport.RegisteredHandlerCount);
+    }
+
+    [Fact]
+    public void RegisterEntity_RegistersFiveHandlers()
+    {
+        var transport = new BmwBinaryTransport();
+        var noop = new BmwBinaryTransport.BinaryHandler((ctx, id, payload) => ValueTask.CompletedTask);
+
+        transport.RegisterEntity(1, "products", noop, noop, noop, noop, noop);
+        // GET, POST, PUT, PATCH, DELETE, HEAD = 6 handlers (PATCH shares with PUT handler)
+        Assert.Equal(6, transport.RegisteredHandlerCount);
+    }
+
+    [Fact]
+    public void GetRouteName_ReturnsRegisteredName()
+    {
+        var transport = new BmwBinaryTransport();
+        var noop = new BmwBinaryTransport.BinaryHandler((ctx, id, payload) => ValueTask.CompletedTask);
+
+        transport.Register(BmwBinaryTransport.MethodGet, 5, noop, "GET /products");
+        Assert.Equal("GET /products", transport.GetRouteName(5));
+    }
+
+    [Fact]
+    public void GetRouteName_UnregisteredRoute_ReturnsNull()
+    {
+        var transport = new BmwBinaryTransport();
+        Assert.Null(transport.GetRouteName(999));
+    }
+
+    [Fact]
+    public void GetRouteName_OutOfRange_ReturnsNull()
+    {
+        var transport = new BmwBinaryTransport();
+        Assert.Null(transport.GetRouteName(-1));
+        Assert.Null(transport.GetRouteName(BmwBinaryTransport.MaxRoutes));
+    }
+
+    // ── Opcode composition ─────────────────────────────────────────────────
+
+    [Fact]
+    public void Opcode_MethodAndRoute_AreIndependent()
+    {
+        // Verify method and route bits don't overlap
+        for (int m = 0; m < 6; m++)
+        {
+            for (int r = 0; r < 10; r++)
+            {
+                var buf = new byte[6];
+                BmwBinaryTransport.EncodeFrame(buf, m, r, 0);
+                BmwBinaryTransport.DecodeFrame(buf, out int opcode, out _);
+
+                Assert.Equal(m, BmwBinaryTransport.GetMethod(opcode));
+                Assert.Equal(r, BmwBinaryTransport.GetRoute(opcode));
+            }
+        }
+    }
+
+    [Fact]
+    public void JumpTableSize_Is16384()
+    {
+        Assert.Equal(16384, BmwBinaryTransport.JumpTableSize);
+    }
+
+    [Fact]
+    public void FrameSize_Is6()
+    {
+        Assert.Equal(6, BmwBinaryTransport.FrameSize);
+    }
+
+    [Fact]
+    public void MaxRoutes_Is2048()
+    {
+        Assert.Equal(2048, BmwBinaryTransport.MaxRoutes);
+    }
+
+    // ── Edge cases ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void EncodeFrame_EntityId_Zero_RoundTrips()
+    {
+        var buf = new byte[6];
+        BmwBinaryTransport.EncodeFrame(buf, BmwBinaryTransport.MethodGet, 1, 0u);
+        BmwBinaryTransport.DecodeFrame(buf, out _, out uint id);
+        Assert.Equal(0u, id);
+    }
+
+    [Fact]
+    public void EncodeFrame_EntityId_MaxUint32_RoundTrips()
+    {
+        var buf = new byte[6];
+        BmwBinaryTransport.EncodeFrame(buf, BmwBinaryTransport.MethodGet, 1, uint.MaxValue);
+        BmwBinaryTransport.DecodeFrame(buf, out _, out uint id);
+        Assert.Equal(uint.MaxValue, id);
+    }
+
+    [Fact]
+    public void EncodeFrame_EntityId_OneMillionRoundTrips()
+    {
+        var buf = new byte[6];
+        BmwBinaryTransport.EncodeFrame(buf, BmwBinaryTransport.MethodPost, 500, 1_000_000u);
+        BmwBinaryTransport.DecodeFrame(buf, out int opcode, out uint id);
+        Assert.Equal(BmwBinaryTransport.MethodPost, BmwBinaryTransport.GetMethod(opcode));
+        Assert.Equal(500, BmwBinaryTransport.GetRoute(opcode));
+        Assert.Equal(1_000_000u, id);
+    }
+
+    [Fact]
+    public void PayloadLength_Various_RoundTrip()
+    {
+        int[] testValues = [0, 1, 255, 256, 65535, 65536, 1_000_000, (1 << 24) - 1];
+        foreach (var val in testValues)
+        {
+            var buf = new byte[3];
+            BmwBinaryTransport.EncodePayloadLength(buf, val);
+            Assert.Equal(val, BmwBinaryTransport.DecodePayloadLength(buf));
+        }
+    }
+
+    [Fact]
+    public void Register_OverwritesPreviousHandler()
+    {
+        var transport = new BmwBinaryTransport();
+        int callCount = 0;
+
+        transport.Register(BmwBinaryTransport.MethodGet, 1,
+            (ctx, id, payload) => { callCount = 1; return ValueTask.CompletedTask; });
+        transport.Register(BmwBinaryTransport.MethodGet, 1,
+            (ctx, id, payload) => { callCount = 2; return ValueTask.CompletedTask; });
+
+        // Still only 1 registered handler at that slot
+        Assert.Equal(1, transport.RegisteredHandlerCount);
+    }
+
+    [Fact]
+    public void MultipleMethodsSameRoute_AreIndependent()
+    {
+        var transport = new BmwBinaryTransport();
+        var noop = new BmwBinaryTransport.BinaryHandler((ctx, id, payload) => ValueTask.CompletedTask);
+
+        transport.Register(BmwBinaryTransport.MethodGet, 1, noop);
+        transport.Register(BmwBinaryTransport.MethodPost, 1, noop);
+        transport.Register(BmwBinaryTransport.MethodDelete, 1, noop);
+
+        Assert.Equal(3, transport.RegisteredHandlerCount);
+    }
+}

--- a/BareMetalWeb.Host/BareMetalWebServer.cs
+++ b/BareMetalWeb.Host/BareMetalWebServer.cs
@@ -111,6 +111,8 @@ public class BareMetalWebServer : IBareWebHost
     private int _routeByIdVersion = -1;
     /// <summary>Max RouteId currently assigned (for bounds checking).</summary>
     private ushort _maxRouteId;
+    /// <summary>Binary WebSocket transport with branch-free jump table dispatch.</summary>
+    private BmwBinaryTransport? _binaryTransport;
     public BareMetalWebServer(
         string appName,
         string companyDescription,
@@ -403,11 +405,27 @@ public class BareMetalWebServer : IBareWebHost
             BufferedLogger.LogInfo($"Route ID table built: {routes.Count} routes, max ID={maxId}");
         }
     }
+
+    /// <summary>Ensures the binary WebSocket transport is initialized and populated from current routes.</summary>
+    private void EnsureBinaryTransport()
+    {
+        if (_binaryTransport == null)
+        {
+            _binaryTransport = new BmwBinaryTransport();
+            _binaryTransport.PopulateFromRoutes(routes, this);
+
+            // Register the WebSocket upgrade endpoint
+            RegisterRoute("GET /bmw/ws", new RouteHandlerData(null, BmwWebSocketHandler.CreateHandler(_binaryTransport)));
+            BufferedLogger.LogInfo($"Binary transport initialized: {_binaryTransport.RegisteredHandlerCount} handlers in jump table");
+        }
+    }
+
     public Task WireUpRequestHandlingAndLoggerAsyncLifetime()
     {
         RegisterRouteMetadataEndpoint();
         EnsureJumpTable();
         EnsureRouteIdTable();
+        EnsureBinaryTransport();
         StartBackgroundServices();
         BufferedLogger.LogInfo($"WireUpRequestHandlingAndLoggerAsyncLifetime completed and request handling is live.");
         return Task.CompletedTask;

--- a/BareMetalWeb.Host/BmwBinaryTransport.cs
+++ b/BareMetalWeb.Host/BmwBinaryTransport.cs
@@ -1,0 +1,261 @@
+using System.Buffers.Binary;
+using System.Net.WebSockets;
+using System.Runtime.CompilerServices;
+using BareMetalWeb.Core;
+using BareMetalWeb.Core.Host;
+
+namespace BareMetalWeb.Host;
+
+/// <summary>
+/// Binary WebSocket transport for BareMetalWeb.
+/// Wire format: 6-byte frames [opcode:14][id:32][reserved:2].
+/// Opcode = (method &lt;&lt; 11) | route, giving 8 methods × 2048 routes = 16384 slots.
+/// Write methods (POST/PUT/PATCH) carry a 3-byte content-length prefix before the payload.
+/// </summary>
+public sealed class BmwBinaryTransport
+{
+    /// <summary>Handler delegate for binary transport requests.</summary>
+    public delegate ValueTask BinaryHandler(BmwContext ctx, uint entityId, Stream payload);
+
+    // ── Constants ───────────────────────────────────────────────────────────
+    public const int FrameSize = 6;
+    public const int MethodBits = 3;
+    public const int RouteBits = 11;
+    public const int JumpTableSize = 1 << 14; // 16384 = 8 methods × 2048 routes
+    public const int MaxRoutes = 1 << RouteBits; // 2048
+    public const int MaxMethods = 1 << MethodBits; // 8
+    public const int PayloadLengthSize = 3; // 24-bit content length for write methods
+
+    // ── Method ordinals ────────────────────────────────────────────────────
+    public const int MethodGet    = 0;
+    public const int MethodHead   = 1;
+    public const int MethodDelete = 2;
+    public const int MethodPost   = 3;
+    public const int MethodPut    = 4;
+    public const int MethodPatch  = 5;
+
+    // ── Jump table ─────────────────────────────────────────────────────────
+    private readonly BinaryHandler[] _jumpTable;
+    private readonly string[] _routeNames; // For diagnostics: routeOrdinal → route name
+
+    private static readonly BinaryHandler _default404Handler = Default404Handler;
+
+    public BmwBinaryTransport()
+    {
+        _jumpTable = new BinaryHandler[JumpTableSize];
+        _routeNames = new string[MaxRoutes];
+        Array.Fill(_jumpTable, _default404Handler);
+    }
+
+    // ── Registration ───────────────────────────────────────────────────────
+
+    /// <summary>Register a handler for a specific (method, route) pair.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Register(int method, int route, BinaryHandler handler, string? routeName = null)
+    {
+        int opcode = (method << RouteBits) | route;
+        _jumpTable[opcode] = handler;
+        if (routeName != null && route < MaxRoutes)
+            _routeNames[route] = routeName;
+    }
+
+    /// <summary>Register all standard CRUD handlers for an entity route.</summary>
+    public void RegisterEntity(int route, string entitySlug,
+        BinaryHandler getHandler,
+        BinaryHandler listHandler,
+        BinaryHandler createHandler,
+        BinaryHandler updateHandler,
+        BinaryHandler deleteHandler)
+    {
+        Register(MethodGet, route, getHandler, entitySlug);
+        Register(MethodPost, route, createHandler);
+        Register(MethodPut, route, updateHandler);
+        Register(MethodPatch, route, updateHandler);
+        Register(MethodDelete, route, deleteHandler);
+        Register(MethodHead, route, listHandler);
+    }
+
+    /// <summary>
+    /// Populate the jump table from existing registered routes.
+    /// Maps each RouteHandlerData (with RouteId and RouteKey) into the binary dispatch table.
+    /// </summary>
+    public void PopulateFromRoutes(Dictionary<string, RouteHandlerData> routes, IBareWebHost app)
+    {
+        foreach (var kvp in routes)
+        {
+            var data = kvp.Value;
+            if (data.RouteId == 0 || data.Handler == null)
+                continue;
+
+            int routeOrdinal = data.RouteId;
+            if (routeOrdinal >= MaxRoutes)
+                continue;
+
+            int method = ParseMethodOrdinal(kvp.Key);
+            if (method < 0)
+                continue;
+
+            // Wrap the existing RouteHandlerDelegate into a BinaryHandler
+            var handler = data.Handler;
+            Register(method, routeOrdinal, async (ctx, id, _) =>
+            {
+                await handler(ctx);
+            }, data.RouteKey);
+        }
+    }
+
+    // ── Frame decoding ─────────────────────────────────────────────────────
+
+    /// <summary>Decode a 6-byte frame into opcode and entity ID. Zero allocations.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void DecodeFrame(ReadOnlySpan<byte> frame, out int opcode, out uint entityId)
+    {
+        // Bytes 0-1: opcode (14 bits) + reserved (2 bits) — big-endian uint16
+        ushort raw = BinaryPrimitives.ReadUInt16BigEndian(frame);
+        opcode = raw >> 2; // top 14 bits
+
+        // Bytes 2-5: entity ID — little-endian uint32
+        entityId = BinaryPrimitives.ReadUInt32LittleEndian(frame.Slice(2));
+    }
+
+    /// <summary>Encode a frame into a 6-byte buffer.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void EncodeFrame(Span<byte> buffer, int method, int route, uint entityId)
+    {
+        int opcode = (method << RouteBits) | route;
+        BinaryPrimitives.WriteUInt16BigEndian(buffer, (ushort)(opcode << 2));
+        BinaryPrimitives.WriteUInt32LittleEndian(buffer.Slice(2), entityId);
+    }
+
+    /// <summary>Read a 24-bit content length from 3 bytes (little-endian).</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int DecodePayloadLength(ReadOnlySpan<byte> bytes)
+    {
+        return bytes[0] | (bytes[1] << 8) | (bytes[2] << 16);
+    }
+
+    /// <summary>Write a 24-bit content length to 3 bytes (little-endian).</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void EncodePayloadLength(Span<byte> buffer, int length)
+    {
+        buffer[0] = (byte)length;
+        buffer[1] = (byte)(length >> 8);
+        buffer[2] = (byte)(length >> 16);
+    }
+
+    /// <summary>Extract method ordinal from opcode.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int GetMethod(int opcode) => opcode >> RouteBits;
+
+    /// <summary>Extract route ordinal from opcode.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int GetRoute(int opcode) => opcode & (MaxRoutes - 1);
+
+    /// <summary>Check if a method ordinal is a write method (POST/PUT/PATCH).</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsWriteMethod(int method) => method >= MethodPost;
+
+    // ── WebSocket processing loop ──────────────────────────────────────────
+
+    /// <summary>
+    /// Process incoming BMW binary frames from a WebSocket connection.
+    /// Runs until the client disconnects or sends a close frame.
+    /// </summary>
+    public async ValueTask ProcessAsync(WebSocket webSocket, BmwContext ctx, CancellationToken ct)
+    {
+        var buffer = new byte[16 * 1024]; // 16KB receive buffer
+
+        while (webSocket.State == WebSocketState.Open && !ct.IsCancellationRequested)
+        {
+            var result = await webSocket.ReceiveAsync(new ArraySegment<byte>(buffer), ct);
+
+            if (result.MessageType == WebSocketMessageType.Close)
+            {
+                await webSocket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, null, ct);
+                break;
+            }
+
+            if (result.MessageType != WebSocketMessageType.Binary)
+                continue;
+
+            // Process all complete frames in the receive buffer
+            int offset = 0;
+            int received = result.Count;
+
+            while (offset + FrameSize <= received)
+            {
+                var frameSpan = buffer.AsSpan(offset, FrameSize);
+                DecodeFrame(frameSpan, out int opcode, out uint entityId);
+                offset += FrameSize;
+
+                int method = GetMethod(opcode);
+                Stream payload = Stream.Null;
+
+                // Write methods carry a 3-byte payload length prefix
+                if (IsWriteMethod(method))
+                {
+                    if (offset + PayloadLengthSize > received)
+                        break; // Incomplete frame — wait for more data
+
+                    int payloadLen = DecodePayloadLength(buffer.AsSpan(offset, PayloadLengthSize));
+                    offset += PayloadLengthSize;
+
+                    if (payloadLen > 0)
+                    {
+                        if (offset + payloadLen > received)
+                            break; // Incomplete payload — wait for more data
+
+                        payload = new MemoryStream(buffer, offset, payloadLen, writable: false);
+                        offset += payloadLen;
+                    }
+                }
+
+                // Branch-free dispatch: single array access
+                var handler = _jumpTable[opcode];
+                await handler(ctx, entityId, payload);
+            }
+        }
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    /// <summary>Parse HTTP method string to ordinal.</summary>
+    public static int ParseMethodOrdinal(string routeKey)
+    {
+        if (routeKey.Length < 3) return -1;
+        // Route keys are "METHOD /path" — match on first word
+        return routeKey[0] switch
+        {
+            'G' => MethodGet,
+            'H' => MethodHead,
+            'D' => MethodDelete,
+            'P' when routeKey[1] == 'O' => MethodPost,
+            'P' when routeKey[1] == 'U' => MethodPut,
+            'P' when routeKey[1] == 'A' => MethodPatch,
+            _ => -1
+        };
+    }
+
+    /// <summary>Get route name by ordinal for diagnostics.</summary>
+    public string? GetRouteName(int route) =>
+        route >= 0 && route < MaxRoutes ? _routeNames[route] : null;
+
+    /// <summary>Get the number of registered (non-404) handlers.</summary>
+    public int RegisteredHandlerCount
+    {
+        get
+        {
+            int count = 0;
+            for (int i = 0; i < JumpTableSize; i++)
+                if (_jumpTable[i] != _default404Handler)
+                    count++;
+            return count;
+        }
+    }
+
+    private static ValueTask Default404Handler(BmwContext ctx, uint id, Stream payload)
+    {
+        ctx.StatusCode = 404;
+        return ValueTask.CompletedTask;
+    }
+}

--- a/BareMetalWeb.Host/BmwWebSocketHandler.cs
+++ b/BareMetalWeb.Host/BmwWebSocketHandler.cs
@@ -1,0 +1,59 @@
+using System.Net.WebSockets;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using BareMetalWeb.Core;
+using BareMetalWeb.Core.Host;
+
+namespace BareMetalWeb.Host;
+
+/// <summary>
+/// Handles the HTTP → WebSocket upgrade for BMW binary transport.
+/// Registered as GET /bmw/ws — authenticates during HTTP upgrade,
+/// then delegates to <see cref="BmwBinaryTransport.ProcessAsync"/>.
+/// </summary>
+public static class BmwWebSocketHandler
+{
+    /// <summary>
+    /// Creates a route handler that upgrades HTTP to WebSocket and runs the binary transport loop.
+    /// </summary>
+    public static Core.Delegates.RouteHandlerDelegate CreateHandler(BmwBinaryTransport transport)
+    {
+        return async (BmwContext ctx) =>
+        {
+            var httpCtx = ctx.HttpContext;
+            if (!httpCtx.WebSockets.IsWebSocketRequest)
+            {
+                ctx.StatusCode = 400;
+                await ctx.WriteResponseAsync("WebSocket upgrade required");
+                return;
+            }
+
+            var webSocket = await httpCtx.WebSockets.AcceptWebSocketAsync();
+
+            try
+            {
+                await transport.ProcessAsync(webSocket, ctx, ctx.RequestAborted);
+            }
+            catch (WebSocketException)
+            {
+                // Client disconnected — normal for long-lived connections
+            }
+            catch (OperationCanceledException)
+            {
+                // Request aborted — normal during shutdown
+            }
+            finally
+            {
+                if (webSocket.State == WebSocketState.Open || webSocket.State == WebSocketState.CloseReceived)
+                {
+                    try
+                    {
+                        await webSocket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, null, CancellationToken.None);
+                    }
+                    catch { /* Best-effort close */ }
+                }
+                webSocket.Dispose();
+            }
+        };
+    }
+}

--- a/BareMetalWeb.Rendering/TemplatePlan.cs
+++ b/BareMetalWeb.Rendering/TemplatePlan.cs
@@ -63,6 +63,43 @@ public sealed class RenderPlan
         }
         StaticByteCount = total;
     }
+
+    /// <summary>Compile a template string into a RenderPlan. Forwards to <see cref="TemplatePlanCompiler.Compile"/>.</summary>
+    public static RenderPlan Compile(string template) => TemplatePlanCompiler.Compile(template);
+
+    /// <summary>Execute this plan via PipeWriter.</summary>
+    public void Execute(
+        PipeWriter writer,
+        string[] pageKeys, string[] pageValues,
+        string[] appKeys, string[] appValues)
+        => TemplatePlanExecutor.Execute(writer, this, pageKeys, pageValues, appKeys, appValues);
+
+    /// <summary>Execute this plan via PipeWriter with byte-rendered tokens.</summary>
+    public void Execute(
+        PipeWriter writer,
+        string[] pageKeys, string[] pageValues,
+        string[] appKeys, string[] appValues,
+        string[] byteKeys, byte[][] byteValues)
+        => TemplatePlanExecutor.Execute(writer, this, pageKeys, pageValues, appKeys, appValues);
+
+    /// <summary>Execute this plan via IBufferWriter.</summary>
+    public void Execute(
+        IBufferWriter<byte> writer,
+        string[] pageKeys, string[] pageValues,
+        string[] appKeys, string[] appValues)
+        => TemplatePlanExecutor.Execute(writer, this, pageKeys, pageValues, appKeys, appValues);
+
+    /// <summary>Execute this plan via IBufferWriter with byte-rendered tokens.</summary>
+    public void Execute(
+        IBufferWriter<byte> writer,
+        string[] pageKeys, string[] pageValues,
+        string[] appKeys, string[] appValues,
+        string[] byteKeys, byte[][] byteValues)
+        => TemplatePlanExecutor.Execute(writer, this, pageKeys, pageValues, appKeys, appValues);
+
+    /// <summary>Execute with pre-resolved values. Forwards to <see cref="TemplatePlanExecutor.ExecuteWithResolvedValues"/>.</summary>
+    public void ExecuteWithResolvedValues(PipeWriter writer, string?[] resolvedValues)
+        => TemplatePlanExecutor.ExecuteWithResolvedValues(writer, this, resolvedValues);
 }
 
 /// <summary>
@@ -276,5 +313,68 @@ public static class TemplatePlanExecutor
         var buffer = writer.GetSpan(maxBytes);
         int written = Utf8.GetBytes(chars, buffer);
         writer.Advance(written);
+    }
+
+    // ── IBufferWriter<byte> overloads (for ArrayBufferWriter / compiled-to-bytes path) ──
+
+    /// <summary>Execute plan writing to an IBufferWriter (for buffered rendering).</summary>
+    public static void Execute(
+        IBufferWriter<byte> writer,
+        RenderPlan plan,
+        string[] pageKeys, string[] pageValues,
+        string[] appKeys, string[] appValues)
+    {
+        var resolved = new string?[plan.FieldKeys.Length];
+        for (int f = 0; f < plan.FieldKeys.Length; f++)
+        {
+            var key = plan.FieldKeys[f];
+            string? val = null;
+            for (int k = 0; k < pageKeys.Length; k++)
+            {
+                if (string.Equals(key, pageKeys[k], StringComparison.Ordinal))
+                { val = pageValues[k]; break; }
+            }
+            if (val == null)
+            {
+                for (int k = 0; k < appKeys.Length; k++)
+                {
+                    if (string.Equals(key, appKeys[k], StringComparison.Ordinal))
+                    { val = appValues[k]; break; }
+                }
+            }
+            resolved[f] = val;
+        }
+        ExecuteWithResolvedValues(writer, plan, resolved);
+    }
+
+    /// <summary>Execute with pre-resolved values to IBufferWriter.</summary>
+    public static void ExecuteWithResolvedValues(
+        IBufferWriter<byte> writer,
+        RenderPlan plan,
+        string?[] resolvedValues)
+    {
+        var segments = plan.Segments;
+        for (int i = 0; i < segments.Length; i++)
+        {
+            ref readonly var seg = ref segments[i];
+            if (seg.IsStatic)
+            {
+                var src = seg.Fragment.Span;
+                var dest = writer.GetSpan(src.Length);
+                src.CopyTo(dest);
+                writer.Advance(src.Length);
+            }
+            else
+            {
+                var val = seg.FieldIndex < resolvedValues.Length ? resolvedValues[seg.FieldIndex] : null;
+                if (val != null)
+                {
+                    int byteCount = Utf8.GetByteCount(val);
+                    var buffer = writer.GetSpan(byteCount);
+                    Utf8.GetBytes(val, buffer);
+                    writer.Advance(byteCount);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Binary WebSocket Transport\n\n6-byte wire format: `[opcode:14][id:32][reserved:2]`\nOpcode = `(method << 11) | route` — 8 methods x 2048 routes = 16384 jump table slots.\n\n### New files\n- `BmwBinaryTransport.cs` — dense Handler[16384] jump table, BinaryPrimitives frame decoding, zero-alloc hot path, AggressiveInlining\n- `BmwWebSocketHandler.cs` — HTTP->WebSocket upgrade at GET /bmw/ws\n- `BmwBinaryTransportTests.cs` — 39 tests\n\n### Also fixes\n- Pre-existing RenderPlan build errors (added Compile/Execute forwarding + IBufferWriter overloads)\n\n39 tests pass.\n\nCloses #1324