### PR TITLE
feat: JS client numeric route ID dispatch with transparent URL rewriting

### DIFF
--- a/BareMetalWeb.Core/wwwroot/static/js/BareMetalRest.js
+++ b/BareMetalWeb.Core/wwwroot/static/js/BareMetalRest.js
@@ -1,14 +1,71 @@
 // BareMetalRest — lean REST client for BareMetalWeb
 // Handles CRUD, metadata fetch and 401 redirect.
 // Uses binary wire format (BSO1) for entity operations when BareMetalBinary is available.
-// API: setRoot(url), getRoot(), entity(slug), call(method, url, body)
+// Supports numeric route ID dispatch for O(1) server-side routing when route table is loaded.
+// API: setRoot(url), getRoot(), entity(slug), call(method, url, body), byId(routeId, opts), init()
 const BareMetalRest = (() => {
   'use strict';
   let root = '/api/';
   let _binaryReady = false;
 
+  // ── Route ID acceleration ──
+  // Map of "VERB /path/template" → numeric route ID (ushort)
+  let _routeLookup = null;
+  let _initPromise = null;
+
   const setRoot = r => { root = r.endsWith('/') ? r : r + '/'; };
   const getRoot = () => root;
+
+  // ── Route table bootstrap ──
+  // Fetches /bmw/routes and builds a lookup map for transparent URL rewriting.
+  // Safe to call multiple times — deduplicates via _initPromise.
+  async function init() {
+    if (_routeLookup) return true;
+    if (_initPromise) return _initPromise;
+    _initPromise = (async () => {
+      try {
+        const r = await fetch('/bmw/routes');
+        if (!r.ok) return false;
+        const table = await r.json();
+        _routeLookup = new Map();
+        for (let i = 0; i < table.length; i++) {
+          const e = table[i];
+          _routeLookup.set(e.verb + ' ' + e.path, e.id);
+        }
+        return true;
+      } catch { return false; }
+    })();
+    return _initPromise;
+  }
+
+  /** Returns true if the route ID table has been loaded. */
+  function isRouteIdReady() { return _routeLookup !== null; }
+
+  /**
+   * Resolve a verb + path template to a numeric route ID.
+   * Returns 0 if the route table is not loaded or the key is not found.
+   */
+  function resolveRouteId(verb, pathTemplate) {
+    if (!_routeLookup) return 0;
+    return _routeLookup.get(verb + ' ' + pathTemplate) || 0;
+  }
+
+  /**
+   * Build a numeric dispatch URL: /{routeId}?key=val&...
+   * @param {number} routeId Numeric route ID
+   * @param {object} [params] Query parameters to append
+   * @returns {string} URL like "/42?type=users&id=abc"
+   */
+  function numericUrl(routeId, params) {
+    let url = '/' + routeId;
+    if (params) {
+      const keys = Object.keys(params);
+      if (keys.length > 0) {
+        url += '?' + new URLSearchParams(params).toString();
+      }
+    }
+    return url;
+  }
 
   // ── Binary bootstrap ──
   // Fetches signing key and initialises BareMetalBinary.
@@ -83,29 +140,63 @@ const BareMetalRest = (() => {
     const jsonBase = root + slug;
     const binBase = root + '_binary/' + slug;
 
+    // Resolve route IDs for this entity's CRUD operations (if table loaded).
+    // Template patterns match the server's route registration keys.
+    function rid(verb, pathTmpl) { return resolveRouteId(verb, pathTmpl); }
+
+    /** Build the URL for a JSON entity call, using numeric route ID when available. */
+    function jsonUrl(verb, pathTmpl, params, qs) {
+      const id = rid(verb, pathTmpl);
+      if (id) {
+        const merged = params ? Object.assign({}, params, qs || {}) : qs;
+        return numericUrl(id, merged);
+      }
+      // Fallback: traditional string URL
+      let url = jsonBase;
+      if (params && params.id) url += '/' + encodeURIComponent(params.id);
+      if (qs) url += '?' + new URLSearchParams(qs).toString();
+      return url;
+    }
+
+    /** Build the URL for a binary entity call, using numeric route ID when available. */
+    function binUrl(verb, pathTmpl, params, qs) {
+      const id = rid(verb, pathTmpl);
+      if (id) {
+        const merged = params ? Object.assign({}, params, qs || {}) : qs;
+        return numericUrl(id, merged);
+      }
+      let url = binBase;
+      if (params && params.id) url += '/' + encodeURIComponent(params.id);
+      if (qs) url += '?' + new URLSearchParams(qs).toString();
+      return url;
+    }
+
+    const tp = { type: slug }; // common type param
+
     return {
       list: async (q) => {
         await ensureBinary();
         if (isBinaryAvailable()) {
           try {
             const schema = await BareMetalBinary.fetchSchema(slug, root);
-            const url = binBase + (q ? '?' + new URLSearchParams(q) : '');
+            const url = binUrl('GET', '/api/_binary/{type}', tp, q);
             const buf = await binaryCall('GET', url);
             return { data: await BareMetalBinary.deserializeList(buf, schema), count: -1 };
           } catch { /* fall back */ }
         }
-        return call('GET', jsonBase + (q ? '?' + new URLSearchParams(q) : ''));
+        return call('GET', jsonUrl('GET', '/api/{type}', tp, q));
       },
       get: async (id) => {
         await ensureBinary();
+        const p = { type: slug, id };
         if (isBinaryAvailable()) {
           try {
             const schema = await BareMetalBinary.fetchSchema(slug, root);
-            const buf = await binaryCall('GET', `${binBase}/${id}`);
+            const buf = await binaryCall('GET', binUrl('GET', '/api/_binary/{type}/{id}', p));
             return BareMetalBinary.deserialize(buf, schema);
           } catch { /* fall back */ }
         }
-        return call('GET', `${jsonBase}/${id}`);
+        return call('GET', jsonUrl('GET', '/api/{type}/{id}', p));
       },
       create: async (data) => {
         await ensureBinary();
@@ -113,33 +204,35 @@ const BareMetalRest = (() => {
           try {
             const schema = await BareMetalBinary.fetchSchema(slug, root);
             const payload = await BareMetalBinary.serialize(data, schema);
-            const buf = await binaryCall('POST', binBase, payload);
+            const buf = await binaryCall('POST', binUrl('POST', '/api/_binary/{type}', tp), payload);
             return BareMetalBinary.deserialize(buf, schema);
           } catch { /* fall back */ }
         }
-        return call('POST', jsonBase, data);
+        return call('POST', jsonUrl('POST', '/api/{type}', tp), data);
       },
       update: async (id, data) => {
         await ensureBinary();
+        const p = { type: slug, id };
         if (isBinaryAvailable()) {
           try {
             const schema = await BareMetalBinary.fetchSchema(slug, root);
             const payload = await BareMetalBinary.serialize(data, schema);
-            const buf = await binaryCall('PUT', `${binBase}/${id}`, payload);
+            const buf = await binaryCall('PUT', binUrl('PUT', '/api/_binary/{type}/{id}', p), payload);
             return BareMetalBinary.deserialize(buf, schema);
           } catch { /* fall back */ }
         }
-        return call('PUT', `${jsonBase}/${id}`, data);
+        return call('PUT', jsonUrl('PUT', '/api/{type}/{id}', p), data);
       },
       remove: async (id) => {
         await ensureBinary();
+        const p = { type: slug, id };
         if (isBinaryAvailable()) {
           try {
-            await binaryCall('DELETE', `${binBase}/${id}`);
+            await binaryCall('DELETE', binUrl('DELETE', '/api/_binary/{type}/{id}', p));
             return null;
           } catch { /* fall back */ }
         }
-        return call('DELETE', `${jsonBase}/${id}`);
+        return call('DELETE', jsonUrl('DELETE', '/api/{type}/{id}', p));
       },
       /** Apply a field-level delta mutation (JSON). Only sends changed fields. */
       delta: async (id, changes, expectedVersion = 0) => {
@@ -149,7 +242,7 @@ const BareMetalRest = (() => {
             return await BareMetalBinary.applyDeltaJson(slug, id, changes, expectedVersion);
           } catch { /* fall back to full update */ }
         }
-        return call('PUT', `${jsonBase}/${id}`, changes);
+        return call('PUT', jsonUrl('PUT', '/api/{type}/{id}', { type: slug, id }), changes);
       },
       /** Apply a binary delta mutation from a change tracker. */
       deltaFromTracker: async (tracker) => {
@@ -161,9 +254,20 @@ const BareMetalRest = (() => {
         const id = tracker.entity.Key;
         return BareMetalBinary.applyDelta(slug, id, buf);
       },
-      metadata: () => call('GET', `${root}metadata/${slug}`)
+      metadata: () => call('GET', jsonUrl('GET', '/api/metadata/{entity}', { entity: slug }))
     };
   }
 
-  return { setRoot, getRoot, entity, call, ensureBinary, isBinaryAvailable };
+  /**
+   * Direct numeric route dispatch — bypasses lookup, sends /{routeId} directly.
+   * @param {number} routeId The server-assigned numeric route ID
+   * @param {object} [opts] Options: { method, params, body }
+   * @returns {Promise} Parsed JSON response
+   */
+  async function byId(routeId, opts) {
+    const { method = 'GET', params, body } = opts || {};
+    return call(method, numericUrl(routeId, params), body);
+  }
+
+  return { setRoot, getRoot, entity, call, byId, init, isRouteIdReady, resolveRouteId, ensureBinary, isBinaryAvailable };
 })();

--- a/BareMetalWeb.Host.Tests/BareMetalWebServerTests.cs
+++ b/BareMetalWeb.Host.Tests/BareMetalWebServerTests.cs
@@ -966,6 +966,116 @@ public class BareMetalWebServerTests : IDisposable
 
     #endregion
 
+    #region Numeric Route ID Param Hydration Tests
+
+    [Fact]
+    public void ReadQueryParam_FindsMatchingParameter()
+    {
+        Assert.Equal("John", BareMetalWebServer.ReadQueryParam("?name=John&age=30", "name"));
+        Assert.Equal("30", BareMetalWebServer.ReadQueryParam("?name=John&age=30", "age"));
+        Assert.Null(BareMetalWebServer.ReadQueryParam("?name=John", "missing"));
+    }
+
+    [Fact]
+    public void ReadQueryParam_HandlesUrlEncodedValues()
+    {
+        Assert.Equal("Hello World", BareMetalWebServer.ReadQueryParam("?msg=Hello%20World", "msg"));
+        Assert.Equal("@#$", BareMetalWebServer.ReadQueryParam("?s=%40%23%24", "s"));
+    }
+
+    [Fact]
+    public void ReadQueryParam_IsCaseInsensitive()
+    {
+        Assert.Equal("val", BareMetalWebServer.ReadQueryParam("?Type=val", "type"));
+        Assert.Equal("val", BareMetalWebServer.ReadQueryParam("?TYPE=val", "type"));
+    }
+
+    [Fact]
+    public void ReadQueryParam_EmptyOrMinimalQueryString()
+    {
+        Assert.Null(BareMetalWebServer.ReadQueryParam("", "key"));
+        Assert.Null(BareMetalWebServer.ReadQueryParam("?", "key"));
+    }
+
+    [Fact]
+    public async Task NumericDispatch_HydratesEntitySlugAndId()
+    {
+        EnsureStore();
+        string? capturedType = null;
+        string? capturedId = null;
+
+        _server.RegisterRoute("GET /api/{type}/{id}", new RouteHandlerData(
+            CreatePageInfo("Entity Get"),
+            async (ctx) =>
+            {
+                capturedType = ctx.EntitySlug;
+                capturedId = ctx.EntityId;
+                await Task.CompletedTask;
+            }));
+
+        // Find the route ID that was assigned
+        var routeId = _server.routes["GET /api/{type}/{id}"].RouteId;
+
+        var context = CreateHttpContext("GET", $"/{routeId}");
+        context.Request.QueryString = new QueryString("?type=users&id=42");
+        await _server.RequestHandler(context.ToBmw());
+
+        Assert.Equal("users", capturedType);
+        Assert.Equal("42", capturedId);
+    }
+
+    [Fact]
+    public async Task NumericDispatch_HydratesRouteParameters()
+    {
+        EnsureStore();
+        Dictionary<string, string>? capturedParams = null;
+
+        _server.RegisterRoute("GET /page/{slug}", new RouteHandlerData(
+            CreatePageInfo("Page View"),
+            async (ctx) =>
+            {
+                capturedParams = ctx.RouteParameters;
+                await Task.CompletedTask;
+            }));
+
+        var routeId = _server.routes["GET /page/{slug}"].RouteId;
+
+        var context = CreateHttpContext("GET", $"/{routeId}");
+        context.Request.QueryString = new QueryString("?slug=about-us");
+        await _server.RequestHandler(context.ToBmw());
+
+        Assert.NotNull(capturedParams);
+        Assert.Equal("about-us", capturedParams["slug"]);
+    }
+
+    [Fact]
+    public async Task NumericDispatch_NoParamsRoute_SkipsHydration()
+    {
+        EnsureStore();
+        var executed = false;
+
+        _server.RegisterRoute("GET /healthz", new RouteHandlerData(
+            CreatePageInfo("Health"),
+            async (ctx) =>
+            {
+                executed = true;
+                // Should not have any route parameters set
+                Assert.Null(ctx.EntitySlug);
+                Assert.Null(ctx.EntityId);
+                Assert.Null(ctx.RouteParameters);
+                await Task.CompletedTask;
+            }));
+
+        var routeId = _server.routes["GET /healthz"].RouteId;
+
+        var context = CreateHttpContext("GET", $"/{routeId}");
+        await _server.RequestHandler(context.ToBmw());
+
+        Assert.True(executed);
+    }
+
+    #endregion
+
     #region Helper Methods
 
     private static PageInfo CreatePageInfo(

--- a/BareMetalWeb.Host/BareMetalWebServer.cs
+++ b/BareMetalWeb.Host/BareMetalWebServer.cs
@@ -659,6 +659,11 @@ public class BareMetalWebServer : IBareWebHost
                         if (idPage.PageInfo != null)
                             bmwCtx.SetPageInfo(idPage.PageInfo);
                         bmwCtx.CompiledPlans = idPage.CompiledPlans;
+
+                        // Hydrate route parameters from query string so handlers
+                        // (GetRouteValue / GetRouteParam) work identically to path-based dispatch.
+                        HydrateRouteParamsFromQuery(bmwCtx, idPage.RouteKey);
+
                         if (!await IsAuthorizedAsync(idPage.PageInfo, bmwCtx, bmwCtx.RequestAborted).ConfigureAwait(false))
                         {
                             await LogAccessDeniedAsync(routeKey, sourceIp, bmwCtx, idPage.PageInfo, bmwCtx.RequestAborted).ConfigureAwait(false);
@@ -919,6 +924,69 @@ public class BareMetalWebServer : IBareWebHost
             if (id > ushort.MaxValue) return 0; // overflow guard
         }
         return id;
+    }
+
+    /// <summary>
+    /// Populates BmwContext route parameter fields from the query string
+    /// when dispatching via numeric route ID. Uses the CompiledRoute segments
+    /// to map query keys → EntitySlug, EntityId, RouteExtra, or RouteParameters.
+    /// </summary>
+    internal void HydrateRouteParamsFromQuery(BmwContext ctx, string? routeKey)
+    {
+        if (routeKey == null || !_compiledRoutes.TryGetValue(routeKey, out var compiled))
+            return;
+        if (compiled.ParameterCount == 0)
+            return;
+
+        var qs = ctx.Request.QueryString;
+        if (qs.Length <= 1) // empty or just "?"
+            return;
+
+        foreach (var seg in compiled.Segments)
+        {
+            if (seg.Kind != RouteSegmentKind.Parameter && seg.Kind != RouteSegmentKind.CatchAll)
+                continue;
+
+            var val = ReadQueryParam(qs, seg.Value);
+            if (val == null)
+                continue;
+
+            if (seg.Value == "type")
+                ctx.EntitySlug = val;
+            else if (seg.Value == "id")
+                ctx.EntityId = val;
+            else
+            {
+                ctx.RouteParameters ??= new Dictionary<string, string>(compiled.ParameterCount);
+                ctx.RouteParameters[seg.Value] = val;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Reads a single query parameter value from a raw query string without allocating
+    /// an IQueryCollection. Returns null if not found.
+    /// </summary>
+    internal static string? ReadQueryParam(string qs, string key)
+    {
+        // qs starts with '?', scan for key=value pairs separated by '&'
+        int pos = 1; // skip '?'
+        while (pos < qs.Length)
+        {
+            int ampIdx = qs.IndexOf('&', pos);
+            int end = ampIdx < 0 ? qs.Length : ampIdx;
+
+            int eqIdx = qs.IndexOf('=', pos);
+            if (eqIdx >= pos && eqIdx < end)
+            {
+                var k = qs.AsSpan(pos, eqIdx - pos);
+                if (k.Equals(key.AsSpan(), StringComparison.OrdinalIgnoreCase))
+                    return Uri.UnescapeDataString(qs.Substring(eqIdx + 1, end - eqIdx - 1));
+            }
+
+            pos = end + 1;
+        }
+        return null;
     }
 
     private static async ValueTask<bool> IsAuthorizedAsync(PageInfo? pageInfo, BmwContext context, CancellationToken cancellationToken = default)

--- a/BareMetalWeb.Rendering/HtmlRenderer.cs
+++ b/BareMetalWeb.Rendering/HtmlRenderer.cs
@@ -14,7 +14,6 @@ using BareMetalWeb.Core.Interfaces;
 using BareMetalWeb.Rendering.Interfaces;
 using BareMetalWeb.Rendering.Models;
 namespace BareMetalWeb.Rendering;
-
 public class HtmlRenderer : IHtmlRenderer
 {
     public static Action<TimeSpan>? OnRenderComplete;

--- a/BareMetalWeb.Rendering/SingleSpanRenderer.cs
+++ b/BareMetalWeb.Rendering/SingleSpanRenderer.cs
@@ -5,7 +5,7 @@ using System.Text;
 namespace BareMetalWeb.Rendering;
 
 /// <summary>
-/// Renders a compiled <see cref="RenderPlan"/> into a single contiguous buffer,
+/// Renders a compiled <see cref="TemplateRenderPlan"/> into a single contiguous buffer,
 /// eliminating repeated <c>PipeWriter.GetSpan</c>/<c>Advance</c> calls.
 /// One <c>GetSpan</c> → one <c>Advance</c> → one <c>FlushAsync</c>.
 /// </summary>
@@ -19,7 +19,7 @@ public static class SingleSpanRenderer
     /// <summary>
     /// Estimates the total byte size needed for the rendered output.
     /// </summary>
-    public static int EstimateTotalSize(RenderPlan plan, string?[] resolvedValues)
+    public static int EstimateTotalSize(TemplateRenderPlan plan, string?[] resolvedValues)
     {
         int total = plan.StaticByteCount;
 
@@ -46,7 +46,7 @@ public static class SingleSpanRenderer
     /// PipeWriter span. Returns the number of bytes written.
     /// </summary>
     public static int RenderToSpan(
-        RenderPlan plan,
+        TemplateRenderPlan plan,
         string?[] resolvedValues,
         Span<byte> buffer)
     {
@@ -92,7 +92,7 @@ public static class SingleSpanRenderer
     /// </summary>
     public static async ValueTask RenderAsync(
         PipeWriter writer,
-        RenderPlan plan,
+        TemplateRenderPlan plan,
         string[] pageKeys,
         string[] pageValues,
         string[] appKeys,
@@ -112,7 +112,7 @@ public static class SingleSpanRenderer
     /// </summary>
     public static async ValueTask RenderAsync(
         PipeWriter writer,
-        RenderPlan plan,
+        TemplateRenderPlan plan,
         string?[] resolvedValues)
     {
         int estimatedSize = EstimateTotalSize(plan, resolvedValues);
@@ -124,7 +124,7 @@ public static class SingleSpanRenderer
     }
 
     private static string?[] ResolveValues(
-        RenderPlan plan,
+        TemplateRenderPlan plan,
         string[] pageKeys, string[] pageValues,
         string[] appKeys, string[] appValues)
     {

--- a/BareMetalWeb.Rendering/TemplatePlan.cs
+++ b/BareMetalWeb.Rendering/TemplatePlan.cs
@@ -43,7 +43,7 @@ public readonly struct RenderSegment
 /// A precompiled render plan: a flat array of segments that can be executed
 /// in linear order to produce the HTML output.
 /// </summary>
-public sealed class RenderPlan
+public sealed class TemplateRenderPlan
 {
     public readonly RenderSegment[] Segments;
     public readonly string[] FieldKeys;
@@ -51,7 +51,7 @@ public sealed class RenderPlan
     /// <summary>Total bytes of all static fragments (for size estimation).</summary>
     public readonly int StaticByteCount;
 
-    public RenderPlan(RenderSegment[] segments, string[] fieldKeys)
+    public TemplateRenderPlan(RenderSegment[] segments, string[] fieldKeys)
     {
         Segments = segments;
         FieldKeys = fieldKeys;
@@ -67,21 +67,21 @@ public sealed class RenderPlan
 
 /// <summary>
 /// Compiles a template string with <c>{{key}}</c> placeholders into a
-/// <see cref="RenderPlan"/> at startup time.
+/// <see cref="TemplateRenderPlan"/> at startup time.
 /// </summary>
 public static class TemplatePlanCompiler
 {
     private static readonly Encoding Utf8 = Encoding.UTF8;
 
     /// <summary>
-    /// Parses <paramref name="template"/> and produces a <see cref="RenderPlan"/>.
+    /// Parses <paramref name="template"/> and produces a <see cref="TemplateRenderPlan"/>.
     /// Static text between tokens is pre-encoded to UTF-8 bytes.
     /// Dynamic tokens become field indices into the returned key array.
     /// </summary>
-    public static RenderPlan Compile(string template)
+    public static TemplateRenderPlan Compile(string template)
     {
         if (string.IsNullOrEmpty(template))
-            return new RenderPlan(Array.Empty<RenderSegment>(), Array.Empty<string>());
+            return new TemplateRenderPlan(Array.Empty<RenderSegment>(), Array.Empty<string>());
 
         var segments = new List<RenderSegment>();
         var fieldKeys = new List<string>();
@@ -128,12 +128,12 @@ public static class TemplatePlanCompiler
             pos = bodyStart + closeIdx + 2;
         }
 
-        return new RenderPlan(segments.ToArray(), fieldKeys.ToArray());
+        return new TemplateRenderPlan(segments.ToArray(), fieldKeys.ToArray());
     }
 }
 
 /// <summary>
-/// Executes a compiled <see cref="RenderPlan"/> against a set of key-value pairs,
+/// Executes a compiled <see cref="TemplateRenderPlan"/> against a set of key-value pairs,
 /// writing output directly to a <see cref="PipeWriter"/>.
 /// </summary>
 public static class TemplatePlanExecutor
@@ -146,7 +146,7 @@ public static class TemplatePlanExecutor
     /// </summary>
     public static void Execute(
         PipeWriter writer,
-        RenderPlan plan,
+        TemplateRenderPlan plan,
         string[] pageKeys,
         string[] pageValues,
         string[] appKeys,
@@ -193,7 +193,7 @@ public static class TemplatePlanExecutor
     /// </summary>
     public static void ExecuteWithResolvedValues(
         PipeWriter writer,
-        RenderPlan plan,
+        TemplateRenderPlan plan,
         string?[] resolvedValues)
     {
         var segments = plan.Segments;


### PR DESCRIPTION
## Summary

Wires the server's numeric route ID dispatch (PR #1311) into the JavaScript client.

### Server-side
- **HydrateRouteParamsFromQuery**: Populates BmwContext.EntitySlug/EntityId/RouteParameters from query string during numeric dispatch, so handlers work identically to path-based routing
- **ReadQueryParam**: Allocation-free query string parser (no IQueryCollection)

### Client-side (BareMetalRest.js)
- **init()**: Fetches `/bmw/routes` at startup, builds `verb+path → routeId` lookup map
- **Transparent rewriting**: `entity().list()` silently rewrites `/api/users` → `/{routeId}?type=users` when table loaded
- **byId(routeId, opts)**: Explicit O(1) dispatch for code that knows its route ID
- Graceful fallback to string URLs when route table unavailable

### Also fixes
- Renamed old `RenderPlan` → `TemplateRenderPlan` in Rendering to resolve namespace collision with Core.RenderPlan (pre-existing build break from #1306-#1310)

### Tests
- 7 new tests: ReadQueryParam (4) + numeric dispatch param hydration (3)