### PR TITLE
feat: JS client numeric route ID dispatch with transparent URL rewriting

### DIFF
--- a/BareMetalWeb.Core/wwwroot/static/js/BareMetalRest.js
+++ b/BareMetalWeb.Core/wwwroot/static/js/BareMetalRest.js
@@ -7,8 +7,48 @@ const BareMetalRest = (() => {
   let root = '/api/';
   let _binaryReady = false;
 
+  // ── Numeric route ID dispatch ──
+  // verb+path → routeId lookup map, populated from /bmw/routes at init().
+  let _routeTable = null; // Map<string, number> e.g. "GET /api/users" → 42
+  let _routeTableReady = false;
+
   const setRoot = r => { root = r.endsWith('/') ? r : r + '/'; };
   const getRoot = () => root;
+
+  /// Fetch route table from /bmw/routes and build verb+path → routeId map.
+  async function init() {
+    if (_routeTableReady) return;
+    try {
+      const r = await fetch('/bmw/routes');
+      if (!r.ok) return;
+      const routes = await r.json();
+      _routeTable = new Map();
+      for (const rt of routes) {
+        _routeTable.set(rt.verb + ' ' + rt.path, rt.id);
+      }
+      _routeTableReady = true;
+    } catch { /* graceful fallback to string URLs */ }
+  }
+
+  /// Look up numeric route ID for a verb+path pair.
+  function resolveRouteId(verb, path) {
+    if (!_routeTable) return null;
+    return _routeTable.get(verb + ' ' + path) || null;
+  }
+
+  /// Rewrite a URL to use numeric route ID dispatch when available.
+  /// e.g. GET /api/users → GET /42?type=users
+  function rewriteUrl(verb, url) {
+    if (!_routeTableReady) return url;
+    const id = resolveRouteId(verb, url);
+    if (id) return '/' + id;
+    return url;
+  }
+
+  /// Explicit O(1) dispatch by route ID.
+  function byId(routeId, opts) {
+    return call(opts && opts.method || 'GET', '/' + routeId, opts && opts.body);
+  }
 
   // ── Binary bootstrap ──
   // Fetches signing key and initialises BareMetalBinary.
@@ -83,6 +123,23 @@ const BareMetalRest = (() => {
     const jsonBase = root + slug;
     const binBase = root + '_binary/' + slug;
 
+    // Build numeric dispatch URLs for entity CRUD operations.
+    // Routes with params are stored as e.g. "/api/orders/{id}".
+    // Returns /{routeId}?type={slug}[&id={id}] when route table loaded,
+    // otherwise falls back to the original path-based URL.
+    function numUrl(verb, id) {
+      if (!_routeTableReady) return null;
+      // For id-bearing routes, look up the parameterized pattern
+      const path = id
+        ? '/api/' + slug + '/{id}'
+        : '/api/' + slug;
+      const routeId = resolveRouteId(verb, path);
+      if (!routeId) return null;
+      let url = '/' + routeId + '?type=' + encodeURIComponent(slug);
+      if (id) url += '&id=' + encodeURIComponent(id);
+      return url;
+    }
+
     return {
       list: async (q) => {
         await ensureBinary();
@@ -94,7 +151,9 @@ const BareMetalRest = (() => {
             return { data: await BareMetalBinary.deserializeList(buf, schema), count: -1 };
           } catch { /* fall back */ }
         }
-        return call('GET', jsonBase + (q ? '?' + new URLSearchParams(q) : ''));
+        const nurl = numUrl('GET', null);
+        const base = nurl || jsonBase;
+        return call('GET', base + (q ? (nurl ? '&' : '?') + new URLSearchParams(q) : ''));
       },
       get: async (id) => {
         await ensureBinary();
@@ -105,7 +164,7 @@ const BareMetalRest = (() => {
             return BareMetalBinary.deserialize(buf, schema);
           } catch { /* fall back */ }
         }
-        return call('GET', `${jsonBase}/${id}`);
+        return call('GET', numUrl('GET', id) || `${jsonBase}/${id}`);
       },
       create: async (data) => {
         await ensureBinary();
@@ -117,7 +176,7 @@ const BareMetalRest = (() => {
             return BareMetalBinary.deserialize(buf, schema);
           } catch { /* fall back */ }
         }
-        return call('POST', jsonBase, data);
+        return call('POST', numUrl('POST', null) || jsonBase, data);
       },
       update: async (id, data) => {
         await ensureBinary();
@@ -129,7 +188,7 @@ const BareMetalRest = (() => {
             return BareMetalBinary.deserialize(buf, schema);
           } catch { /* fall back */ }
         }
-        return call('PUT', `${jsonBase}/${id}`, data);
+        return call('PUT', numUrl('PUT', id) || `${jsonBase}/${id}`, data);
       },
       remove: async (id) => {
         await ensureBinary();
@@ -139,7 +198,7 @@ const BareMetalRest = (() => {
             return null;
           } catch { /* fall back */ }
         }
-        return call('DELETE', `${jsonBase}/${id}`);
+        return call('DELETE', numUrl('DELETE', id) || `${jsonBase}/${id}`);
       },
       /** Apply a field-level delta mutation (JSON). Only sends changed fields. */
       delta: async (id, changes, expectedVersion = 0) => {
@@ -149,7 +208,7 @@ const BareMetalRest = (() => {
             return await BareMetalBinary.applyDeltaJson(slug, id, changes, expectedVersion);
           } catch { /* fall back to full update */ }
         }
-        return call('PUT', `${jsonBase}/${id}`, changes);
+        return call('PUT', numUrl('PUT', id) || `${jsonBase}/${id}`, changes);
       },
       /** Apply a binary delta mutation from a change tracker. */
       deltaFromTracker: async (tracker) => {
@@ -165,5 +224,5 @@ const BareMetalRest = (() => {
     };
   }
 
-  return { setRoot, getRoot, entity, call, ensureBinary, isBinaryAvailable };
+  return { setRoot, getRoot, entity, call, ensureBinary, isBinaryAvailable, init, byId, resolveRouteId };
 })();

--- a/BareMetalWeb.Host.Tests/NumericDispatchTests.cs
+++ b/BareMetalWeb.Host.Tests/NumericDispatchTests.cs
@@ -1,0 +1,89 @@
+using System;
+
+namespace BareMetalWeb.Host.Tests;
+
+/// <summary>
+/// Tests for ReadQueryParam (allocation-free query string parsing)
+/// used by HydrateRouteParamsFromQuery during numeric route dispatch.
+/// </summary>
+public class NumericDispatchTests
+{
+    [Fact]
+    public void ReadQueryParam_ReturnsValue_WhenKeyExists()
+    {
+        var result = BareMetalWebServer.ReadQueryParam("?type=users&id=42".AsSpan(), "type".AsSpan());
+        Assert.Equal("users", result.ToString());
+    }
+
+    [Fact]
+    public void ReadQueryParam_ReturnsValue_ForSecondParam()
+    {
+        var result = BareMetalWebServer.ReadQueryParam("?type=users&id=42".AsSpan(), "id".AsSpan());
+        Assert.Equal("42", result.ToString());
+    }
+
+    [Fact]
+    public void ReadQueryParam_ReturnsEmpty_WhenKeyMissing()
+    {
+        var result = BareMetalWebServer.ReadQueryParam("?type=users&id=42".AsSpan(), "name".AsSpan());
+        Assert.True(result.IsEmpty);
+    }
+
+    [Fact]
+    public void ReadQueryParam_ReturnsEmpty_WhenQueryEmpty()
+    {
+        var result = BareMetalWebServer.ReadQueryParam(ReadOnlySpan<char>.Empty, "type".AsSpan());
+        Assert.True(result.IsEmpty);
+    }
+
+    [Fact]
+    public void ReadQueryParam_HandlesNoLeadingQuestionMark()
+    {
+        var result = BareMetalWebServer.ReadQueryParam("type=orders&id=7".AsSpan(), "type".AsSpan());
+        Assert.Equal("orders", result.ToString());
+    }
+
+    [Fact]
+    public void ReadQueryParam_ReturnsFirstMatch_WhenDuplicateKeys()
+    {
+        var result = BareMetalWebServer.ReadQueryParam("?x=1&x=2".AsSpan(), "x".AsSpan());
+        Assert.Equal("1", result.ToString());
+    }
+
+    [Fact]
+    public void ReadQueryParam_HandlesEmptyValue()
+    {
+        var result = BareMetalWebServer.ReadQueryParam("?key=".AsSpan(), "key".AsSpan());
+        Assert.Equal("", result.ToString());
+    }
+
+    [Fact]
+    public void ReadQueryParam_DoesNotPartialMatchKeys()
+    {
+        // "type" should not match "typeId"
+        var result = BareMetalWebServer.ReadQueryParam("?typeId=foo".AsSpan(), "type".AsSpan());
+        Assert.True(result.IsEmpty);
+    }
+
+    [Fact]
+    public void ReadQueryParam_HandlesTrailingAmpersand()
+    {
+        var result = BareMetalWebServer.ReadQueryParam("?id=99&".AsSpan(), "id".AsSpan());
+        Assert.Equal("99", result.ToString());
+    }
+
+    [Fact]
+    public void ReadQueryParam_SingleParam()
+    {
+        var result = BareMetalWebServer.ReadQueryParam("?field=Name".AsSpan(), "field".AsSpan());
+        Assert.Equal("Name", result.ToString());
+    }
+
+    [Fact]
+    public void ReadQueryParam_MultipleParams_Command()
+    {
+        var result = BareMetalWebServer.ReadQueryParam(
+            "?type=users&id=5&command=SendEmail".AsSpan(), "command".AsSpan());
+        Assert.Equal("SendEmail", result.ToString());
+    }
+}

--- a/BareMetalWeb.Host/BareMetalWebServer.cs
+++ b/BareMetalWeb.Host/BareMetalWebServer.cs
@@ -677,6 +677,9 @@ public class BareMetalWebServer : IBareWebHost
                         if (idPage.PageInfo != null)
                             bmwCtx.SetPageInfo(idPage.PageInfo);
                         bmwCtx.CompiledPlans = idPage.CompiledPlans;
+                        // Hydrate EntitySlug/EntityId/RouteParameters from query string
+                        // so handlers work identically to path-based routing.
+                        HydrateRouteParamsFromQuery(bmwCtx);
                         if (!await IsAuthorizedAsync(idPage.PageInfo, bmwCtx, bmwCtx.RequestAborted).ConfigureAwait(false))
                         {
                             await LogAccessDeniedAsync(routeKey, sourceIp, bmwCtx, idPage.PageInfo, bmwCtx.RequestAborted).ConfigureAwait(false);
@@ -937,6 +940,69 @@ public class BareMetalWebServer : IBareWebHost
             if (id > ushort.MaxValue) return 0; // overflow guard
         }
         return id;
+    }
+
+    /// <summary>
+    /// Allocation-free query string parameter reader.
+    /// Scans the raw query string for <paramref name="key"/> and returns its value.
+    /// </summary>
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+    internal static ReadOnlySpan<char> ReadQueryParam(ReadOnlySpan<char> query, ReadOnlySpan<char> key)
+    {
+        if (query.IsEmpty) return ReadOnlySpan<char>.Empty;
+        // Skip leading '?'
+        if (query[0] == '?') query = query.Slice(1);
+
+        while (!query.IsEmpty)
+        {
+            int ampIdx = query.IndexOf('&');
+            ReadOnlySpan<char> pair = ampIdx >= 0 ? query.Slice(0, ampIdx) : query;
+
+            int eqIdx = pair.IndexOf('=');
+            if (eqIdx >= 0)
+            {
+                var pairKey = pair.Slice(0, eqIdx);
+                if (pairKey.SequenceEqual(key))
+                    return pair.Slice(eqIdx + 1);
+            }
+
+            if (ampIdx < 0) break;
+            query = query.Slice(ampIdx + 1);
+        }
+        return ReadOnlySpan<char>.Empty;
+    }
+
+    /// <summary>
+    /// Populates BmwContext.EntitySlug, EntityId, and RouteParameters from query string
+    /// parameters during numeric route dispatch, so entity handlers work identically
+    /// to path-based routing. Recognized params: type, id, field, command.
+    /// </summary>
+    private static void HydrateRouteParamsFromQuery(BmwContext ctx)
+    {
+        var qs = ctx.Request.QueryString.AsSpan();
+        if (qs.IsEmpty) return;
+
+        var typeVal = ReadQueryParam(qs, "type".AsSpan());
+        if (!typeVal.IsEmpty)
+            ctx.EntitySlug = typeVal.ToString();
+
+        var idVal = ReadQueryParam(qs, "id".AsSpan());
+        if (!idVal.IsEmpty)
+            ctx.EntityId = idVal.ToString();
+
+        var fieldVal = ReadQueryParam(qs, "field".AsSpan());
+        if (!fieldVal.IsEmpty)
+        {
+            ctx.RouteExtra = fieldVal.ToString();
+            ctx.RouteExtraKey = "field";
+        }
+
+        var cmdVal = ReadQueryParam(qs, "command".AsSpan());
+        if (!cmdVal.IsEmpty)
+        {
+            ctx.RouteExtra = cmdVal.ToString();
+            ctx.RouteExtraKey = "command";
+        }
     }
 
     private static async ValueTask<bool> IsAuthorizedAsync(PageInfo? pageInfo, BmwContext context, CancellationToken cancellationToken = default)

--- a/tests/js-unit/tests/BareMetalRest.test.js
+++ b/tests/js-unit/tests/BareMetalRest.test.js
@@ -216,3 +216,142 @@ describe('BareMetalRest – call() HTTP semantics', () => {
     expect(opts.headers['Content-Type']).toBeUndefined();
   });
 });
+
+// ── init() – route table loading ──────────────────────────────────────────
+
+describe('BareMetalRest – init() route table', () => {
+  let rest;
+
+  beforeEach(() => {
+    global.fetch = jest.fn();
+    rest = loadRest();
+  });
+
+  afterEach(() => { delete global.fetch; });
+
+  test('init() fetches /bmw/routes and builds route map', async () => {
+    global.fetch.mockResolvedValue(jsonResponse([
+      { id: 1, verb: 'GET', path: '/api/users', params: 0 },
+      { id: 2, verb: 'POST', path: '/api/users', params: 0 },
+      { id: 3, verb: 'GET', path: '/api/users/{id}', params: 1 },
+    ]));
+    await rest.init();
+    expect(global.fetch).toHaveBeenCalledWith('/bmw/routes');
+    expect(rest.resolveRouteId('GET', '/api/users')).toBe(1);
+    expect(rest.resolveRouteId('POST', '/api/users')).toBe(2);
+  });
+
+  test('init() is idempotent — only fetches once', async () => {
+    global.fetch.mockResolvedValue(jsonResponse([
+      { id: 1, verb: 'GET', path: '/api/users', params: 0 },
+    ]));
+    await rest.init();
+    await rest.init();
+    // Only one fetch call for /bmw/routes (not counting other fetches)
+    const routeCalls = global.fetch.mock.calls.filter(c => c[0] === '/bmw/routes');
+    expect(routeCalls).toHaveLength(1);
+  });
+
+  test('init() gracefully handles fetch error', async () => {
+    global.fetch.mockRejectedValue(new Error('network'));
+    await rest.init(); // should not throw
+    expect(rest.resolveRouteId('GET', '/api/users')).toBeNull();
+  });
+
+  test('init() gracefully handles non-ok response', async () => {
+    global.fetch.mockResolvedValue({ ok: false, status: 404 });
+    await rest.init(); // should not throw
+    expect(rest.resolveRouteId('GET', '/api/users')).toBeNull();
+  });
+});
+
+// ── Numeric dispatch – transparent URL rewriting ──────────────────────────
+
+describe('BareMetalRest – numeric route dispatch', () => {
+  let rest;
+
+  beforeEach(async () => {
+    global.fetch = jest.fn().mockImplementation((url) => {
+      if (url === '/bmw/routes') {
+        return Promise.resolve(jsonResponse([
+          { id: 10, verb: 'GET', path: '/api/orders', params: 0 },
+          { id: 11, verb: 'POST', path: '/api/orders', params: 0 },
+          { id: 12, verb: 'GET', path: '/api/orders/{id}', params: 1 },
+          { id: 13, verb: 'PUT', path: '/api/orders/{id}', params: 1 },
+          { id: 14, verb: 'DELETE', path: '/api/orders/{id}', params: 1 },
+        ]));
+      }
+      return Promise.resolve(jsonResponse([]));
+    });
+    rest = loadRest();
+    rest.setRoot('/api/');
+    await rest.init();
+    // Reset fetch mock after init so we only see entity calls
+    global.fetch.mockClear();
+    global.fetch.mockResolvedValue(jsonResponse([]));
+  });
+
+  afterEach(() => { delete global.fetch; });
+
+  test('entity().list() uses numeric URL /10?type=orders', async () => {
+    await rest.entity('orders').list();
+    const url = global.fetch.mock.calls[0][0];
+    expect(url).toBe('/10?type=orders');
+  });
+
+  test('entity().list(params) appends query params with &', async () => {
+    await rest.entity('orders').list({ status: 'open' });
+    const url = global.fetch.mock.calls[0][0];
+    expect(url).toContain('/10?type=orders&');
+    expect(url).toContain('status=open');
+  });
+
+  test('entity().get(id) uses numeric URL /12?type=orders&id=42', async () => {
+    global.fetch.mockResolvedValue(jsonResponse({ id: '42' }));
+    await rest.entity('orders').get('42');
+    const url = global.fetch.mock.calls[0][0];
+    expect(url).toBe('/12?type=orders&id=42');
+  });
+
+  test('entity().create(data) uses numeric URL /11?type=orders', async () => {
+    global.fetch.mockResolvedValue(jsonResponse({ id: '1' }));
+    await rest.entity('orders').create({ item: 'widget' });
+    const url = global.fetch.mock.calls[0][0];
+    expect(url).toBe('/11?type=orders');
+  });
+
+  test('entity().update(id, data) uses numeric URL /13?type=orders&id=7', async () => {
+    global.fetch.mockResolvedValue(jsonResponse({ id: '7' }));
+    await rest.entity('orders').update('7', { qty: 5 });
+    const url = global.fetch.mock.calls[0][0];
+    expect(url).toBe('/13?type=orders&id=7');
+  });
+
+  test('entity().remove(id) uses numeric URL /14?type=orders&id=9', async () => {
+    global.fetch.mockResolvedValue(noContentResponse());
+    await rest.entity('orders').remove('9');
+    const url = global.fetch.mock.calls[0][0];
+    expect(url).toBe('/14?type=orders&id=9');
+  });
+
+  test('falls back to string URL when slug not in route table', async () => {
+    await rest.entity('unknown').list();
+    const url = global.fetch.mock.calls[0][0];
+    expect(url).toBe('/api/unknown');
+  });
+
+  test('byId() dispatches directly by route ID', async () => {
+    global.fetch.mockResolvedValue(jsonResponse({ ok: true }));
+    await rest.byId(42);
+    const url = global.fetch.mock.calls[0][0];
+    expect(url).toBe('/42');
+  });
+
+  test('byId() with method option', async () => {
+    global.fetch.mockResolvedValue(jsonResponse({}));
+    await rest.byId(5, { method: 'POST', body: { x: 1 } });
+    const [url, opts] = global.fetch.mock.calls[0];
+    expect(url).toBe('/5');
+    expect(opts.method).toBe('POST');
+  });
+});


### PR DESCRIPTION
Closes #1329

## Server-side
- **ReadQueryParam**: allocation-free `Span<char>`-based query string parser
- **HydrateRouteParamsFromQuery**: populates EntitySlug/EntityId/RouteExtra/RouteExtraKey from query params (type, id, field, command) during numeric dispatch

## Client-side (BareMetalRest.js)
- **init()**: fetches `/bmw/routes`, builds `verb+path -> routeId` Map
- **Transparent URL rewriting**: entity().list/get/create/update/remove silently rewrites `/api/{slug}` -> `/{routeId}?type={slug}` when route table loaded
- **byId(routeId, opts)**: explicit O(1) dispatch for known route IDs
- **resolveRouteId(verb, path)**: public lookup for custom dispatch
- Graceful fallback to string URLs when route table unavailable

## Tests
- 11 C# tests for ReadQueryParam
- 13 JS tests for init(), numeric dispatch, fallback, byId()
- All 119 JS tests pass, all C# tests pass