### PR TITLE
fix(ci): add --runtime linux-x64 to L1.0 AOT restore step

### DIFF
--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -104,7 +104,7 @@ jobs:
           dotnet-version: '10.0.x'
 
       - name: Restore
-        run: dotnet restore BareMetalWeb.Host/BareMetalWeb.Host.csproj
+        run: dotnet restore BareMetalWeb.Host/BareMetalWeb.Host.csproj --runtime linux-x64
 
       - name: AOT/Trim publish (Debug, linux-x64)
         run: |


### PR DESCRIPTION
The `dotnet restore` in the L1.0 AOT/Trim Build Check job was missing `--runtime linux-x64`, causing `NETSDK1047: Assets file doesn't have a target for net10.0/linux-x64` when `dotnet publish` ran with `--no-restore --runtime linux-x64`.

Fix: add `--runtime linux-x64` to the restore command so the assets file includes the RID target.