### PR TITLE
fix(ci): let dotnet publish handle its own restore for AOT

### DIFF
--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -103,16 +103,12 @@ jobs:
         with:
           dotnet-version: '10.0.x'
 
-      - name: Restore
-        run: dotnet restore BareMetalWeb.Host/BareMetalWeb.Host.csproj --runtime linux-x64
-
       - name: AOT/Trim publish (Release, linux-x64)
         run: |
           dotnet publish BareMetalWeb.Host/BareMetalWeb.Host.csproj \
             --configuration Release \
             --runtime linux-x64 \
             --self-contained true \
-            --no-restore \
             -p:AssemblyVersion=${{ needs.version.outputs.assembly_version }} \
             -p:InformationalVersion=${{ needs.version.outputs.info_version }} \
             -o /tmp/aot-check


### PR DESCRIPTION
Separate restore + `--no-restore` publish fails with `PrivateSdkAssemblies` error because the ILCompiler targets require SDK assembly resolution that only happens during a RID-aware restore in the publish context. Removing the separate restore step and `--no-restore` flag lets `dotnet publish` do an implicit restore with full AOT/RID awareness.