### PR TITLE
feat: zero-serialization WAL binary streaming via PipeWriter

### DIFF
--- a/BareMetalWeb.Host.Tests/WalStreamWriterTests.cs
+++ b/BareMetalWeb.Host.Tests/WalStreamWriterTests.cs
@@ -1,0 +1,194 @@
+using System;
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Pipelines;
+using System.Threading;
+using System.Threading.Tasks;
+using BareMetalWeb.Data;
+using Xunit;
+
+namespace BareMetalWeb.Host.Tests;
+
+/// <summary>
+/// Tests for <see cref="WalStreamWriter"/> binary length-prefixed WAL streaming.
+/// </summary>
+public class WalStreamWriterTests : IDisposable
+{
+    private readonly string _tempDir;
+    private readonly WalStore _walStore;
+    private readonly WalDataProvider _walProvider;
+
+    public WalStreamWriterTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "bmw_walstream_" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+
+        _walProvider = new WalDataProvider(_tempDir);
+        _walStore = _walProvider.WalStore;
+    }
+
+    public void Dispose()
+    {
+        _walProvider.Dispose();
+        try { Directory.Delete(_tempDir, true); } catch { }
+    }
+
+    [Fact]
+    public async Task StreamAllAsync_EmptyStore_WritesZeroCount()
+    {
+        var pipe = new Pipe();
+        var count = await WalStreamWriter.StreamAllAsync(pipe.Writer, _walProvider, CancellationToken.None);
+        await pipe.Writer.CompleteAsync();
+
+        Assert.Equal(0, count);
+
+        var result = await pipe.Reader.ReadAsync();
+        var buffer = result.Buffer;
+        Assert.True(buffer.Length >= 4);
+
+        var countBytes = new byte[4];
+        buffer.Slice(0, 4).CopyTo(countBytes);
+        var recordCount = BinaryPrimitives.ReadUInt32LittleEndian(countBytes);
+        Assert.Equal(0u, recordCount);
+
+        pipe.Reader.AdvanceTo(buffer.End);
+        await pipe.Reader.CompleteAsync();
+    }
+
+    [Fact]
+    public async Task StreamAllAsync_WithRecords_WritesCorrectFraming()
+    {
+        // Commit some WAL records
+        var tableId = 1u;
+        var key1 = _walStore.AllocateKey(tableId);
+        var key2 = _walStore.AllocateKey(tableId);
+        var payload1 = new byte[] { 0x01, 0x02, 0x03, 0x04 };
+        var payload2 = new byte[] { 0xAA, 0xBB, 0xCC };
+
+        await _walStore.CommitAsync(new[]
+        {
+            WalOp.Upsert(key1, payload1),
+            WalOp.Upsert(key2, payload2),
+        });
+
+        var pipe = new Pipe();
+        var count = await WalStreamWriter.StreamAllAsync(pipe.Writer, _walProvider, CancellationToken.None);
+        await pipe.Writer.CompleteAsync();
+
+        Assert.Equal(2, count);
+
+        // Read all output
+        var result = await pipe.Reader.ReadAsync();
+        var buffer = result.Buffer;
+        var bytes = buffer.ToArray();
+        pipe.Reader.AdvanceTo(buffer.End);
+        await pipe.Reader.CompleteAsync();
+
+        // Verify framing: [count:4] [len1:4] [data1:N] [len2:4] [data2:N]
+        int offset = 0;
+        var recordCount = BinaryPrimitives.ReadUInt32LittleEndian(bytes.AsSpan(offset, 4));
+        offset += 4;
+        Assert.Equal(2u, recordCount);
+
+        // Record 1
+        var len1 = BinaryPrimitives.ReadUInt32LittleEndian(bytes.AsSpan(offset, 4));
+        offset += 4;
+        Assert.True(len1 > 0);
+        offset += (int)len1;
+
+        // Record 2
+        var len2 = BinaryPrimitives.ReadUInt32LittleEndian(bytes.AsSpan(offset, 4));
+        offset += 4;
+        Assert.True(len2 > 0);
+        offset += (int)len2;
+
+        // All bytes consumed
+        Assert.Equal(bytes.Length, offset);
+    }
+
+    [Fact]
+    public async Task StreamEntityAsync_UnknownEntity_WritesZeroCount()
+    {
+        var pipe = new Pipe();
+        var count = await WalStreamWriter.StreamEntityAsync(
+            pipe.Writer, _walProvider, "nonexistent", CancellationToken.None);
+        await pipe.Writer.CompleteAsync();
+
+        Assert.Equal(0, count);
+
+        var result = await pipe.Reader.ReadAsync();
+        var buffer = result.Buffer;
+        var bytes = new byte[4];
+        buffer.Slice(0, 4).CopyTo(bytes);
+        Assert.Equal(0u, BinaryPrimitives.ReadUInt32LittleEndian(bytes));
+
+        pipe.Reader.AdvanceTo(buffer.End);
+        await pipe.Reader.CompleteAsync();
+    }
+
+    [Fact]
+    public async Task StreamAllAsync_Cancellation_ThrowsWhenCancelled()
+    {
+        // Pre-cancelled token should throw immediately
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        // Commit a record so there's data to iterate
+        var key = _walStore.AllocateKey(1u);
+        await _walStore.CommitAsync(new[] { WalOp.Upsert(key, new byte[] { 1, 2 }) });
+
+        var pipe = new Pipe();
+        try
+        {
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+                await WalStreamWriter.StreamAllAsync(pipe.Writer, _walProvider, cts.Token));
+        }
+        finally
+        {
+            await pipe.Writer.CompleteAsync();
+            await pipe.Reader.CompleteAsync();
+        }
+    }
+
+    [Fact]
+    public async Task StreamAllAsync_LargePayload_FramesCorrectly()
+    {
+        // 4KB payload (compressible text to avoid Brotli expansion)
+        var payload = new byte[4096];
+        Array.Fill<byte>(payload, 0x41); // 'A' repeated — highly compressible
+        var key = _walStore.AllocateKey(1u);
+        await _walStore.CommitAsync(new[] { WalOp.Upsert(key, payload) });
+
+        var pipe = new Pipe(new PipeOptions(useSynchronizationContext: false));
+        var count = await WalStreamWriter.StreamAllAsync(pipe.Writer, _walProvider, CancellationToken.None);
+        await pipe.Writer.CompleteAsync();
+
+        Assert.Equal(1, count);
+
+        // Read all output
+        var ms = new MemoryStream();
+        while (true)
+        {
+            var result = await pipe.Reader.ReadAsync();
+            foreach (var seg in result.Buffer)
+                ms.Write(seg.Span);
+            pipe.Reader.AdvanceTo(result.Buffer.End);
+            if (result.IsCompleted) break;
+        }
+        await pipe.Reader.CompleteAsync();
+        var bytes = ms.ToArray();
+
+        // Count header
+        var recordCount = BinaryPrimitives.ReadUInt32LittleEndian(bytes.AsSpan(0, 4));
+        Assert.Equal(1u, recordCount);
+
+        // Length prefix
+        var len = BinaryPrimitives.ReadUInt32LittleEndian(bytes.AsSpan(4, 4));
+        Assert.True(len > 0);
+
+        // Total = 4 (count) + 4 (len) + len (payload)
+        Assert.Equal(8 + (int)len, bytes.Length);
+    }
+}

--- a/BareMetalWeb.Host/BareMetalWebServer.cs
+++ b/BareMetalWeb.Host/BareMetalWebServer.cs
@@ -447,6 +447,32 @@ public class BareMetalWebServer : IBareWebHost
             }));
 
             BufferedLogger.LogInfo($"Binary transport initialized: {_binaryTransport.RegisteredHandlerCount} handlers in jump table, {_protocolDescriptor.Routes.Count} protocol routes");
+
+            // Register WAL binary stream endpoint
+            RegisterRoute("GET /bmw/wal/stream", new RouteHandlerData(null, async (BmwContext ctx) =>
+            {
+                if (DataStoreProvider.PrimaryProvider is not WalDataProvider walProv)
+                {
+                    ctx.StatusCode = 503;
+                    await ctx.WriteResponseAsync("WAL provider not available");
+                    return;
+                }
+
+                ctx.StatusCode = 200;
+                ctx.ContentType = "application/octet-stream";
+
+                var entity = ReadQueryParam(ctx.HttpRequest.QueryString.Value.AsSpan(), "entity".AsSpan());
+                if (entity.Length > 0)
+                {
+                    await WalStreamWriter.StreamEntityAsync(
+                        ctx.ResponseBody, walProv, entity.ToString(), ctx.RequestAborted);
+                }
+                else
+                {
+                    await WalStreamWriter.StreamAllAsync(
+                        ctx.ResponseBody, walProv, ctx.RequestAborted);
+                }
+            }));
         }
     }
 

--- a/BareMetalWeb.Host/WalStreamWriter.cs
+++ b/BareMetalWeb.Host/WalStreamWriter.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Buffers;
+using System.Buffers.Binary;
+using System.IO.Pipelines;
+using System.Threading;
+using System.Threading.Tasks;
+using BareMetalWeb.Core;
+using BareMetalWeb.Data;
+
+namespace BareMetalWeb.Host;
+
+/// <summary>
+/// Zero-serialization WAL streaming over binary length-prefixed protocol.
+///
+/// <para>Wire format:</para>
+/// <code>
+/// [count : uint32]                    ← total record count
+///
+/// repeat count times:
+///   [length : uint32]                 ← payload byte length
+///   [wal record bytes ... ]           ← raw WAL payload (may be compressed/encrypted)
+/// </code>
+///
+/// <para>
+/// Records are shovelled directly from the WAL store's memory-mapped segments
+/// to the <see cref="PipeWriter"/> with no intermediate buffering, JSON formatting,
+/// or object materialisation. The only unavoidable copy is PipeWriter → socket send buffer.
+/// </para>
+/// </summary>
+internal static class WalStreamWriter
+{
+    /// <summary>
+    /// Streams all WAL records for a given entity type using binary length-prefixed framing.
+    /// </summary>
+    /// <param name="writer">The output <see cref="PipeWriter"/> (typically BmwContext.ResponseBody).</param>
+    /// <param name="walProvider">The WAL data provider to read records from.</param>
+    /// <param name="entityName">Entity type name to stream records for.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The number of records written.</returns>
+    public static async ValueTask<int> StreamEntityAsync(
+        PipeWriter writer,
+        WalDataProvider walProvider,
+        string entityName,
+        CancellationToken ct = default)
+    {
+        var walStore = walProvider.WalStore;
+        var payloads = walProvider.QueryBinary(entityName);
+        int count = payloads.Count;
+
+        // Write record count header (4 bytes, little-endian)
+        WriteUInt32(writer, (uint)count);
+
+        for (int i = 0; i < count; i++)
+        {
+            ct.ThrowIfCancellationRequested();
+            var payload = payloads[i];
+
+            // Write length prefix (4 bytes, little-endian)
+            WriteUInt32(writer, (uint)payload.Length);
+
+            // Write payload directly — zero intermediate buffer
+            if (payload.Length > 0)
+            {
+                var dest = writer.GetMemory(payload.Length);
+                payload.Span.CopyTo(dest.Span);
+                writer.Advance(payload.Length);
+            }
+
+            // Flush periodically to maintain back-pressure (every 64 records)
+            if ((i & 63) == 63)
+            {
+                var result = await writer.FlushAsync(ct).ConfigureAwait(false);
+                if (result.IsCompleted) return i + 1;
+            }
+        }
+
+        await writer.FlushAsync(ct).ConfigureAwait(false);
+        return count;
+    }
+
+    /// <summary>
+    /// Streams all WAL records across all entities using binary length-prefixed framing.
+    /// Iterates the entire HeadMap via CopyArrays for a full database dump.
+    /// </summary>
+    public static async ValueTask<int> StreamAllAsync(
+        PipeWriter writer,
+        WalDataProvider walProvider,
+        CancellationToken ct = default)
+    {
+        var walStore = walProvider.WalStore;
+
+        // Extract all live key→head pairs
+        walStore.HeadMap.CopyArrays(out var keys, out var heads);
+        int count = keys.Length;
+
+        // Write record count header
+        WriteUInt32(writer, (uint)count);
+
+        for (int i = 0; i < count; i++)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            if (!walStore.TryReadOpPayload(heads[i], keys[i], out var payload))
+            {
+                // Tombstone or unreadable — write zero-length record
+                WriteUInt32(writer, 0u);
+            }
+            else
+            {
+                WriteUInt32(writer, (uint)payload.Length);
+                if (payload.Length > 0)
+                {
+                    var dest = writer.GetMemory(payload.Length);
+                    payload.Span.CopyTo(dest.Span);
+                    writer.Advance(payload.Length);
+                }
+            }
+
+            if ((i & 63) == 63)
+            {
+                var result = await writer.FlushAsync(ct).ConfigureAwait(false);
+                if (result.IsCompleted) return i + 1;
+            }
+        }
+
+        await writer.FlushAsync(ct).ConfigureAwait(false);
+        return count;
+    }
+
+    /// <summary>
+    /// Writes a uint32 value in little-endian to the PipeWriter.
+    /// Uses GetSpan(4) for zero-allocation inline writing.
+    /// </summary>
+    private static void WriteUInt32(PipeWriter writer, uint value)
+    {
+        var span = writer.GetSpan(4);
+        BinaryPrimitives.WriteUInt32LittleEndian(span, value);
+        writer.Advance(4);
+    }
+}


### PR DESCRIPTION
## Summary
Implements #1332 — high-performance WAL binary streaming with zero serialization overhead.

### Wire format
```
[count : uint32]
repeat count times:
  [length : uint32]
  [wal record bytes ...]
```

### Endpoint
`GET /bmw/wal/stream` — streams all WAL records
`GET /bmw/wal/stream?entity=orders` — streams records for a specific entity

### Implementation
- **WalStreamWriter.cs** — static streaming class:
  - `StreamAllAsync`: iterates entire HeadMap via CopyArrays, writes each payload directly to PipeWriter
  - `StreamEntityAsync`: uses QueryBinary for per-entity filtered streaming
  - Back-pressure via FlushAsync every 64 records
  - Zero intermediate buffers — WAL payloads go straight from memory-mapped segments to PipeWriter

- **BareMetalWebServer.cs** — registers `GET /bmw/wal/stream` endpoint
  - Uses existing `ReadQueryParam` for allocation-free query string parsing
  - Returns `application/octet-stream` content type

### Performance
- No JSON formatting (no `[`, `]`, `,` tokens)
- No object materialisation or serialisation
- No intermediate buffer construction
- Records streamed as-is (compressed/encrypted per WAL codec — client decodes)
- Only unavoidable copy: PipeWriter → socket send buffer

### Tests (5/5 passing)
- Empty store → zero count header
- Multi-record framing verification
- Unknown entity → zero count
- Pre-cancelled token throws OperationCanceledException
- Large payload (4KB) correct framing

Closes #1332