### PR TITLE
fix: delegate runtime actions to CommandService in DataCommandHandler

### DIFF
--- a/BareMetalWeb.Host/ActionApiHandlers.cs
+++ b/BareMetalWeb.Host/ActionApiHandlers.cs
@@ -152,9 +152,10 @@ public static class ActionApiHandlers
         {
             await WriteError(context, 409, "Lock acquisition timed out. Retry later.");
         }
-        catch (Exception)
+        catch (Exception ex)
         {
-            await WriteError(context, 500, "An internal error occurred.");
+            System.Diagnostics.Debug.WriteLine($"[ActionApiHandlers] Action '{actionId}' on '{typeSlug}' failed: {ex}");
+            await WriteError(context, 500, $"Action failed: {ex.Message}");
         }
     }
 

--- a/BareMetalWeb.Host/RouteHandlers.cs
+++ b/BareMetalWeb.Host/RouteHandlers.cs
@@ -7325,7 +7325,37 @@ public sealed class RouteHandlers : IRouteHandlers
         try
         {
             var userName = (await UserAuth.GetUserAsync(context, context.RequestAborted).ConfigureAwait(false))?.UserName ?? "system";
-            
+
+            // Runtime-defined actions have Method == null; delegate to CommandService
+            if (cmd.Method == null)
+            {
+                var svc = new CommandService();
+                var intent = new CommandIntent
+                {
+                    EntitySlug = meta.Slug,
+                    EntityId = id,
+                    Operation = commandName,
+                    Fields = new Dictionary<string, string?>()
+                };
+                var cmdResult = await svc.ExecuteAsync(intent, context.RequestAborted).ConfigureAwait(false);
+
+                var msg = cmdResult.Success ? "Command executed." : cmdResult.Error;
+
+                if (instance is BaseDataObject bdoRuntime)
+                    await _auditService.AuditRemoteCommandAsync(bdoRuntime, commandName, userName, null,
+                        new RemoteCommandResult(cmdResult.Success, msg ?? string.Empty),
+                        context.RequestAborted).ConfigureAwait(false);
+
+                context.Response.StatusCode = cmdResult.Success ? StatusCodes.Status200OK : StatusCodes.Status422UnprocessableEntity;
+                await WriteJsonResponseAsync(context, new Dictionary<string, object?>
+                {
+                    ["success"] = cmdResult.Success,
+                    ["message"] = msg,
+                    ["data"] = cmdResult.Success ? cmdResult.Data : null
+                });
+                return;
+            }
+
             RemoteCommandResult result;
             var returnType = cmd.Method.ReturnType;
             if (returnType == typeof(RemoteCommandResult))
@@ -7358,8 +7388,9 @@ public sealed class RouteHandlers : IRouteHandlers
         }
         catch (Exception ex)
         {
+            System.Diagnostics.Debug.WriteLine($"[DataCommandHandler] Command '{commandName}' on '{meta.Slug}/{id}' failed: {ex}");
             context.Response.StatusCode = StatusCodes.Status500InternalServerError;
-            await WriteJsonResponseAsync(context, new Dictionary<string, object?> { ["success"] = false, ["message"] = "Command failed due to an internal error." });
+            await WriteJsonResponseAsync(context, new Dictionary<string, object?> { ["success"] = false, ["message"] = $"Command failed: {ex.Message}" });
         }
     }
 


### PR DESCRIPTION
## Problem

Runtime-defined entities (e.g. the todo sample) register actions with `Method=null` in `RemoteCommandMetadata`. `DataCommandHandler` attempted to invoke this null `MethodInfo` via reflection, causing a `NullReferenceException` silently swallowed by a bare `catch` block — returning the generic *'Command failed due to an internal error.'* message.

## Root Cause

`RuntimeEntityModel` (line 175) sets `Method: null!` when building `RemoteCommandMetadata` for runtime-defined actions because these aren't backed by .NET methods — they're `SetIfCommand`-based declarative actions expanded by the `ActionExpander`.

## Fix

1. **DataCommandHandler**: When `cmd.Method` is null, delegate to `CommandService.ExecuteAsync()` which properly resolves the `RuntimeActionModel`, expands commands via `ActionExpander`, acquires aggregate locks, applies field mutations, and saves.
2. **Error visibility**: Both `DataCommandHandler` and `ActionApiHandlers` now surface `ex.Message` instead of swallowing exceptions with a generic error string.

Fixes #1337