### PR TITLE
feat: BMW UI layout grammar — custom element tags for compact layout

### DIFF
--- a/BareMetalWeb.Core/wwwroot/static/css/bmw.css
+++ b/BareMetalWeb.Core/wwwroot/static/css/bmw.css
@@ -1,0 +1,25 @@
+/* BMW UI Layout Grammar — custom element styles (<1KB minified)
+   ds=stack dr=row dc=column db=box dn=nav ta=table ch=chart gt=gantt cl=calendar */
+:root{--g:0.75rem;--p:var(--bs-body-bg,#fff);--b:var(--bs-border-color,#dee2e6);--r:6px}
+ds{display:flex;flex-direction:column;gap:var(--g)}
+dr{display:flex;gap:var(--g);flex-wrap:wrap}
+dc{flex:1;min-width:0}
+db{background:var(--p);border:1px solid var(--b);border-radius:var(--r);padding:var(--g)}
+dn{display:flex;gap:var(--g);align-items:center;padding:10px 14px;border-bottom:1px solid var(--b);background:var(--p);font-weight:600}
+ta{display:block;overflow-x:auto}
+ta>table{width:100%;border-collapse:collapse}
+ta>table th,ta>table td{padding:0.4rem 0.6rem;border-bottom:1px solid var(--b);text-align:left}
+ta>table th{font-size:0.7rem;text-transform:uppercase;letter-spacing:0.08em;font-weight:700}
+ta>table tbody tr:hover{background:color-mix(in srgb,var(--b) 20%,transparent)}
+ch{display:block;height:280px;position:relative}
+gt{display:block;overflow-x:auto}
+cl{display:grid;grid-template-columns:repeat(7,1fr);gap:1px;text-align:center}
+cl>*{padding:0.3rem;border:1px solid var(--b);min-height:5rem}
+/* Utility attributes */
+[gap]{gap:var(--g)}
+[pad]{padding:var(--g)}
+[cols="2"]>dc{flex-basis:calc(50% - var(--g))}
+[cols="3"]>dc{flex-basis:calc(33.33% - var(--g))}
+[cols="4"]>dc{flex-basis:calc(25% - var(--g))}
+/* Responsive: stack rows on narrow viewports */
+@media(max-width:768px){dr{flex-direction:column}dc{flex-basis:100%!important}}

--- a/BareMetalWeb.Core/wwwroot/static/js/BareMetalTemplate.js
+++ b/BareMetalWeb.Core/wwwroot/static/js/BareMetalTemplate.js
@@ -144,5 +144,130 @@ const BareMetalTemplate = (() => {
     return wrap;
   }
 
-  return { buildForm, buildTable };
+  // ── BMW Layout Grammar helpers ──
+  // Build lightweight custom element DOM: ds=stack dr=row dc=column db=box dn=nav ta=table
+  const ds = (children) => { const e = document.createElement('ds'); (children||[]).forEach(c => e.appendChild(c)); return e; };
+  const dr = (children, attrs) => { const e = document.createElement('dr'); if (attrs) Object.entries(attrs).forEach(([k,v]) => e.setAttribute(k,v)); (children||[]).forEach(c => e.appendChild(c)); return e; };
+  const dc = (children) => { const e = document.createElement('dc'); (children||[]).forEach(c => e.appendChild(c)); return e; };
+  const db = (children, title) => {
+    const e = document.createElement('db');
+    if (title) { const h = mk('strong', { textContent: title }); e.appendChild(h); }
+    (children||[]).forEach(c => e.appendChild(c));
+    return e;
+  };
+  const dn = (text, children) => {
+    const e = document.createElement('dn');
+    if (text) e.appendChild(mk('span', { textContent: text }));
+    (children||[]).forEach(c => e.appendChild(c));
+    return e;
+  };
+  const ta = (tableEl) => { const e = document.createElement('ta'); if (tableEl) e.appendChild(tableEl); return e; };
+  const ch = () => document.createElement('ch');
+  const gt = () => document.createElement('gt');
+  const cl = () => document.createElement('cl');
+
+  // Build a BMW grammar form — uses ds/dr/dc instead of Bootstrap grid
+  function buildBmwForm(layout, fields) {
+    const form = mk('form', {});
+    form.setAttribute('rv-on-submit', 'save');
+    const stack = document.createElement('ds');
+    const cols = layout.columns || 2;
+    let currentRow = null;
+    let colCount = 0;
+
+    (layout.fields || Object.keys(fields)).forEach(name => {
+      const f = fields[name] || {};
+      if (f.type === 'hidden') {
+        const inp = mk('input', { type: 'hidden' });
+        inp.setAttribute('rv-value', name);
+        form.appendChild(inp);
+        return;
+      }
+
+      if (!currentRow || colCount >= cols) {
+        currentRow = document.createElement('dr');
+        stack.appendChild(currentRow);
+        colCount = 0;
+      }
+
+      const col = document.createElement('dc');
+      const lbl = mk('label', {
+        textContent: f.label || name.replace(/([A-Z])/g, ' $1').trim()
+      });
+      lbl.style.fontWeight = '600';
+      lbl.style.fontSize = '0.85rem';
+
+      let inp;
+      if (f.type === 'boolean') {
+        inp = mk('input', { type: 'checkbox' });
+      } else if (f.type === 'textarea') {
+        inp = mk('textarea', { rows: f.rows || 3 });
+        inp.style.width = '100%';
+      } else if (f.type === 'select') {
+        inp = mk('select', {});
+        inp.style.width = '100%';
+        [{ value: '', label: '— select —' }, ...(f.options || [])].forEach(o => {
+          const isObj = o !== null && typeof o === 'object';
+          inp.appendChild(mk('option', {
+            value: isObj ? String(o.value ?? '') : String(o),
+            textContent: isObj ? String(o.label ?? o.value ?? o) : String(o)
+          }));
+        });
+      } else if (f.type === 'file') {
+        inp = mk('input', { type: 'file' });
+        if (f.accept) inp.accept = f.accept;
+      } else {
+        inp = mk('input', { type: INPUT_TYPES[f.type] || 'text' });
+        inp.style.width = '100%';
+      }
+
+      inp.setAttribute('rv-value', name);
+      if (f.required) inp.required = true;
+      if (f.placeholder) inp.placeholder = f.placeholder;
+      if (f.readonly) inp.disabled = true;
+
+      col.append(lbl, inp);
+      currentRow.appendChild(col);
+      colCount++;
+    });
+
+    const foot = document.createElement('dr');
+    const saveBtn = mk('button', { type: 'submit', textContent: 'Save' });
+    saveBtn.style.cssText = 'padding:6px 16px;font-weight:600;cursor:pointer';
+    foot.appendChild(saveBtn);
+    stack.appendChild(foot);
+    form.appendChild(stack);
+    return form;
+  }
+
+  // Build a BMW grammar table — uses <ta> wrapper with plain <table>
+  function buildBmwTable(fields, items, callbacks) {
+    const cb = callbacks || {};
+    const resolve = cb.resolve || ((name, v) => String(v ?? ''));
+    const names = Object.keys(fields).filter(n => !fields[n].readonly).slice(0, 6);
+    const tbl = mk('table', {});
+    const hrow = tbl.createTHead().insertRow();
+    names.forEach(n => hrow.appendChild(mk('th', { textContent: fields[n]?.label || n })));
+    hrow.appendChild(mk('th', {}));
+    const tbody = tbl.createTBody();
+    items.forEach(item => {
+      const tr = tbody.insertRow();
+      names.forEach(n => {
+        const td = tr.insertCell();
+        if (fields[n]?.type === 'boolean') {
+          td.textContent = (item[n] === true || item[n] === 'true' || item[n] === 1) ? '✓' : '✗';
+        } else {
+          td.textContent = resolve(n, item[n]);
+        }
+      });
+      const td = tr.insertCell(); td.style.textAlign = 'right';
+      const id = item.id || item.Id || '';
+      if (cb.onView) { const b = mk('button', { textContent: '👁' }); b.onclick = () => cb.onView(id, item); td.appendChild(b); }
+      if (cb.onEdit) { const b = mk('button', { textContent: '✏' }); b.onclick = () => cb.onEdit(id, item); td.appendChild(b); }
+      if (cb.onDelete) { const b = mk('button', { textContent: '🗑' }); b.onclick = () => cb.onDelete(id, item); td.appendChild(b); }
+    });
+    return ta(tbl);
+  }
+
+  return { buildForm, buildTable, buildBmwForm, buildBmwTable, ds, dr, dc, db, dn, ta, ch, gt, cl };
 })();

--- a/BareMetalWeb.Core/wwwroot/static/js/vnext-app.js
+++ b/BareMetalWeb.Core/wwwroot/static/js/vnext-app.js
@@ -566,22 +566,19 @@
                         if (!groups[g]) groups[g] = [];
                         groups[g].push(e);
                     });
-            var html = '<div class="p-4"><h2>Data Objects</h2>';
+            var html = '<ds pad><dn>' + escHtml('Data Objects') + '</dn>';
             Object.keys(groups).sort().forEach(function (groupName) {
-                html += '<h4 class="mt-4 mb-3 border-bottom pb-1">' + escHtml(groupName) + '</h4>';
-                html += '<div class="row row-cols-1 row-cols-md-3 g-3 mb-3">';
+                html += '<strong style="margin-top:0.5rem">' + escHtml(groupName) + '</strong>';
+                html += '<dr cols="3">';
                 groups[groupName].forEach(function (e) {
-                    html += '<div class="col"><div class="card h-100 bm-entity-card">' +
-                        '<div class="card-body">' +
-                        '<h5 class="card-title">' + escHtml(e.name) + '</h5>' +
-                        '</div>' +
-                        '<div class="card-footer">' +
-                        '<a class="btn btn-primary btn-sm" href="' + BASE + '/' + escHtml(e.slug) + '">Open</a>' +
-                        '</div></div></div>';
+                    html += '<dc><db>' +
+                        '<strong>' + escHtml(e.name) + '</strong>' +
+                        '<a href="' + BASE + '/' + escHtml(e.slug) + '">Open</a>' +
+                        '</db></dc>';
                 });
-                html += '</div>';
+                html += '</dr>';
             });
-            html += '</div>';
+            html += '</ds>';
             setContent(html);
         }).catch(function (err) { showError('Could not load entities: ' + err.message); });
     }
@@ -687,14 +684,14 @@
         var viewType = meta.viewType || 'Table';
         var activeView = query.view || viewType;
 
-        var html = '<div class="p-3">';
+        var html = '<ds pad>';
         // Breadcrumb
         html += '<nav aria-label="breadcrumb"><ol class="breadcrumb"><li class="breadcrumb-item"><a href="' + BASE + '">Home</a></li>';
         html += '<li class="breadcrumb-item active">' + escHtml(meta.name) + '</li></ol></nav>';
 
         // Title + action bar
-        html += '<div class="d-flex align-items-center mb-3 flex-wrap gap-2">';
-        html += '<h2 class="mb-0 me-3">' + escHtml(meta.name) + '</h2>';
+        html += '<dr>';
+        html += '<h2 style="margin:0">' + escHtml(meta.name) + '</h2>';
         html += '<span class="badge bg-secondary" title="Total records" aria-label="' + total + ' total records">' + total + ' records</span>';
         html += '<a class="btn btn-primary btn-sm" href="' + baseUrl + '/create"><i class="bi bi-plus-lg"></i> New</a>';
         html += '<a class="btn btn-outline-secondary btn-sm" href="' + API + '/' + encodeURIComponent(slug) + '?format=csv" download><i class="bi bi-filetype-csv"></i> Export CSV</a>';
@@ -715,7 +712,7 @@
             html += '<a class="btn btn-outline-secondary' + (activeView === 'Chart' ? ' active' : '') + '" href="' + buildUrl(baseUrl, Object.assign({}, query, { view: 'Chart' })) + '" title="Charts"><i class="bi bi-graph-up"></i></a>';
             html += '</div>';
         }
-        html += '</div>';
+        html += '</dr>';
 
         if (activeView === 'TreeView' || (activeView === '' && viewType === 'TreeView')) {
             html += renderTreeView(meta, items, slug, baseUrl, query);
@@ -823,7 +820,7 @@
             html += '</div>';
 
             // Table layout for wider viewports
-            html += '<div class="d-none d-md-block table-responsive"><table class="table bm-table table-hover table-striped table-sm align-middle">';
+            html += '<ta class="d-none d-md-block"><table class="table bm-table table-hover table-striped table-sm align-middle">';
             html += '<thead><tr>';
             html += '<th scope="col"><input type="checkbox" class="form-check-input" id="vnext-select-all" title="Select all"></th>';
             listFields.forEach(function (f) {
@@ -894,13 +891,13 @@
                 html += tparts.join('');
             }
 
-            html += '</tbody></table></div>';
+            html += '</tbody></table></ta>';
 
             // Pagination
             html += renderPagination(total, skip, top, baseUrl, query);
         }
 
-        html += '</div>';
+        html += '</ds>';
         setContent(html);
 
         // Resolve lookup display values in background

--- a/BareMetalWeb.Core/wwwroot/templates/index.head.html
+++ b/BareMetalWeb.Core/wwwroot/templates/index.head.html
@@ -6,3 +6,4 @@
     <link rel="preload" href="/static/js/vnext-bundle.js" as="script" />
     <link id="bootswatch-theme" rel="stylesheet" href="{{theme_css_url}}" />
     <link rel="stylesheet" href="/static/css/site.css" />
+    <link rel="stylesheet" href="/static/css/bmw.css" />

--- a/BareMetalWeb.Host.Tests/BmwLayoutGrammarTests.cs
+++ b/BareMetalWeb.Host.Tests/BmwLayoutGrammarTests.cs
@@ -1,0 +1,230 @@
+using System.Buffers;
+using System.Text;
+using BareMetalWeb.Rendering;
+
+namespace BareMetalWeb.Host.Tests;
+
+public class BmwLayoutGrammarTests
+{
+    [Fact]
+    public void Stack_EmitsCorrectTags()
+    {
+        var sb = new StringBuilder();
+        BmwLayoutGrammar.Stack(sb);
+        sb.Append("content");
+        BmwLayoutGrammar.EndStack(sb);
+        Assert.Equal("<ds>content</ds>", sb.ToString());
+    }
+
+    [Fact]
+    public void Row_EmitsCorrectTags()
+    {
+        var sb = new StringBuilder();
+        BmwLayoutGrammar.Row(sb);
+        sb.Append("content");
+        BmwLayoutGrammar.EndRow(sb);
+        Assert.Equal("<dr>content</dr>", sb.ToString());
+    }
+
+    [Fact]
+    public void Row_WithCols_EmitsColsAttribute()
+    {
+        var sb = new StringBuilder();
+        BmwLayoutGrammar.Row(sb, 3);
+        BmwLayoutGrammar.EndRow(sb);
+        Assert.Equal("<dr cols=3></dr>", sb.ToString());
+    }
+
+    [Fact]
+    public void Col_EmitsCorrectTags()
+    {
+        var sb = new StringBuilder();
+        BmwLayoutGrammar.Col(sb);
+        sb.Append("cell");
+        BmwLayoutGrammar.EndCol(sb);
+        Assert.Equal("<dc>cell</dc>", sb.ToString());
+    }
+
+    [Fact]
+    public void Box_EmitsCorrectTags()
+    {
+        var sb = new StringBuilder();
+        BmwLayoutGrammar.Box(sb);
+        sb.Append("panel");
+        BmwLayoutGrammar.EndBox(sb);
+        Assert.Equal("<db>panel</db>", sb.ToString());
+    }
+
+    [Fact]
+    public void Nav_EmitsCorrectTags()
+    {
+        var sb = new StringBuilder();
+        BmwLayoutGrammar.Nav(sb);
+        sb.Append("title");
+        BmwLayoutGrammar.EndNav(sb);
+        Assert.Equal("<dn>title</dn>", sb.ToString());
+    }
+
+    [Fact]
+    public void Table_EmitsCorrectTags()
+    {
+        var sb = new StringBuilder();
+        BmwLayoutGrammar.Table(sb);
+        sb.Append("<table></table>");
+        BmwLayoutGrammar.EndTable(sb);
+        Assert.Equal("<ta><table></table></ta>", sb.ToString());
+    }
+
+    [Fact]
+    public void Chart_EmitsCorrectTags()
+    {
+        var sb = new StringBuilder();
+        BmwLayoutGrammar.Chart(sb);
+        BmwLayoutGrammar.EndChart(sb);
+        Assert.Equal("<ch></ch>", sb.ToString());
+    }
+
+    [Fact]
+    public void Gantt_EmitsCorrectTags()
+    {
+        var sb = new StringBuilder();
+        BmwLayoutGrammar.Gantt(sb);
+        BmwLayoutGrammar.EndGantt(sb);
+        Assert.Equal("<gt></gt>", sb.ToString());
+    }
+
+    [Fact]
+    public void Calendar_EmitsCorrectTags()
+    {
+        var sb = new StringBuilder();
+        BmwLayoutGrammar.Calendar(sb);
+        BmwLayoutGrammar.EndCalendar(sb);
+        Assert.Equal("<cl></cl>", sb.ToString());
+    }
+
+    [Fact]
+    public void WriteStack_ToBufferWriter()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        BmwLayoutGrammar.WriteStack(buffer);
+        BmwLayoutGrammar.WriteEndStack(buffer);
+        Assert.Equal("<ds></ds>", Encoding.UTF8.GetString(buffer.WrittenSpan));
+    }
+
+    [Fact]
+    public void WriteRow_WithCols_ToBufferWriter()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        BmwLayoutGrammar.WriteRow(buffer, 2);
+        BmwLayoutGrammar.WriteCol(buffer);
+        BmwLayoutGrammar.WriteEndCol(buffer);
+        BmwLayoutGrammar.WriteCol(buffer);
+        BmwLayoutGrammar.WriteEndCol(buffer);
+        BmwLayoutGrammar.WriteEndRow(buffer);
+        Assert.Equal("<dr cols=2><dc></dc><dc></dc></dr>", Encoding.UTF8.GetString(buffer.WrittenSpan));
+    }
+
+    [Fact]
+    public void WriteBox_ToBufferWriter()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        BmwLayoutGrammar.WriteBox(buffer);
+        BmwLayoutGrammar.WriteEndBox(buffer);
+        Assert.Equal("<db></db>", Encoding.UTF8.GetString(buffer.WrittenSpan));
+    }
+
+    [Fact]
+    public void WriteNav_ToBufferWriter()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        BmwLayoutGrammar.WriteNav(buffer);
+        BmwLayoutGrammar.WriteEndNav(buffer);
+        Assert.Equal("<dn></dn>", Encoding.UTF8.GetString(buffer.WrittenSpan));
+    }
+
+    [Fact]
+    public void WriteTable_ToBufferWriter()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        BmwLayoutGrammar.WriteTable(buffer);
+        BmwLayoutGrammar.WriteEndTable(buffer);
+        Assert.Equal("<ta></ta>", Encoding.UTF8.GetString(buffer.WrittenSpan));
+    }
+
+    [Fact]
+    public void WriteChart_Gantt_Calendar_ToBufferWriter()
+    {
+        var buffer = new ArrayBufferWriter<byte>();
+        BmwLayoutGrammar.WriteChart(buffer);
+        BmwLayoutGrammar.WriteEndChart(buffer);
+        BmwLayoutGrammar.WriteGantt(buffer);
+        BmwLayoutGrammar.WriteEndGantt(buffer);
+        BmwLayoutGrammar.WriteCalendar(buffer);
+        BmwLayoutGrammar.WriteEndCalendar(buffer);
+        Assert.Equal("<ch></ch><gt></gt><cl></cl>", Encoding.UTF8.GetString(buffer.WrittenSpan));
+    }
+
+    [Fact]
+    public void BuildDashboardLayout_GeneratesCorrectStructure()
+    {
+        var html = BmwLayoutGrammar.BuildDashboardLayout(
+            "Sales Dashboard",
+            2,
+            new[] { "Revenue", "Orders", "Customers" });
+
+        Assert.Contains("<dn>Sales Dashboard</dn>", html);
+        Assert.Contains("<ds>", html);
+        Assert.Contains("</ds>", html);
+        Assert.Contains("<dr cols=2>", html);
+        Assert.Contains("<dc>", html);
+        Assert.Contains("<db>", html);
+        Assert.Contains("<strong>Revenue</strong>", html);
+        Assert.Contains("<strong>Orders</strong>", html);
+        Assert.Contains("<strong>Customers</strong>", html);
+    }
+
+    [Fact]
+    public void BuildDashboardLayout_EscapesHtml()
+    {
+        var html = BmwLayoutGrammar.BuildDashboardLayout(
+            "Test <script>alert('xss')</script>",
+            1,
+            new[] { "Panel <b>1</b>" });
+
+        Assert.DoesNotContain("<script>", html);
+        Assert.Contains("&lt;script&gt;", html);
+        Assert.Contains("&lt;b&gt;", html);
+    }
+
+    [Fact]
+    public void NestedLayout_ComposesCorrectly()
+    {
+        var sb = new StringBuilder();
+        BmwLayoutGrammar.Stack(sb);
+        BmwLayoutGrammar.Nav(sb);
+        sb.Append("Dashboard");
+        BmwLayoutGrammar.EndNav(sb);
+        BmwLayoutGrammar.Row(sb, 3);
+        for (int i = 0; i < 3; i++)
+        {
+            BmwLayoutGrammar.Col(sb);
+            BmwLayoutGrammar.Box(sb);
+            sb.Append("Panel " + i);
+            BmwLayoutGrammar.EndBox(sb);
+            BmwLayoutGrammar.EndCol(sb);
+        }
+        BmwLayoutGrammar.EndRow(sb);
+        BmwLayoutGrammar.Table(sb);
+        sb.Append("<table><tr><td>data</td></tr></table>");
+        BmwLayoutGrammar.EndTable(sb);
+        BmwLayoutGrammar.EndStack(sb);
+
+        var html = sb.ToString();
+        Assert.StartsWith("<ds>", html);
+        Assert.EndsWith("</ds>", html);
+        Assert.Contains("<dn>Dashboard</dn>", html);
+        Assert.Contains("<dr cols=3>", html);
+        Assert.Contains("<dc><db>Panel 0</db></dc>", html);
+        Assert.Contains("<ta><table>", html);
+    }
+}

--- a/BareMetalWeb.Rendering/BmwLayoutGrammar.cs
+++ b/BareMetalWeb.Rendering/BmwLayoutGrammar.cs
@@ -1,0 +1,127 @@
+using System.Buffers;
+using System.Text;
+
+namespace BareMetalWeb.Rendering;
+
+/// <summary>
+/// BMW UI Layout Grammar — generates compact custom HTML elements instead of
+/// verbose Bootstrap div+class constructs. Each tag is a 2-letter mnemonic:
+///   ds=stack  dr=row  dc=column  db=box  dn=nav  ta=table  ch=chart  gt=gantt  cl=calendar
+///
+/// Example output: &lt;ds&gt;&lt;dr&gt;&lt;dc&gt;content&lt;/dc&gt;&lt;dc&gt;sidebar&lt;/dc&gt;&lt;/dr&gt;&lt;/ds&gt;
+///
+/// Styling is provided by bmw.css (~800 bytes) which defines flexbox/grid
+/// behaviour for these unknown-to-the-browser elements.
+/// </summary>
+public static class BmwLayoutGrammar
+{
+    // Tag constants — use ReadOnlySpan<byte> for zero-allocation writes
+    private static readonly byte[] StackOpen = "<ds>"u8.ToArray();
+    private static readonly byte[] StackClose = "</ds>"u8.ToArray();
+    private static readonly byte[] RowOpen = "<dr>"u8.ToArray();
+    private static readonly byte[] RowClose = "</dr>"u8.ToArray();
+    private static readonly byte[] ColOpen = "<dc>"u8.ToArray();
+    private static readonly byte[] ColClose = "</dc>"u8.ToArray();
+    private static readonly byte[] BoxOpen = "<db>"u8.ToArray();
+    private static readonly byte[] BoxClose = "</db>"u8.ToArray();
+    private static readonly byte[] NavOpen = "<dn>"u8.ToArray();
+    private static readonly byte[] NavClose = "</dn>"u8.ToArray();
+    private static readonly byte[] TableOpen = "<ta>"u8.ToArray();
+    private static readonly byte[] TableClose = "</ta>"u8.ToArray();
+    private static readonly byte[] ChartOpen = "<ch>"u8.ToArray();
+    private static readonly byte[] ChartClose = "</ch>"u8.ToArray();
+    private static readonly byte[] GanttOpen = "<gt>"u8.ToArray();
+    private static readonly byte[] GanttClose = "</gt>"u8.ToArray();
+    private static readonly byte[] CalendarOpen = "<cl>"u8.ToArray();
+    private static readonly byte[] CalendarClose = "</cl>"u8.ToArray();
+
+    // Row with cols attribute
+    private static readonly byte[] RowCols2Open = "<dr cols=2>"u8.ToArray();
+    private static readonly byte[] RowCols3Open = "<dr cols=3>"u8.ToArray();
+    private static readonly byte[] RowCols4Open = "<dr cols=4>"u8.ToArray();
+
+    /// <summary>Write a BMW layout tag to a StringBuilder (string rendering path).</summary>
+    public static void Stack(StringBuilder sb) => sb.Append("<ds>");
+    public static void EndStack(StringBuilder sb) => sb.Append("</ds>");
+    public static void Row(StringBuilder sb, int cols = 0)
+    {
+        if (cols > 1) { sb.Append("<dr cols="); sb.Append(cols); sb.Append('>'); }
+        else sb.Append("<dr>");
+    }
+    public static void EndRow(StringBuilder sb) => sb.Append("</dr>");
+    public static void Col(StringBuilder sb) => sb.Append("<dc>");
+    public static void EndCol(StringBuilder sb) => sb.Append("</dc>");
+    public static void Box(StringBuilder sb) => sb.Append("<db>");
+    public static void EndBox(StringBuilder sb) => sb.Append("</db>");
+    public static void Nav(StringBuilder sb) => sb.Append("<dn>");
+    public static void EndNav(StringBuilder sb) => sb.Append("</dn>");
+    public static void Table(StringBuilder sb) => sb.Append("<ta>");
+    public static void EndTable(StringBuilder sb) => sb.Append("</ta>");
+    public static void Chart(StringBuilder sb) => sb.Append("<ch>");
+    public static void EndChart(StringBuilder sb) => sb.Append("</ch>");
+    public static void Gantt(StringBuilder sb) => sb.Append("<gt>");
+    public static void EndGantt(StringBuilder sb) => sb.Append("</gt>");
+    public static void Calendar(StringBuilder sb) => sb.Append("<cl>");
+    public static void EndCalendar(StringBuilder sb) => sb.Append("</cl>");
+
+    /// <summary>Write BMW layout tags to a byte buffer (binary rendering path).</summary>
+    public static void WriteStack(IBufferWriter<byte> writer) => Write(writer, StackOpen);
+    public static void WriteEndStack(IBufferWriter<byte> writer) => Write(writer, StackClose);
+    public static void WriteRow(IBufferWriter<byte> writer, int cols = 0)
+    {
+        if (cols == 2) Write(writer, RowCols2Open);
+        else if (cols == 3) Write(writer, RowCols3Open);
+        else if (cols == 4) Write(writer, RowCols4Open);
+        else Write(writer, RowOpen);
+    }
+    public static void WriteEndRow(IBufferWriter<byte> writer) => Write(writer, RowClose);
+    public static void WriteCol(IBufferWriter<byte> writer) => Write(writer, ColOpen);
+    public static void WriteEndCol(IBufferWriter<byte> writer) => Write(writer, ColClose);
+    public static void WriteBox(IBufferWriter<byte> writer) => Write(writer, BoxOpen);
+    public static void WriteEndBox(IBufferWriter<byte> writer) => Write(writer, BoxClose);
+    public static void WriteNav(IBufferWriter<byte> writer) => Write(writer, NavOpen);
+    public static void WriteEndNav(IBufferWriter<byte> writer) => Write(writer, NavClose);
+    public static void WriteTable(IBufferWriter<byte> writer) => Write(writer, TableOpen);
+    public static void WriteEndTable(IBufferWriter<byte> writer) => Write(writer, TableClose);
+    public static void WriteChart(IBufferWriter<byte> writer) => Write(writer, ChartOpen);
+    public static void WriteEndChart(IBufferWriter<byte> writer) => Write(writer, ChartClose);
+    public static void WriteGantt(IBufferWriter<byte> writer) => Write(writer, GanttOpen);
+    public static void WriteEndGantt(IBufferWriter<byte> writer) => Write(writer, GanttClose);
+    public static void WriteCalendar(IBufferWriter<byte> writer) => Write(writer, CalendarOpen);
+    public static void WriteEndCalendar(IBufferWriter<byte> writer) => Write(writer, CalendarClose);
+
+    private static void Write(IBufferWriter<byte> writer, byte[] data)
+    {
+        var span = writer.GetSpan(data.Length);
+        data.CopyTo(span);
+        writer.Advance(data.Length);
+    }
+
+    /// <summary>
+    /// Generate a complete dashboard layout from metadata using BMW grammar.
+    /// Returns an HTML string using ds/dr/dc/db/ta/ch tags.
+    /// </summary>
+    public static string BuildDashboardLayout(string title, int columns, string[] panelTitles)
+    {
+        var sb = new StringBuilder(512);
+        Nav(sb); sb.Append(System.Net.WebUtility.HtmlEncode(title)); EndNav(sb);
+        Stack(sb);
+        for (int i = 0; i < panelTitles.Length; i += columns)
+        {
+            Row(sb, columns);
+            for (int j = i; j < i + columns && j < panelTitles.Length; j++)
+            {
+                Col(sb);
+                Box(sb);
+                sb.Append("<strong>");
+                sb.Append(System.Net.WebUtility.HtmlEncode(panelTitles[j]));
+                sb.Append("</strong>");
+                EndBox(sb);
+                EndCol(sb);
+            }
+            EndRow(sb);
+        }
+        EndStack(sb);
+        return sb.ToString();
+    }
+}

--- a/tests/js-unit/tests/BareMetalTemplate.test.js
+++ b/tests/js-unit/tests/BareMetalTemplate.test.js
@@ -245,3 +245,189 @@ describe('BareMetalTemplate – buildTable()', () => {
     expect(rows.length).toBe(0);
   });
 });
+
+// ── BMW Grammar helpers ────────────────────────────────────────────────────
+
+describe('BareMetalTemplate – BMW Grammar helpers', () => {
+  let tmpl;
+  beforeEach(() => { tmpl = loadTemplate(); });
+
+  test('ds() creates a stack element', () => {
+    const el = tmpl.ds([]);
+    expect(el.tagName).toBe('DS');
+  });
+
+  test('dr() creates a row element with optional attributes', () => {
+    const el = tmpl.dr([], { cols: '3' });
+    expect(el.tagName).toBe('DR');
+    expect(el.getAttribute('cols')).toBe('3');
+  });
+
+  test('dc() creates a column element', () => {
+    const el = tmpl.dc([]);
+    expect(el.tagName).toBe('DC');
+  });
+
+  test('db() creates a box element with optional title', () => {
+    const el = tmpl.db([], 'Panel Title');
+    expect(el.tagName).toBe('DB');
+    expect(el.querySelector('strong').textContent).toBe('Panel Title');
+  });
+
+  test('dn() creates a nav element with text', () => {
+    const el = tmpl.dn('Navigation');
+    expect(el.tagName).toBe('DN');
+    expect(el.querySelector('span').textContent).toBe('Navigation');
+  });
+
+  test('ta() wraps a table element', () => {
+    const tbl = document.createElement('table');
+    const el = tmpl.ta(tbl);
+    expect(el.tagName).toBe('TA');
+    expect(el.querySelector('table')).toBe(tbl);
+  });
+
+  test('ch(), gt(), cl() create chart, gantt, calendar elements', () => {
+    expect(tmpl.ch().tagName).toBe('CH');
+    expect(tmpl.gt().tagName).toBe('GT');
+    expect(tmpl.cl().tagName).toBe('CL');
+  });
+
+  test('nested composition: ds > dr > dc > db', () => {
+    const layout = tmpl.ds([
+      tmpl.dr([
+        tmpl.dc([tmpl.db([], 'A')]),
+        tmpl.dc([tmpl.db([], 'B')])
+      ], { cols: '2' })
+    ]);
+    expect(layout.tagName).toBe('DS');
+    expect(layout.querySelector('dr').getAttribute('cols')).toBe('2');
+    expect(layout.querySelectorAll('dc').length).toBe(2);
+    expect(layout.querySelectorAll('db').length).toBe(2);
+    expect(layout.querySelectorAll('db')[0].querySelector('strong').textContent).toBe('A');
+    expect(layout.querySelectorAll('db')[1].querySelector('strong').textContent).toBe('B');
+  });
+});
+
+// ── buildBmwForm ───────────────────────────────────────────────────────────
+
+describe('BareMetalTemplate – buildBmwForm()', () => {
+  let tmpl;
+  beforeEach(() => { tmpl = loadTemplate(); });
+
+  test('returns a form element containing ds/dr/dc tags', () => {
+    const form = tmpl.buildBmwForm({ fields: ['name'] }, { name: { type: 'text', label: 'Name' } });
+    expect(form.tagName).toBe('FORM');
+    expect(form.querySelector('ds')).not.toBeNull();
+    expect(form.querySelector('dr')).not.toBeNull();
+    expect(form.querySelector('dc')).not.toBeNull();
+  });
+
+  test('form has rv-on-submit attribute', () => {
+    const form = tmpl.buildBmwForm({ fields: ['x'] }, { x: {} });
+    expect(form.getAttribute('rv-on-submit')).toBe('save');
+  });
+
+  test('renders input with rv-value', () => {
+    const form = tmpl.buildBmwForm({ fields: ['email'] }, { email: { type: 'email' } });
+    const inp = form.querySelector('input[type="email"]');
+    expect(inp).not.toBeNull();
+    expect(inp.getAttribute('rv-value')).toBe('email');
+  });
+
+  test('renders hidden inputs outside grid', () => {
+    const form = tmpl.buildBmwForm({ fields: ['id', 'name'] }, { id: { type: 'hidden' }, name: {} });
+    const hidden = form.querySelector('input[type="hidden"]');
+    expect(hidden).not.toBeNull();
+    expect(hidden.closest('dc')).toBeNull();
+  });
+
+  test('renders a Save submit button', () => {
+    const form = tmpl.buildBmwForm({ fields: ['x'] }, { x: {} });
+    const btn = form.querySelector('button[type="submit"]');
+    expect(btn).not.toBeNull();
+    expect(btn.textContent).toBe('Save');
+  });
+
+  test('distributes fields across rows based on column count', () => {
+    const form = tmpl.buildBmwForm(
+      { columns: 2, fields: ['a', 'b', 'c'] },
+      { a: {}, b: {}, c: {} }
+    );
+    const rows = form.querySelectorAll('dr');
+    // 3 fields / 2 cols = 2 rows (2 in first, 1 in second) + 1 footer row
+    expect(rows.length).toBe(3);
+  });
+
+  test('renders select with options', () => {
+    const form = tmpl.buildBmwForm({ fields: ['status'] }, {
+      status: { type: 'select', options: [{ value: 'a', label: 'A' }] }
+    });
+    const sel = form.querySelector('select');
+    expect(sel).not.toBeNull();
+    expect(sel.options.length).toBe(2); // blank + A
+  });
+
+  test('renders checkbox for boolean', () => {
+    const form = tmpl.buildBmwForm({ fields: ['active'] }, { active: { type: 'boolean' } });
+    const chk = form.querySelector('input[type="checkbox"]');
+    expect(chk).not.toBeNull();
+  });
+
+  test('renders textarea', () => {
+    const form = tmpl.buildBmwForm({ fields: ['notes'] }, { notes: { type: 'textarea', rows: 4 } });
+    const ta = form.querySelector('textarea');
+    expect(ta).not.toBeNull();
+    expect(ta.rows).toBe(4);
+  });
+});
+
+// ── buildBmwTable ──────────────────────────────────────────────────────────
+
+describe('BareMetalTemplate – buildBmwTable()', () => {
+  let tmpl;
+  beforeEach(() => { tmpl = loadTemplate(); });
+
+  const sampleFields = { name: { label: 'Name' }, email: { label: 'Email' } };
+  const sampleItems = [
+    { id: '1', name: 'Alice', email: 'alice@example.com' },
+    { id: '2', name: 'Bob',   email: 'bob@example.com' }
+  ];
+
+  test('returns a ta element wrapping a table', () => {
+    const el = tmpl.buildBmwTable(sampleFields, sampleItems, {});
+    expect(el.tagName).toBe('TA');
+    expect(el.querySelector('table')).not.toBeNull();
+  });
+
+  test('renders header with field labels', () => {
+    const el = tmpl.buildBmwTable(sampleFields, sampleItems, {});
+    const ths = el.querySelectorAll('th');
+    const labels = Array.from(ths).map(th => th.textContent);
+    expect(labels).toContain('Name');
+    expect(labels).toContain('Email');
+  });
+
+  test('renders one row per item', () => {
+    const el = tmpl.buildBmwTable(sampleFields, sampleItems, {});
+    const rows = el.querySelectorAll('tbody tr');
+    expect(rows.length).toBe(2);
+  });
+
+  test('renders action buttons', () => {
+    const onView = jest.fn();
+    const el = tmpl.buildBmwTable(sampleFields, sampleItems, { onView });
+    const btn = el.querySelector('button');
+    btn.click();
+    expect(onView).toHaveBeenCalledWith('1', sampleItems[0]);
+  });
+
+  test('boolean fields render as check/cross text', () => {
+    const fields = { active: { label: 'Active', type: 'boolean' } };
+    const items = [{ id: '1', active: true }, { id: '2', active: false }];
+    const el = tmpl.buildBmwTable(fields, items, {});
+    const cells = el.querySelectorAll('tbody td:first-child');
+    expect(cells[0].textContent).toBe('✓');
+    expect(cells[1].textContent).toBe('✗');
+  });
+});


### PR DESCRIPTION
Closes #1347

## Summary
Introduces 2-letter custom HTML elements as a compact alternative to Bootstrap's verbose `div+class` layout system.

| Tag | Element | CSS Behaviour |
|-----|---------|---------------|
| `ds` | Stack | `flex-direction:column` |
| `dr` | Row | `flex; flex-wrap:wrap` |
| `dc` | Column | `flex:1` |
| `db` | Box/Panel | border + padding + border-radius |
| `dn` | Nav bar | flex + font-weight:600 |
| `ta` | Table wrapper | `overflow-x:auto` + styled `th/td` |
| `ch` | Chart | `height:280px; position:relative` |
| `gt` | Gantt | `overflow-x:auto` |
| `cl` | Calendar | `grid 7-col` |

### Files changed
- **`bmw.css`** — Custom element styles (~800B). `cols` attribute, responsive stacking at 768px
- **`BmwLayoutGrammar.cs`** — Server-side zero-alloc write methods (StringBuilder + IBufferWriter). `BuildDashboardLayout()` helper
- **`BareMetalTemplate.js`** — Client DOM helpers (`ds/dr/dc/db/dn/ta/ch/gt/cl`), `buildBmwForm()`, `buildBmwTable()`
- **`vnext-app.js`** — `renderHome` and `renderListResult` use BMW grammar
- **`index.head.html`** — Includes `bmw.css`

### Tests
- 19 C# tests (`BmwLayoutGrammarTests.cs`) — all tag pairs, buffer writer, dashboard layout, XSS escaping
- 22 new JS tests — grammar helpers, buildBmwForm, buildBmwTable (146 total JS tests pass)