### PR TITLE
feat(intelligence): structured filters, count handler, conversational context

### DIFF
--- a/BareMetalWeb.Intelligence/AdminToolCatalogue.cs
+++ b/BareMetalWeb.Intelligence/AdminToolCatalogue.cs
@@ -40,7 +40,11 @@ public static class AdminToolCatalogue
 
         new("query-entity",
             "Query records from a data entity",
-            ["query", "find", "search", "get", "records", "rows", "data", "fetch", "count", "how", "many"]),
+            ["query", "find", "search", "get", "records", "rows", "data", "fetch", "where", "filter"]),
+
+        new("count-entity",
+            "Count records in a data entity",
+            ["count", "how", "many", "total", "number"]),
 
         new("system-status",
             "Show system status and diagnostics",
@@ -106,9 +110,23 @@ public static class AdminToolCatalogue
             [
                 new ToolParameter("entity", "Entity name or slug", true),
                 new ToolParameter("query", "Optional search text to filter results", false),
+                new ToolParameter("filterField", "Field name for structured filter", false),
+                new ToolParameter("filterOp", "Filter operator (Equals, Contains, etc.)", false),
+                new ToolParameter("filterValue", "Filter value", false),
                 new ToolParameter("limit", "Max records to return", false),
             ],
             QueryEntityHandler);
+
+        registry.Register(
+            "count-entity",
+            "Count records in a data entity",
+            [
+                new ToolParameter("entity", "Entity name or slug", true),
+                new ToolParameter("filterField", "Field name for structured filter", false),
+                new ToolParameter("filterOp", "Filter operator (Equals, Contains, etc.)", false),
+                new ToolParameter("filterValue", "Filter value", false),
+            ],
+            CountEntityHandler);
 
         registry.Register(
             "system-status",
@@ -281,6 +299,9 @@ public static class AdminToolCatalogue
             if (entity is null)
                 return ToolResult.Fail($"Entity '{entityName}' not found. Use 'list entities' to see available types.");
 
+            // Build a structured filter if filterField/filterOp/filterValue are provided
+            QueryDefinition? query = BuildFilterQuery(parameters);
+
             // If a search query is provided, search by text
             parameters.TryGetValue("query", out var searchText);
             if (!string.IsNullOrWhiteSpace(searchText))
@@ -297,12 +318,13 @@ public static class AdminToolCatalogue
                 return ToolResult.Ok(sb.ToString());
             }
 
-            var count = await entity.Handlers.CountAsync(null, ct).ConfigureAwait(false);
-            var items = await entity.Handlers.QueryAsync(null, ct).ConfigureAwait(false);
+            var count = await entity.Handlers.CountAsync(query, ct).ConfigureAwait(false);
+            var items = await entity.Handlers.QueryAsync(query, ct).ConfigureAwait(false);
             var list = items.Take(limit).ToList();
 
+            var filterDesc = query != null ? " (filtered)" : "";
             var output = new System.Text.StringBuilder(256);
-            output.AppendLine($"{entity.Name}: {count} total records (showing {list.Count})");
+            output.AppendLine($"{entity.Name}{filterDesc}: {count} total records (showing {list.Count})");
             output.AppendLine();
 
             foreach (var item in list)
@@ -314,6 +336,50 @@ public static class AdminToolCatalogue
         {
             return ToolResult.Fail($"Query failed: {ex.GetType().Name}");
         }
+    }
+
+    private static async ValueTask<ToolResult> CountEntityHandler(
+        IReadOnlyDictionary<string, string> parameters, CancellationToken ct)
+    {
+        if (!parameters.TryGetValue("entity", out var entityName) || string.IsNullOrEmpty(entityName))
+            return ToolResult.Fail("Please specify an entity name.");
+
+        try
+        {
+            var entity = ResolveEntity(entityName);
+            if (entity is null)
+                return ToolResult.Fail($"Entity '{entityName}' not found. Use 'list entities' to see available types.");
+
+            QueryDefinition? query = BuildFilterQuery(parameters);
+            var count = await entity.Handlers.CountAsync(query, ct).ConfigureAwait(false);
+
+            var filterDesc = query != null ? " matching filter" : " total";
+            return ToolResult.Ok($"{entity.Name}: {count} record(s){filterDesc}.");
+        }
+        catch (Exception ex)
+        {
+            return ToolResult.Fail($"Count failed: {ex.GetType().Name}");
+        }
+    }
+
+    /// <summary>
+    /// Builds a QueryDefinition from structured filter parameters, if present.
+    /// </summary>
+    private static QueryDefinition? BuildFilterQuery(IReadOnlyDictionary<string, string> parameters)
+    {
+        if (!parameters.TryGetValue("filterField", out var field) || string.IsNullOrWhiteSpace(field))
+            return null;
+        if (!parameters.TryGetValue("filterValue", out var value) || string.IsNullOrWhiteSpace(value))
+            return null;
+
+        parameters.TryGetValue("filterOp", out var opStr);
+        if (!Enum.TryParse<QueryOperator>(opStr ?? "Equals", true, out var op))
+            op = QueryOperator.Equals;
+
+        return new QueryDefinition
+        {
+            Clauses = [new QueryClause { Field = field, Operator = op, Value = value }]
+        };
     }
 
     private static ValueTask<ToolResult> SystemStatusHandler(
@@ -508,7 +574,7 @@ public static class AdminToolCatalogue
     {
         var layout = EntityLayoutCompiler.GetOrCompile(entity);
         var sb = new System.Text.StringBuilder(512);
-        sb.AppendLine($"{entity.Name} #{item.Key}");
+        sb.AppendLine($"{entity.Name} #{item.Key}  → /{entity.Slug}/{item.Key}");
         sb.AppendLine();
 
         foreach (var field in layout.Fields)
@@ -552,6 +618,6 @@ public static class AdminToolCatalogue
             catch { }
         }
 
-        return $"  [{item.Key}] {string.Join(", ", parts)}";
+        return $"  [{item.Key}] {string.Join(", ", parts)}  → /{entity.Slug}/{item.Key}";
     }
 }

--- a/BareMetalWeb.Intelligence/IntelligenceOrchestrator.cs
+++ b/BareMetalWeb.Intelligence/IntelligenceOrchestrator.cs
@@ -7,12 +7,16 @@ namespace BareMetalWeb.Intelligence;
 /// <summary>
 /// Orchestrates intent classification and tool execution for admin chat.
 /// Two-tier architecture: fast keyword match → optional BitNet fallback.
+/// Maintains single-slot entity context across turns for follow-up queries.
 /// </summary>
 public sealed class IntelligenceOrchestrator
 {
     private readonly IIntentClassifier _classifier;
     private readonly IToolExecutor _executor;
     private readonly IBitNetEngine? _engine;
+
+    // Single-slot conversational context — remembers the last entity mentioned
+    private string? _lastEntity;
 
     public IntelligenceOrchestrator(
         IIntentClassifier classifier,
@@ -44,6 +48,7 @@ public sealed class IntelligenceOrchestrator
         {
             // Direct tool execution — fast path
             var parameters = ExtractParameters(sanitised, intent.IntentName);
+            ApplyContext(parameters, intent.IntentName);
             var result = await _executor.ExecuteAsync(intent.IntentName, parameters, ct)
                 .ConfigureAwait(false);
 
@@ -57,6 +62,7 @@ public sealed class IntelligenceOrchestrator
         {
             // Medium confidence — try tool execution but note uncertainty
             var parameters = ExtractParameters(sanitised, intent.IntentName);
+            ApplyContext(parameters, intent.IntentName);
             var result = await _executor.ExecuteAsync(intent.IntentName, parameters, ct)
                 .ConfigureAwait(false);
 
@@ -84,46 +90,207 @@ public sealed class IntelligenceOrchestrator
     }
 
     /// <summary>
-    /// Extract simple parameters from the query based on intent.
+    /// Apply conversational context — carry forward the last entity when none
+    /// is mentioned in a follow-up query, and remember the current entity.
+    /// </summary>
+    private void ApplyContext(Dictionary<string, string> parameters, string intentName)
+    {
+        if (intentName is "describe-entity" or "query-entity" or "show-entity" or "count-entity")
+        {
+            if (parameters.TryGetValue("entity", out var entity) && !string.IsNullOrEmpty(entity))
+            {
+                _lastEntity = entity;
+            }
+            else if (_lastEntity != null)
+            {
+                parameters["entity"] = _lastEntity;
+            }
+        }
+    }
+
+    // ── Skip-word list shared across extraction methods ──
+
+    private static readonly HashSet<string> SkipWords = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "describe", "show", "display", "view", "open", "list",
+        "query", "find", "search", "get", "fetch", "count",
+        "how", "many", "fields", "of", "for", "the", "a",
+        "an", "in", "from", "all", "me", "record", "detail",
+        "records", "items", "results", "data", "please"
+    };
+
+    // ── Filter operator keywords mapped to QueryOperator names ──
+
+    private static readonly Dictionary<string, string> FilterOperators = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["equals"]   = "Equals",   ["="]        = "Equals",   ["is"]       = "Equals",
+        ["contains"] = "Contains", ["like"]     = "Contains", ["has"]      = "Contains",
+        ["starts"]   = "StartsWith", ["startswith"] = "StartsWith",
+        ["ends"]     = "EndsWith",   ["endswith"]   = "EndsWith",
+        [">"]        = "GreaterThan",  ["greater"]    = "GreaterThan", ["above"]  = "GreaterThan", ["after"] = "GreaterThan",
+        ["<"]        = "LessThan",     ["less"]       = "LessThan",    ["below"]  = "LessThan",    ["before"] = "LessThan",
+        [">="]       = "GreaterThanOrEqual",
+        ["<="]       = "LessThanOrEqual",
+        ["not"]      = "NotEquals",    ["!="]         = "NotEquals",
+    };
+
+    /// <summary>
+    /// Extract parameters from natural language, handling:
+    /// - Multi-word entity names (tries 2-word then 1-word against known slugs)
+    /// - "where field operator value" filter clauses
+    /// - "how many" → count-entity intent upgrade
+    /// - Remaining text as free-text query
     /// </summary>
     private static Dictionary<string, string> ExtractParameters(string query, string intentName)
     {
         var parameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
-        // Extract entity name and optional search text for entity-related intents
-        if (intentName is "describe-entity" or "query-entity" or "show-entity")
+        if (intentName is not ("describe-entity" or "query-entity" or "show-entity" or "count-entity"))
+            return parameters;
+
+        var words = query.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+        // Phase 1: Find the entity name (try multi-word slug match first)
+        int entityEndIdx = -1;
+        string? resolvedEntity = null;
+
+        // Collect candidate words (skip verb/filler words)
+        var candidateIndices = new List<int>();
+        for (int i = 0; i < words.Length; i++)
         {
-            var words = query.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-            string[] skipWords = ["describe", "show", "display", "view", "open", "list",
-                                  "query", "find", "search", "get", "fetch", "count",
-                                  "how", "many", "fields", "of", "for", "the", "a",
-                                  "an", "in", "from", "all", "me", "record", "detail"];
+            if (!SkipWords.Contains(words[i]))
+                candidateIndices.Add(i);
+        }
 
-            bool foundEntity = false;
-            var queryParts = new List<string>();
-
-            foreach (var word in words)
+        if (candidateIndices.Count >= 2)
+        {
+            // Try 2-word slug: "work orders" → "work-orders"
+            int i0 = candidateIndices[0], i1 = candidateIndices[1];
+            if (i1 == i0 + 1) // adjacent words
             {
-                if (!foundEntity)
+                var twoWord = words[i0] + "-" + words[i1];
+                if (TryResolveEntitySlug(twoWord))
                 {
-                    if (!Array.Exists(skipWords, s =>
-                        string.Equals(s, word, StringComparison.OrdinalIgnoreCase)))
+                    resolvedEntity = twoWord;
+                    entityEndIdx = i1;
+                }
+                // Also try without hyphen as a single joined slug
+                if (resolvedEntity == null)
+                {
+                    var joined = words[i0] + words[i1];
+                    if (TryResolveEntitySlug(joined))
                     {
-                        parameters["entity"] = word;
-                        foundEntity = true;
+                        resolvedEntity = joined;
+                        entityEndIdx = i1;
                     }
                 }
-                else
-                {
-                    queryParts.Add(word);
-                }
             }
+        }
 
-            if (queryParts.Count > 0)
-                parameters["query"] = string.Join(' ', queryParts);
+        if (resolvedEntity == null && candidateIndices.Count >= 1)
+        {
+            // Single word entity
+            resolvedEntity = words[candidateIndices[0]];
+            entityEndIdx = candidateIndices[0];
+        }
+
+        if (resolvedEntity != null)
+            parameters["entity"] = resolvedEntity;
+
+        // Phase 2: Parse remaining words for filters or free-text query
+        if (entityEndIdx >= 0 && entityEndIdx + 1 < words.Length)
+        {
+            var remainder = words.AsSpan()[(entityEndIdx + 1)..];
+            ParseRemainder(remainder, parameters);
         }
 
         return parameters;
+    }
+
+    /// <summary>
+    /// Parse the remainder of the query after the entity name.
+    /// Detects "where field op value" filter patterns and free-text search.
+    /// </summary>
+    private static void ParseRemainder(ReadOnlySpan<string> words, Dictionary<string, string> parameters)
+    {
+        // Look for "where" keyword to start structured filter parsing
+        int whereIdx = -1;
+        for (int i = 0; i < words.Length; i++)
+        {
+            if (string.Equals(words[i], "where", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(words[i], "with", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(words[i], "whose", StringComparison.OrdinalIgnoreCase))
+            {
+                whereIdx = i;
+                break;
+            }
+        }
+
+        if (whereIdx >= 0 && whereIdx + 2 < words.Length)
+        {
+            // "where <field> <op> <value...>" or "where <field> <value>" (implicit equals)
+            var filterWords = words[(whereIdx + 1)..];
+            string field = filterWords[0];
+
+            if (filterWords.Length >= 3 && FilterOperators.TryGetValue(filterWords[1], out var opName))
+            {
+                // Explicit operator: "where status equals active"
+                var valueParts = new List<string>();
+                for (int i = 2; i < filterWords.Length; i++)
+                    valueParts.Add(filterWords[i]);
+
+                parameters["filterField"] = field;
+                parameters["filterOp"] = opName;
+                parameters["filterValue"] = string.Join(' ', valueParts);
+            }
+            else if (filterWords.Length >= 2)
+            {
+                // Implicit equals: "where status active"
+                var valueParts = new List<string>();
+                for (int i = 1; i < filterWords.Length; i++)
+                    valueParts.Add(filterWords[i]);
+
+                parameters["filterField"] = field;
+                parameters["filterOp"] = "Contains";
+                parameters["filterValue"] = string.Join(' ', valueParts);
+            }
+
+            // Pre-where text becomes the query
+            if (whereIdx > 0)
+            {
+                var preWhere = new List<string>();
+                for (int i = 0; i < whereIdx; i++)
+                    preWhere.Add(words[i]);
+                if (preWhere.Count > 0)
+                    parameters["query"] = string.Join(' ', preWhere);
+            }
+        }
+        else
+        {
+            // No "where" clause — everything is free-text query
+            var parts = new List<string>();
+            for (int i = 0; i < words.Length; i++)
+                parts.Add(words[i]);
+            if (parts.Count > 0)
+                parameters["query"] = string.Join(' ', parts);
+        }
+    }
+
+    /// <summary>
+    /// Quick check if a slug or its singular/plural variant resolves to an entity.
+    /// </summary>
+    private static bool TryResolveEntitySlug(string candidate)
+    {
+        if (BareMetalWeb.Core.DataScaffold.TryGetEntity(candidate, out _))
+            return true;
+        // Try plural
+        if (BareMetalWeb.Core.DataScaffold.TryGetEntity(candidate + "s", out _))
+            return true;
+        // Try singular
+        if (candidate.EndsWith('s') && candidate.Length > 2 &&
+            BareMetalWeb.Core.DataScaffold.TryGetEntity(candidate[..^1], out _))
+            return true;
+        return false;
     }
 
     private static string SanitiseInput(string input)


### PR DESCRIPTION
## Enhancement — SLM Text Interface

Follow-up to #1350. Adds structured query capabilities and conversational context to the admin chat SLM.

### Structured filter parsing
- `customers where status equals active` → builds a `QueryDefinition` with `QueryClause(Field=status, Op=Equals, Value=active)`
- Supports natural language operators: equals/is/=, contains/like/has, starts, ends, greater/above/after, less/below/before, not/!=
- `ParseRemainder()` detects `where/with/whose field op value` patterns

### Count handler
- New `count-entity` intent: `how many customers` → returns count
- Supports optional filters: `how many customers where status equals active`

### Conversational context
- Single-slot `_lastEntity` memory carries the entity across follow-up queries
- `show customers` then `how many are active?` → remembers `customers`

### Multi-word entity resolution
- `show work orders` → tries `work-orders` and `workorders` against DataScaffold
- Two-word candidate detection before falling back to single-word

### Response URLs
- `FormatRecord` and `FormatRecordSummary` now include `→ /{slug}/{id}` links

### QueryEntityHandler upgrade
- Now accepts `filterField`/`filterOp`/`filterValue` parameters
- `BuildFilterQuery()` creates proper `QueryDefinition` from parsed filters
- Falls back to text search when no structured filter is present