### PR TITLE
fix: eliminate CLS layout shifts from SPA activation and fixed elements

### DIFF
--- a/BareMetalWeb.Core/wwwroot/static/css/site.css
+++ b/BareMetalWeb.Core/wwwroot/static/css/site.css
@@ -15,6 +15,7 @@ body {
     left: 0;
     right: 0;
     z-index: 1030;
+    contain: layout style;
 }
 
 .bm-navbar .navbar-brand {
@@ -41,6 +42,22 @@ body {
 
 .bm-content {
     min-height: calc(100vh - var(--bm-nav-height) - var(--bm-footer-height));
+    contain: layout style;
+}
+
+/* CLS-safe hiding: removes from visual flow without triggering layout shift */
+.bm-ssr-hidden {
+    visibility: hidden !important;
+    position: absolute !important;
+    width: 0 !important;
+    height: 0 !important;
+    overflow: hidden !important;
+    pointer-events: none !important;
+}
+
+/* Prevent CLS during SPA activation — vnext-root starts hidden, sized to fill */
+#vnext-root:empty {
+    min-height: 0;
 }
 
 .bm-page-card {
@@ -67,6 +84,7 @@ body {
 .bm-footer {
     min-height: var(--bm-footer-height);
     border-top: 1px solid rgba(255, 255, 255, 0.08);
+    contain: layout style;
 }
 
 .bm-table {

--- a/BareMetalWeb.Core/wwwroot/static/js/vnext-app.js
+++ b/BareMetalWeb.Core/wwwroot/static/js/vnext-app.js
@@ -4979,8 +4979,11 @@
   if (!R) return;
 
   // ── SPA Activation: hide server-rendered content, take over navigation ──
+  // Use class-based hiding (not display:none) to avoid CLS — the .bm-ssr-hidden
+  // class uses visibility:hidden + position:absolute so the element is removed
+  // from visual flow without triggering a layout shift.
   const ssrContent = document.querySelector('.bm-ssr-content');
-  if (ssrContent) ssrContent.style.display = 'none';
+  if (ssrContent) ssrContent.classList.add('bm-ssr-hidden');
   R.style.display = '';
 
   // Intercept ALL internal link clicks for SPA navigation (not just [data-go])

--- a/BareMetalWeb.Host/RouteRegistrationExtensions.cs
+++ b/BareMetalWeb.Host/RouteRegistrationExtensions.cs
@@ -1949,7 +1949,7 @@ public static class RouteRegistrationExtensions
         sb.Append("</head>");
         sb.Append("<body>");
         sb.Append(ReplaceTemplateTokens(navbarSection, tokens));
-        sb.Append("<div class=\"container-fluid py-3\" id=\"vnext-content\"><div class=\"text-center py-5\"><div class=\"spinner-border\" role=\"status\"><span class=\"visually-hidden\">Loading...</span></div></div></div>");
+        sb.Append("<div class=\"container-fluid py-4 px-4 bm-content\" id=\"vnext-content\"><div class=\"text-center py-5\"><div class=\"spinner-border\" role=\"status\"><span class=\"visually-hidden\">Loading...</span></div></div></div>");
         sb.Append("<div id=\"vnext-modal-container\"></div>");
         sb.Append("<div id=\"vnext-toast-container\" class=\"position-fixed top-0 end-0 p-3\"></div>");
         sb.Append(ReplaceTemplateTokens(footerElement, tokens));


### PR DESCRIPTION
Closes #1355

## Problem
CLS scores of **0.34–0.998** (poor; target is <0.1) caused by:
1. SPA activation using `display:none` to hide SSR content → full layout recalculation
2. VNext shell `#vnext-content` missing `bm-content` class → inconsistent `min-height`
3. No layout containment on fixed navbar/footer → cascading reflows

## Fixes

### 1. CLS-safe SSR hiding (`site.css`)
`css
.bm-ssr-hidden {
    visibility: hidden !important;
    position: absolute !important;
    width: 0 !important; height: 0 !important;
    overflow: hidden !important;
    pointer-events: none !important;
}
`
Removes element from visual flow **without** triggering layout shift (unlike `display:none`).

### 2. Layout containment (`site.css`)
Added `contain: layout style` to `.bm-navbar`, `.bm-content`, `.bm-footer` — isolates paint/layout recalculations so changes inside one container don't cascade.

### 3. SPA activation (`vnext-app.js`)
`ssrContent.classList.add('bm-ssr-hidden')` replaces `ssrContent.style.display = 'none'`.

### 4. VNext shell consistency (`RouteRegistrationExtensions.cs`)
`div#vnext-content` now has `bm-content` class and `py-4 px-4` padding matching the SSR template.

## Tests
- 146 JS tests pass ✅
- C# build succeeds (0 errors) ✅