### PR TITLE
perf/aot: audit AOT annotations, remove unnecessary reflection fallbacks

### DIFF
--- a/BareMetalWeb.Data/ExpressionEngine/CalculatedFieldService.cs
+++ b/BareMetalWeb.Data/ExpressionEngine/CalculatedFieldService.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using BareMetalWeb.Core;
@@ -306,34 +305,21 @@ public static class CalculatedFieldService
         return dependencies;
     }
 
-    // Cached PropertyInfo[] per type for BuildContext fallback (unregistered types).
-    private static readonly ConcurrentDictionary<Type, System.Reflection.PropertyInfo[]> _propertyCache = new();
-
-    private static Dictionary<string, object?> BuildContext(BaseDataObject instance, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type type)
+    private static Dictionary<string, object?> BuildContext(BaseDataObject instance, Type type)
     {
-        // Use compiled layout for efficient field access when available
         var meta = DataScaffold.GetEntityByType(type);
-        if (meta != null)
-        {
-            var layout = EntityLayoutCompiler.GetOrCompile(meta);
-            var context = new Dictionary<string, object?>(layout.Fields.Length + 4);
-            context["Key"] = instance.Key;
-            foreach (var field in layout.Fields)
-            {
-                try { context[field.Name] = field.Getter(instance); }
-                catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"CalculatedFieldService: field '{field.Name}' getter failed: {ex.Message}"); context[field.Name] = null; }
-            }
-            return context;
-        }
+        if (meta == null)
+            return new Dictionary<string, object?> { ["Key"] = instance.Key };
 
-        // Fallback for unregistered types — cache PropertyInfo[] per type
-        var ctx = new Dictionary<string, object?>();
-        var props = _propertyCache.GetOrAdd(type, static t => t.GetProperties());
-        foreach (var prop in props)
+        var layout = EntityLayoutCompiler.GetOrCompile(meta);
+        var context = new Dictionary<string, object?>(layout.Fields.Length + 4);
+        context["Key"] = instance.Key;
+        foreach (var field in layout.Fields)
         {
-            ctx[prop.Name] = prop.GetValue(instance);
+            try { context[field.Name] = field.Getter(instance); }
+            catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"CalculatedFieldService: field '{field.Name}' getter failed: {ex.Message}"); context[field.Name] = null; }
         }
-        return ctx;
+        return context;
     }
 
     private static bool HasCycle(

--- a/BareMetalWeb.Data/SearchIndexing.cs
+++ b/BareMetalWeb.Data/SearchIndexing.cs
@@ -4,10 +4,8 @@ using System.Buffers.Binary;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Numerics;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
@@ -376,56 +374,33 @@ public sealed class SearchIndexManager
     /// Pre-warms the type metadata cache for the given type so that the first
     /// real query does not pay the reflection/compilation cost.
     /// </summary>
-    public void WarmTypeMetadata([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type type)
+    public void WarmTypeMetadata(Type type)
     {
         GetOrCreateTypeMetadata(type);
     }
 
-    private TypeMetadata GetOrCreateTypeMetadata([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)] Type type)
+    private TypeMetadata GetOrCreateTypeMetadata(Type type)
     {
         return _typeMetadata.GetOrAdd(type, t =>
         {
-            // Prefer DataScaffold metadata (already has compiled delegates) over raw reflection
             var entityMeta = BareMetalWeb.Core.DataScaffold.GetEntityByType(t);
-            if (entityMeta != null)
-            {
-                var indexed = new List<IndexedFieldAccessor>();
-                var kinds = new HashSet<IndexKind>(4);
-                foreach (var f in entityMeta.Fields)
-                {
-                    if (f.DataIndex != null)
-                    {
-                        indexed.Add(new IndexedFieldAccessor(f.Name, f.ClrType, f.GetValueFn, f.DataIndex));
-                        kinds.Add(f.DataIndex.Kind);
-                    }
-                }
-                return new TypeMetadata
-                {
-                    IndexedFields = indexed.ToArray(),
-                    IndexKinds = kinds
-                };
-            }
+            if (entityMeta == null)
+                return new TypeMetadata { IndexedFields = Array.Empty<IndexedFieldAccessor>(), IndexKinds = new HashSet<IndexKind>(0) };
 
-            // Fallback: scan properties directly (startup only, cached)
-            var props = t.GetProperties(BindingFlags.Public | BindingFlags.Instance);
-            var indexedProps = new List<IndexedFieldAccessor>(props.Length);
-            var fallbackKinds = new HashSet<IndexKind>(4);
-
-            foreach (var prop in props)
+            var indexed = new List<IndexedFieldAccessor>();
+            var kinds = new HashSet<IndexKind>(4);
+            foreach (var f in entityMeta.Fields)
             {
-                var attr = prop.GetCustomAttribute<DataIndexAttribute>();
-                if (attr != null)
+                if (f.DataIndex != null)
                 {
-                    var getter = PropertyAccessorFactory.BuildGetter(prop);
-                    indexedProps.Add(new IndexedFieldAccessor(prop.Name, prop.PropertyType, getter, attr));
-                    fallbackKinds.Add(attr.Kind);
+                    indexed.Add(new IndexedFieldAccessor(f.Name, f.ClrType, f.GetValueFn, f.DataIndex));
+                    kinds.Add(f.DataIndex.Kind);
                 }
             }
-
             return new TypeMetadata
             {
-                IndexedFields = indexedProps.ToArray(),
-                IndexKinds = fallbackKinds
+                IndexedFields = indexed.ToArray(),
+                IndexKinds = kinds
             };
         });
     }


### PR DESCRIPTION
## Summary

Comprehensive audit of all 107 AOT annotations in the codebase. Removes 3 unnecessary `[DynamicallyAccessedMembers]` annotations and their reflection fallback code.

### Audit Results

| Annotation | Count | Removable | Still Needed |
|---|---|---|---|
| `[DynamicallyAccessedMembers]` | 22 | **3** | 19 |
| `[RequiresUnreferencedCode]` | 5 | 0 | 5 |
| `[JsonSerializable]` | 77 | 0 | 77 |
| `[JsonSourceGenerationOptions]` | 3 | 0 | 3 |

### Changes

**SearchIndexing.cs** — Removed `GetProperties()` reflection fallback in `GetOrCreateTypeMetadata`. Types must be registered in DataScaffold (metadata-driven architecture). Removed `[DynamicallyAccessedMembers]` from `WarmTypeMetadata` and `GetOrCreateTypeMetadata`. Removed `System.Reflection` and `System.Diagnostics.CodeAnalysis` imports.

**CalculatedFieldService.cs** — Removed `GetProperties()`/`GetValue()` reflection fallback in `BuildContext` and the associated `_propertyCache` field. Removed `[DynamicallyAccessedMembers]` annotation and `System.Diagnostics.CodeAnalysis` import.

### Why the remaining 19 DAM + 5 RequiresUnreferencedCode annotations stay

Every remaining annotation guards **active reflection** that cannot yet be eliminated:
- BinaryObjectSerializer (11 DAM): `GetFields()`, `GetProperties()`, `Activator.CreateInstance()` for type shape building, blittable struct I/O, and member accessor compilation
- DataScaffold (7 DAM, 3 RUC): `GetProperties()`, `GetMethods()`, `MakeGenericType()`, `Activator.CreateInstance()` for entity metadata and child list/dictionary parsing
- ReportExecutor (1 DAM): `GetProperty()` for report field access
- ValidationService (2 RUC): `GetCustomAttributes()` for attribute scanning
- RegisterKnownType (2 DAM): Flow annotations — the trimmer cannot track types through `ConcurrentDictionary`, so these ensure callers preserve type metadata

### Test Results

Build: 0 errors. Tests: same pass/fail counts as baseline (no regressions).

Closes #1384