### PR TITLE
ui: render /metrics as grouped cards with sub-tables

### DIFF
--- a/BareMetalWeb.Core/Interfaces/IMetricsTracker.cs
+++ b/BareMetalWeb.Core/Interfaces/IMetricsTracker.cs
@@ -16,5 +16,6 @@ public interface IMetricsTracker
     void EnterRequest();
     void LeaveRequest();
     void GetMetricTable(out string[] tableColumns, out string[][] tableRows);
+    string GetMetricGroupsHtml();
     MetricsSnapshot GetSnapshot();
 }

--- a/BareMetalWeb.Host.Tests/BareMetalWebServerTests.cs
+++ b/BareMetalWeb.Host.Tests/BareMetalWebServerTests.cs
@@ -1125,6 +1125,7 @@ public class BareMetalWebServerTests : IDisposable
             tableColumns = Array.Empty<string>();
             tableRows = Array.Empty<string[]>();
         }
+        public string GetMetricGroupsHtml() => string.Empty;
         public MetricsSnapshot GetSnapshot() => new MetricsSnapshot(
             0, 0, TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero,
             TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero, 0, 0, 0, 0, 0,

--- a/BareMetalWeb.Host.Tests/LookupApiHandlerTests.cs
+++ b/BareMetalWeb.Host.Tests/LookupApiHandlerTests.cs
@@ -721,6 +721,7 @@ public class LookupApiHandlerTests : IDisposable
             tableColumns = Array.Empty<string>();
             tableRows = Array.Empty<string[]>();
         }
+        public string GetMetricGroupsHtml() => string.Empty;
         public MetricsSnapshot GetSnapshot() => new MetricsSnapshot(
             0, 0, TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero,
             TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero, 0, 0, 0, 0, 0,

--- a/BareMetalWeb.Host.Tests/RouteRegistrationExtensionsTests.cs
+++ b/BareMetalWeb.Host.Tests/RouteRegistrationExtensionsTests.cs
@@ -878,6 +878,7 @@ public class RouteRegistrationExtensionsTests : IDisposable
             tableColumns = Array.Empty<string>();
             tableRows = Array.Empty<string[]>();
         }
+        public string GetMetricGroupsHtml() => string.Empty;
         public MetricsSnapshot GetSnapshot() => new MetricsSnapshot(
             0, 0, TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero,
             TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero, 0, 0, 0, 0, 0,

--- a/BareMetalWeb.Host/MetricsTracker.cs
+++ b/BareMetalWeb.Host/MetricsTracker.cs
@@ -447,4 +447,56 @@ public sealed class MetricsTracker : IMetricsTracker, IDisposable
         }
         return features.ToArray();
     }
+
+    /// <summary>
+    /// Renders metrics as grouped Bootstrap cards, each containing a compact sub-table.
+    /// One card per logical group instead of one row per metric.
+    /// </summary>
+    public string GetMetricGroupsHtml()
+    {
+        GetMetricTable(out _, out string[][] allRows);
+
+        var sb = new System.Text.StringBuilder(4096);
+        sb.Append("<div class=\"row g-3\">");
+
+        string? currentGroup = null;
+        var groupRows = new List<string[]>();
+
+        for (int i = 0; i <= allRows.Length; i++)
+        {
+            bool isHeader = i < allRows.Length && allRows[i].Length >= 2 && allRows[i][1] == "";
+            bool isEnd = i == allRows.Length;
+
+            if ((isHeader || isEnd) && currentGroup != null && groupRows.Count > 0)
+            {
+                sb.Append("<div class=\"col-12 col-lg-6\">");
+                sb.Append("<div class=\"card shadow-sm h-100\">");
+                sb.Append("<div class=\"card-header fw-semibold\">");
+                sb.Append(System.Net.WebUtility.HtmlEncode(currentGroup));
+                sb.Append("</div>");
+                sb.Append("<div class=\"card-body p-0\">");
+                sb.Append("<table class=\"table table-sm table-striped align-middle mb-0\">");
+                sb.Append("<tbody>");
+                foreach (var row in groupRows)
+                {
+                    sb.Append("<tr><td class=\"ps-3\">");
+                    sb.Append(System.Net.WebUtility.HtmlEncode(row[0]));
+                    sb.Append("</td><td class=\"text-end pe-3 text-nowrap\">");
+                    sb.Append(System.Net.WebUtility.HtmlEncode(row[1]));
+                    sb.Append("</td></tr>");
+                }
+                sb.Append("</tbody></table>");
+                sb.Append("</div></div></div>");
+                groupRows.Clear();
+            }
+
+            if (isHeader)
+                currentGroup = allRows[i][0];
+            else if (!isEnd)
+                groupRows.Add(allRows[i]);
+        }
+
+        sb.Append("</div>");
+        return sb.ToString();
+    }
 }

--- a/BareMetalWeb.Host/RouteRegistrationExtensions.cs
+++ b/BareMetalWeb.Host/RouteRegistrationExtensions.cs
@@ -215,9 +215,8 @@ public static class RouteRegistrationExtensions
             routeHandlers.BuildPageHandler(context =>
             {
                 var app = context.GetApp()!;
-                app.Metrics.GetMetricTable(out string[] tableColumns, out string[][] tableRows);
                 context.SetStringValue("title", "Metric Viewer");
-                context.AddTable(tableColumns, tableRows);
+                context.SetStringValue("message", app.Metrics.GetMetricGroupsHtml());
             })));
 
         host.RegisterRoute("GET /metrics/json", new RouteHandlerData(

--- a/BareMetalWeb.Rendering.Tests/HtmlRendererTests.cs
+++ b/BareMetalWeb.Rendering.Tests/HtmlRendererTests.cs
@@ -620,6 +620,7 @@ internal sealed class StubMetricsTracker : IMetricsTracker
         tableColumns = Array.Empty<string>();
         tableRows = Array.Empty<string[]>();
     }
+    public string GetMetricGroupsHtml() => string.Empty;
     public MetricsSnapshot GetSnapshot() => new MetricsSnapshot(
         0, 0, TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero, TimeSpan.FromMilliseconds(1.5),
         TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero, 0, 0, 0, 0, 0, 0, 0, 0, 0, TimeSpan.Zero,


### PR DESCRIPTION
## Summary

Changes the `/metrics` page layout from a flat 2-column table (which on mobile renders as dozens of tiny card-like blocks) to **one Bootstrap card per metric group** with a compact sub-table inside each card.

### Before
- Single flat `<table>` with ~40+ rows
- On mobile, CSS (`.bm-table tbody tr { display: block; border-radius; box-shadow }`) converts each row into a small card
- Hard to read, lots of scrolling

### After
- ~10 cards, one per logical group (Request Statistics, Response Times, Status Codes, Subsystem Timers, GC Statistics, Memory & Process, Environment, SIMD & Vector, Active Acceleration Paths, CPU Features, Cluster)
- Each card has the group emoji+name as header, metrics as a compact sub-table
- Two-column responsive grid (`col-12 col-lg-6`) — single column on mobile, two on desktop
- Fewer DOM elements overall (faster rendering)

### Changes
- **MetricsTracker.cs** — Added `GetMetricGroupsHtml()` which parses the existing `GetMetricTable()` output, groups rows by emoji-header separators, and renders each group as a Bootstrap card with a sub-table
- **IMetricsTracker.cs** — Added `GetMetricGroupsHtml()` to interface
- **RouteRegistrationExtensions.cs** — `/metrics` handler now uses `GetMetricGroupsHtml()` via the `message` template slot instead of `AddTable()`
- **Test mocks** — Added `GetMetricGroupsHtml()` stub to all 4 mock implementations

### Test results
Build: 0 errors. Tests: same pass/fail counts as baseline (no regressions).

Closes #1387