### PR TITLE
feat: chat entities and API endpoint for BitNet engine integration

### DIFF
--- a/BareMetalWeb.Core/wwwroot/static/js/vnext-app.js
+++ b/BareMetalWeb.Core/wwwroot/static/js/vnext-app.js
@@ -5143,6 +5143,18 @@
     toolsLi.appendChild(toolsMenu);
     rightUl.appendChild(toolsLi);
 
+    // Chat icon linking to chat page
+    const chatLi  = el('li', { className: 'nav-item' });
+    const chatA   = el('a', {
+      className: 'nav-link' + (activeSlug === '_chat' ? ' active' : ''),
+      href: BASE + '/_chat',
+      title: 'AI Chat'
+    });
+    chatA.setAttribute('data-go', '');
+    chatA.innerHTML = '<i class="bi bi-chat-dots"></i>';
+    chatLi.appendChild(chatA);
+    rightUl.appendChild(chatLi);
+
     // Bell icon linking to inbox page
     const jobsLi  = el('li', { className: 'nav-item' });
     const jobsA   = el('a', {
@@ -6445,6 +6457,204 @@
     }
   }
 
+  // ── Chat Interface ────────────────────────────────────────────────────────
+
+  function renderChatPage(container) {
+    var row = el('div', { className: 'row g-0 h-100' });
+
+    // Left sidebar — session list
+    var sidebar = el('div', { className: 'col-md-3 col-lg-2 border-end d-flex flex-column h-100' });
+    var sidebarHeader = el('div', { className: 'p-3 border-bottom d-flex align-items-center gap-2' });
+    sidebarHeader.appendChild(el('h6', { className: 'mb-0 flex-grow-1', textContent: '\uD83D\uDCAC Chat' }));
+    var newChatBtn = el('button', { className: 'btn btn-sm btn-primary', innerHTML: '<i class="bi bi-plus-lg"></i>' });
+    sidebarHeader.appendChild(newChatBtn);
+    sidebar.appendChild(sidebarHeader);
+    var sessionList = el('div', { className: 'flex-grow-1 overflow-auto', id: 'chat-session-list' });
+    sidebar.appendChild(sessionList);
+    row.appendChild(sidebar);
+
+    // Right panel — message thread
+    var mainPanel = el('div', { className: 'col-md-9 col-lg-10 d-flex flex-column h-100' });
+    var chatHeader = el('div', { className: 'p-3 border-bottom d-flex align-items-center gap-2', id: 'chat-header' });
+    chatHeader.appendChild(el('h5', { className: 'mb-0', id: 'chat-title', textContent: 'Select or start a conversation' }));
+    mainPanel.appendChild(chatHeader);
+    var messageArea = el('div', { className: 'flex-grow-1 overflow-auto p-3', id: 'chat-messages', style: 'background: var(--bs-body-bg)' });
+    messageArea.innerHTML = '<div class="d-flex flex-column align-items-center justify-content-center h-100 text-muted"><i class="bi bi-chat-dots" style="font-size:3rem"></i><p class="mt-2">Start a new conversation or select one from the sidebar</p></div>';
+    mainPanel.appendChild(messageArea);
+
+    // Input bar
+    var inputBar = el('div', { className: 'p-3 border-top', id: 'chat-input-bar' });
+    inputBar.innerHTML =
+      '<div class="input-group">' +
+        '<textarea class="form-control" id="chat-input" placeholder="Type a message\u2026" rows="1" style="resize:none;max-height:120px"></textarea>' +
+        '<button class="btn btn-primary" id="chat-send-btn" disabled><i class="bi bi-send"></i></button>' +
+      '</div>';
+    mainPanel.appendChild(inputBar);
+    row.appendChild(mainPanel);
+    container.appendChild(row);
+
+    var activeSessionId = null;
+
+    // Load sessions
+    function loadSessions() {
+      apiFetch('/api/chat/sessions').then(function (sessions) {
+        sessionList.innerHTML = '';
+        if (!Array.isArray(sessions) || sessions.length === 0) {
+          sessionList.innerHTML = '<div class="p-3 text-muted small fst-italic">No conversations yet</div>';
+          return;
+        }
+        sessions.forEach(function (s) {
+          var item = el('a', {
+            href: '#',
+            className: 'list-group-item list-group-item-action border-0 py-2 px-3' + (s.id === activeSessionId ? ' active' : '')
+          });
+          item.innerHTML =
+            '<div class="d-flex justify-content-between align-items-start">' +
+              '<div class="text-truncate me-2"><strong class="small">' + escHtml(s.title) + '</strong>' +
+              '<br><small class="text-muted">' + s.messageCount + ' message' + (s.messageCount !== 1 ? 's' : '') + '</small></div>' +
+              '<button class="btn btn-sm btn-link text-danger p-0 chat-delete-btn" data-id="' + s.id + '" title="Delete"><i class="bi bi-trash"></i></button>' +
+            '</div>';
+          item.addEventListener('click', function (e) {
+            if (e.target.closest('.chat-delete-btn')) return;
+            e.preventDefault();
+            activeSessionId = s.id;
+            loadSession(s.id);
+            loadSessions();
+          });
+          var deleteBtn = item.querySelector('.chat-delete-btn');
+          deleteBtn.addEventListener('click', function (e) {
+            e.preventDefault();
+            e.stopPropagation();
+            if (!confirm('Delete this conversation?')) return;
+            apiFetch('/api/chat/sessions/' + s.id, {
+              method: 'DELETE',
+              headers: { 'X-CSRF-Token': getCsrfToken() }
+            }).then(function () {
+              if (activeSessionId === s.id) {
+                activeSessionId = null;
+                messageArea.innerHTML = '<div class="d-flex flex-column align-items-center justify-content-center h-100 text-muted"><i class="bi bi-chat-dots" style="font-size:3rem"></i><p class="mt-2">Start a new conversation</p></div>';
+                document.getElementById('chat-title').textContent = 'Select or start a conversation';
+              }
+              loadSessions();
+            });
+          });
+          sessionList.appendChild(item);
+        });
+      });
+    }
+
+    // Load a specific session
+    function loadSession(sessionId) {
+      apiFetch('/api/chat/sessions/' + sessionId).then(function (data) {
+        document.getElementById('chat-title').textContent = data.title;
+        renderMessages(data.messages || []);
+        activeSessionId = sessionId;
+      });
+    }
+
+    // Render messages
+    function renderMessages(messages) {
+      messageArea.innerHTML = '';
+      if (messages.length === 0) {
+        messageArea.innerHTML = '<div class="text-muted text-center mt-4">No messages yet. Say hello!</div>';
+        return;
+      }
+      messages.forEach(function (m) { appendMessage(m); });
+      messageArea.scrollTop = messageArea.scrollHeight;
+    }
+
+    function appendMessage(m) {
+      var isUser = m.role === 'user';
+      var wrap = el('div', { className: 'd-flex mb-3 ' + (isUser ? 'justify-content-end' : 'justify-content-start') });
+      var bubble = el('div', {
+        className: 'p-2 px-3 rounded-3 ' + (isUser ? 'bg-primary text-white' : 'bg-body-secondary'),
+        style: 'max-width:75%;white-space:pre-wrap;word-break:break-word'
+      });
+      bubble.textContent = m.content;
+      if (!isUser && m.latencyMs > 0) {
+        var meta = el('div', { className: 'mt-1 small ' + (isUser ? 'text-white-50' : 'text-muted') });
+        meta.textContent = m.latencyMs + 'ms';
+        if (m.resolvedIntent && m.resolvedIntent !== 'unknown') meta.textContent += ' \u00B7 ' + m.resolvedIntent;
+        if (m.confidence > 0) meta.textContent += ' (' + (m.confidence * 100).toFixed(0) + '%)';
+        bubble.appendChild(meta);
+      }
+      wrap.appendChild(bubble);
+      messageArea.appendChild(wrap);
+    }
+
+    // New chat button
+    newChatBtn.addEventListener('click', function () {
+      apiFetch('/api/chat/sessions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': getCsrfToken() },
+        body: JSON.stringify({ title: 'New Chat' })
+      }).then(function (data) {
+        activeSessionId = data.id;
+        loadSessions();
+        loadSession(data.id);
+      });
+    });
+
+    // Input handling
+    var inputEl = document.getElementById('chat-input');
+    var sendBtn = document.getElementById('chat-send-btn');
+
+    inputEl.addEventListener('input', function () {
+      sendBtn.disabled = !inputEl.value.trim() || !activeSessionId;
+      inputEl.style.height = 'auto';
+      inputEl.style.height = Math.min(inputEl.scrollHeight, 120) + 'px';
+    });
+
+    inputEl.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        if (!sendBtn.disabled) sendBtn.click();
+      }
+    });
+
+    sendBtn.addEventListener('click', function () {
+      var content = inputEl.value.trim();
+      if (!content || !activeSessionId) return;
+
+      // Optimistically show user message
+      appendMessage({ role: 'user', content: content });
+      messageArea.scrollTop = messageArea.scrollHeight;
+      inputEl.value = '';
+      inputEl.style.height = 'auto';
+      sendBtn.disabled = true;
+
+      // Show typing indicator
+      var typingEl = el('div', { className: 'd-flex mb-3 justify-content-start', id: 'chat-typing' });
+      var typingBubble = el('div', { className: 'p-2 px-3 rounded-3 bg-body-secondary' });
+      typingBubble.innerHTML = '<span class="spinner-grow spinner-grow-sm me-1"></span><span class="spinner-grow spinner-grow-sm me-1" style="animation-delay:.15s"></span><span class="spinner-grow spinner-grow-sm" style="animation-delay:.3s"></span>';
+      typingEl.appendChild(typingBubble);
+      messageArea.appendChild(typingEl);
+      messageArea.scrollTop = messageArea.scrollHeight;
+
+      apiFetch('/api/chat/sessions/' + activeSessionId + '/messages', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': getCsrfToken() },
+        body: JSON.stringify({ content: content })
+      }).then(function (data) {
+        var typing = document.getElementById('chat-typing');
+        if (typing) typing.remove();
+        appendMessage(data.assistantMessage);
+        messageArea.scrollTop = messageArea.scrollHeight;
+        sendBtn.disabled = false;
+        // Update session title in sidebar if it changed
+        loadSessions();
+      }).catch(function (err) {
+        var typing = document.getElementById('chat-typing');
+        if (typing) typing.remove();
+        appendMessage({ role: 'assistant', content: 'Error: ' + err.message, latencyMs: 0 });
+        messageArea.scrollTop = messageArea.scrollHeight;
+        sendBtn.disabled = false;
+      });
+    });
+
+    loadSessions();
+  }
+
   async function route() {
     // Cancel any in-flight navigation fetches from the previous route
     cancelNavigation();
@@ -6601,6 +6811,15 @@
         const main = el('div', { className: 'container-fluid mt-3' });
         R.appendChild(main);
         renderModuleEditorPage(main, rawId);
+        wire(); return;
+      }
+
+      // ── Chat page ─────────────────────────────────────────────────────────
+      if (slug === '_chat') {
+        R.replaceChildren(navbar('_chat'));
+        const main = el('div', { className: 'container-fluid mt-3', style: 'height: calc(100vh - 80px)' });
+        R.appendChild(main);
+        renderChatPage(main);
         wire(); return;
       }
 

--- a/BareMetalWeb.Data/SystemEntitySchemas.cs
+++ b/BareMetalWeb.Data/SystemEntitySchemas.cs
@@ -216,6 +216,26 @@ public static class SystemEntitySchemas
         .AddField("Enabled", FieldType.Bool, typeof(bool))
         .Build();
 
+    public static EntitySchema ChatSession { get; } = new EntitySchema.Builder("ChatSession", "chat-sessions")
+        .AddField("UserName", FieldType.StringUtf8, typeof(string), required: true, indexed: true)
+        .AddField("Title", FieldType.StringUtf8, typeof(string), required: true)
+        .AddField("CreatedAtUtc", FieldType.DateTime, typeof(DateTime))
+        .AddField("UpdatedAtUtc", FieldType.DateTime, typeof(DateTime))
+        .AddField("MessageCount", FieldType.Int32, typeof(int))
+        .AddField("Status", FieldType.StringUtf8, typeof(string))
+        .Build();
+
+    public static EntitySchema ChatMessage { get; } = new EntitySchema.Builder("ChatMessage", "chat-messages")
+        .AddField("SessionId", FieldType.UInt32, typeof(uint), required: true, indexed: true)
+        .AddField("Role", FieldType.StringUtf8, typeof(string), required: true)
+        .AddField("Content", FieldType.StringUtf8, typeof(string), required: true)
+        .AddField("TimestampUtc", FieldType.DateTime, typeof(DateTime))
+        .AddField("TokenCount", FieldType.Int32, typeof(int))
+        .AddField("LatencyMs", FieldType.Int32, typeof(int))
+        .AddField("ResolvedIntent", FieldType.StringUtf8, typeof(string))
+        .AddField("Confidence", FieldType.Decimal, typeof(decimal))
+        .Build();
+
     /// <summary>All system entity schemas, for bulk registration.</summary>
     public static IReadOnlyList<EntitySchema> All { get; } = new[]
     {
@@ -226,6 +246,8 @@ public static class SystemEntitySchemas
         ActionDefinition, ActionCommandDefinition,
         SessionLog,
         RecordComment,
-        Module
+        Module,
+        ChatSession,
+        ChatMessage
     };
 }

--- a/BareMetalWeb.Host/AgentApiHandlers.cs
+++ b/BareMetalWeb.Host/AgentApiHandlers.cs
@@ -23,6 +23,15 @@ public static class AgentApiHandlers
 
     private static IntelligenceOrchestrator GetOrchestrator()
     {
+        return GetOrCreateOrchestrator();
+    }
+
+    /// <summary>
+    /// Get or create the shared IntelligenceOrchestrator instance.
+    /// Used by chat API routes and the agent panel.
+    /// </summary>
+    public static IntelligenceOrchestrator GetOrCreateOrchestrator()
+    {
         if (_orchestrator is not null)
             return _orchestrator;
 

--- a/BareMetalWeb.Host/BareMetalWebExtensions.cs
+++ b/BareMetalWeb.Host/BareMetalWebExtensions.cs
@@ -378,6 +378,7 @@ public static class BareMetalWebExtensions
         appInfo.RegisterReportRoutes(pageInfoFactory);
         appInfo.RegisterDashboardRoutes(pageInfoFactory);
         appInfo.RegisterModuleRoutes(pageInfoFactory);
+        appInfo.RegisterChatRoutes(pageInfoFactory);
         appInfo.RegisterViewRoutes(pageInfoFactory);
         appInfo.RegisterMcpRoutes(pageInfoFactory);
         appInfo.RegisterOpenApiRoute(pageInfoFactory);

--- a/BareMetalWeb.Host/RouteRegistrationExtensions.cs
+++ b/BareMetalWeb.Host/RouteRegistrationExtensions.cs
@@ -2663,6 +2663,359 @@ public static class RouteRegistrationExtensions
             }));
     }
 
+    // ── Chat API Routes ───────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Registers JSON API routes for the Chat feature.
+    /// <list type="bullet">
+    ///   <item><c>GET  /api/chat/sessions</c> — list sessions for current user</item>
+    ///   <item><c>POST /api/chat/sessions</c> — create a new session</item>
+    ///   <item><c>GET  /api/chat/sessions/{id}</c> — session detail with messages</item>
+    ///   <item><c>DELETE /api/chat/sessions/{id}</c> — delete a session</item>
+    ///   <item><c>POST /api/chat/sessions/{id}/messages</c> — send message, get AI response</item>
+    ///   <item><c>GET  /api/chat/sessions/{id}/messages</c> — paginated message history</item>
+    /// </list>
+    /// </summary>
+    public static void RegisterChatRoutes(
+        this IBareWebHost host,
+        IPageInfoFactory pageInfoFactory)
+    {
+        var raw = pageInfoFactory.RawPage("", false);
+
+        // ── GET /api/chat/sessions — list user's sessions ────────────────────
+        host.RegisterRoute("GET /api/chat/sessions", new RouteHandlerData(raw, async context =>
+        {
+            var user = await UserAuth.GetRequestUserAsync(context, context.RequestAborted).ConfigureAwait(false);
+            if (user == null) { context.Response.StatusCode = 401; return; }
+
+            var query = new QueryDefinition
+            {
+                Clauses = new List<QueryClause>
+                {
+                    new() { Field = "UserName", Operator = QueryOperator.Equals, Value = user.UserName }
+                },
+                Sorts = new List<SortClause>
+                {
+                    new() { Field = "UpdatedAtUtc", Direction = SortDirection.Desc }
+                },
+                Top = 50
+            };
+            var sessions = DataStoreProvider.Current.Query<Runtime.ChatSession>(query).ToList();
+
+            context.Response.ContentType = "application/json";
+            var payload = new Dictionary<string, object?>[sessions.Count];
+            for (int i = 0; i < sessions.Count; i++)
+            {
+                var s = sessions[i];
+                payload[i] = new Dictionary<string, object?>
+                {
+                    ["id"] = s.Key,
+                    ["title"] = s.Title,
+                    ["createdAtUtc"] = s.CreatedAtUtc,
+                    ["updatedAtUtc"] = s.UpdatedAtUtc,
+                    ["messageCount"] = s.MessageCount,
+                    ["status"] = s.Status
+                };
+            }
+            await using (var w = new Utf8JsonWriter(context.Response.Body, s_compactWriterOptions))
+            {
+                JsonWriterHelper.WriteValue(w, payload);
+            }
+        }));
+
+        // ── POST /api/chat/sessions — create a new session ───────────────────
+        host.RegisterRoute("POST /api/chat/sessions", new RouteHandlerData(raw, async context =>
+        {
+            var user = await UserAuth.GetRequestUserAsync(context, context.RequestAborted).ConfigureAwait(false);
+            if (user == null) { context.Response.StatusCode = 401; return; }
+
+            if (!CsrfProtection.ValidateApiToken(context))
+            { context.Response.StatusCode = 403; context.Response.ContentType = "application/json"; await context.Response.WriteAsync("{\"error\":\"CSRF validation failed\"}"); return; }
+
+            string title = "New Chat";
+            if (context.HttpRequest.ContentLength > 0)
+            {
+                using var doc = await JsonDocument.ParseAsync(context.HttpRequest.Body, default, context.RequestAborted).ConfigureAwait(false);
+                if (doc.RootElement.TryGetProperty("title", out var titleProp))
+                    title = titleProp.GetString() ?? title;
+            }
+
+            var session = new Runtime.ChatSession
+            {
+                UserName = user.UserName,
+                Title = title,
+                CreatedAtUtc = DateTime.UtcNow,
+                UpdatedAtUtc = DateTime.UtcNow,
+                MessageCount = 0,
+                Status = "active"
+            };
+            await DataStoreProvider.Current.SaveAsync(session, context.RequestAborted).ConfigureAwait(false);
+
+            context.Response.StatusCode = 201;
+            context.Response.ContentType = "application/json";
+            await using (var w = new Utf8JsonWriter(context.Response.Body, s_compactWriterOptions))
+            {
+                w.WriteStartObject();
+                w.WriteNumber("id", session.Key);
+                w.WriteString("title", session.Title);
+                w.WriteString("createdAtUtc", session.CreatedAtUtc);
+                w.WriteEndObject();
+            }
+        }));
+
+        // ── GET /api/chat/sessions/{id} — session detail with messages ───────
+        host.RegisterRoute("GET /api/chat/sessions/{id}", new RouteHandlerData(raw, async context =>
+        {
+            var user = await UserAuth.GetRequestUserAsync(context, context.RequestAborted).ConfigureAwait(false);
+            if (user == null) { context.Response.StatusCode = 401; return; }
+
+            var idStr = GetRouteParam(context, "id");
+            if (!uint.TryParse(idStr, out var sessionId))
+            { context.Response.StatusCode = 400; context.Response.ContentType = "application/json"; await context.Response.WriteAsync("{\"error\":\"Invalid session id\"}"); return; }
+
+            var session = await DataStoreProvider.Current.LoadAsync<Runtime.ChatSession>(sessionId, context.RequestAborted).ConfigureAwait(false);
+            if (session == null || !string.Equals(session.UserName, user.UserName, StringComparison.OrdinalIgnoreCase))
+            { context.Response.StatusCode = 404; context.Response.ContentType = "application/json"; await context.Response.WriteAsync("{\"error\":\"Session not found\"}"); return; }
+
+            var msgQuery = new QueryDefinition
+            {
+                Clauses = new List<QueryClause>
+                {
+                    new() { Field = "SessionId", Operator = QueryOperator.Equals, Value = sessionId }
+                },
+                Sorts = new List<SortClause>
+                {
+                    new() { Field = "TimestampUtc", Direction = SortDirection.Asc }
+                },
+                Top = 200
+            };
+            var messages = DataStoreProvider.Current.Query<Runtime.ChatMessage>(msgQuery).ToList();
+
+            context.Response.ContentType = "application/json";
+            await using (var w = new Utf8JsonWriter(context.Response.Body, s_compactWriterOptions))
+            {
+                w.WriteStartObject();
+                w.WriteNumber("id", session.Key);
+                w.WriteString("title", session.Title);
+                w.WriteString("status", session.Status);
+                w.WriteString("createdAtUtc", session.CreatedAtUtc);
+                w.WriteString("updatedAtUtc", session.UpdatedAtUtc);
+                w.WriteNumber("messageCount", session.MessageCount);
+
+                w.WritePropertyName("messages");
+                w.WriteStartArray();
+                foreach (var m in messages)
+                {
+                    w.WriteStartObject();
+                    w.WriteNumber("id", m.Key);
+                    w.WriteString("role", m.Role);
+                    w.WriteString("content", m.Content);
+                    w.WriteString("timestampUtc", m.TimestampUtc);
+                    w.WriteNumber("tokenCount", m.TokenCount);
+                    w.WriteNumber("latencyMs", m.LatencyMs);
+                    w.WriteString("resolvedIntent", m.ResolvedIntent);
+                    w.WriteNumber("confidence", m.Confidence);
+                    w.WriteEndObject();
+                }
+                w.WriteEndArray();
+                w.WriteEndObject();
+            }
+        }));
+
+        // ── DELETE /api/chat/sessions/{id} — delete a session ────────────────
+        host.RegisterRoute("DELETE /api/chat/sessions/{id}", new RouteHandlerData(raw, async context =>
+        {
+            var user = await UserAuth.GetRequestUserAsync(context, context.RequestAborted).ConfigureAwait(false);
+            if (user == null) { context.Response.StatusCode = 401; return; }
+
+            if (!CsrfProtection.ValidateApiToken(context))
+            { context.Response.StatusCode = 403; context.Response.ContentType = "application/json"; await context.Response.WriteAsync("{\"error\":\"CSRF validation failed\"}"); return; }
+
+            var idStr = GetRouteParam(context, "id");
+            if (!uint.TryParse(idStr, out var sessionId))
+            { context.Response.StatusCode = 400; return; }
+
+            var session = await DataStoreProvider.Current.LoadAsync<Runtime.ChatSession>(sessionId, context.RequestAborted).ConfigureAwait(false);
+            if (session == null || !string.Equals(session.UserName, user.UserName, StringComparison.OrdinalIgnoreCase))
+            { context.Response.StatusCode = 404; return; }
+
+            // Delete all messages in the session
+            var msgQuery = new QueryDefinition
+            {
+                Clauses = new List<QueryClause>
+                {
+                    new() { Field = "SessionId", Operator = QueryOperator.Equals, Value = sessionId }
+                }
+            };
+            var messages = DataStoreProvider.Current.Query<Runtime.ChatMessage>(msgQuery).ToList();
+            foreach (var msg in messages)
+                await DataStoreProvider.Current.DeleteAsync<Runtime.ChatMessage>(msg.Key, context.RequestAborted).ConfigureAwait(false);
+
+            await DataStoreProvider.Current.DeleteAsync<Runtime.ChatSession>(sessionId, context.RequestAborted).ConfigureAwait(false);
+
+            context.Response.StatusCode = 200;
+            context.Response.ContentType = "application/json";
+            await context.Response.WriteAsync("{\"ok\":true}");
+        }));
+
+        // ── POST /api/chat/sessions/{id}/messages — send message, get AI reply ─
+        host.RegisterRoute("POST /api/chat/sessions/{id}/messages", new RouteHandlerData(raw, async context =>
+        {
+            var user = await UserAuth.GetRequestUserAsync(context, context.RequestAborted).ConfigureAwait(false);
+            if (user == null) { context.Response.StatusCode = 401; return; }
+
+            if (!CsrfProtection.ValidateApiToken(context))
+            { context.Response.StatusCode = 403; context.Response.ContentType = "application/json"; await context.Response.WriteAsync("{\"error\":\"CSRF validation failed\"}"); return; }
+
+            var idStr = GetRouteParam(context, "id");
+            if (!uint.TryParse(idStr, out var sessionId))
+            { context.Response.StatusCode = 400; context.Response.ContentType = "application/json"; await context.Response.WriteAsync("{\"error\":\"Invalid session id\"}"); return; }
+
+            var session = await DataStoreProvider.Current.LoadAsync<Runtime.ChatSession>(sessionId, context.RequestAborted).ConfigureAwait(false);
+            if (session == null || !string.Equals(session.UserName, user.UserName, StringComparison.OrdinalIgnoreCase))
+            { context.Response.StatusCode = 404; context.Response.ContentType = "application/json"; await context.Response.WriteAsync("{\"error\":\"Session not found\"}"); return; }
+
+            using var doc = await JsonDocument.ParseAsync(context.HttpRequest.Body, default, context.RequestAborted).ConfigureAwait(false);
+            var content = doc.RootElement.TryGetProperty("content", out var cp)
+                ? cp.GetString() ?? ""
+                : doc.RootElement.TryGetProperty("message", out var mp)
+                    ? mp.GetString() ?? ""
+                    : "";
+
+            if (string.IsNullOrWhiteSpace(content))
+            { context.Response.StatusCode = 400; context.Response.ContentType = "application/json"; await context.Response.WriteAsync("{\"error\":\"Missing message content\"}"); return; }
+
+            // Save user message
+            var userMsg = new Runtime.ChatMessage
+            {
+                SessionId = sessionId,
+                Role = "user",
+                Content = content,
+                TimestampUtc = DateTime.UtcNow,
+                TokenCount = EstimateTokens(content)
+            };
+            await DataStoreProvider.Current.SaveAsync(userMsg, context.RequestAborted).ConfigureAwait(false);
+
+            // Invoke the IntelligenceOrchestrator
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            Intelligence.ChatResponse aiResponse;
+            try
+            {
+                var orchestrator = AgentApiHandlers.GetOrCreateOrchestrator();
+                aiResponse = await orchestrator.ProcessAsync(content, context.RequestAborted).ConfigureAwait(false);
+            }
+            catch
+            {
+                aiResponse = new Intelligence.ChatResponse("Sorry, an error occurred processing your request.", "error", 0f);
+            }
+            sw.Stop();
+
+            // Save assistant message
+            var assistantMsg = new Runtime.ChatMessage
+            {
+                SessionId = sessionId,
+                Role = "assistant",
+                Content = aiResponse.Message,
+                TimestampUtc = DateTime.UtcNow,
+                TokenCount = EstimateTokens(aiResponse.Message),
+                LatencyMs = (int)sw.ElapsedMilliseconds,
+                ResolvedIntent = aiResponse.ResolvedIntent,
+                Confidence = (decimal)aiResponse.Confidence
+            };
+            await DataStoreProvider.Current.SaveAsync(assistantMsg, context.RequestAborted).ConfigureAwait(false);
+
+            // Update session
+            session.MessageCount += 2;
+            session.UpdatedAtUtc = DateTime.UtcNow;
+            if (session.MessageCount == 2 && session.Title == "New Chat")
+                session.Title = content.Length > 60 ? content[..57] + "..." : content;
+            await DataStoreProvider.Current.SaveAsync(session, context.RequestAborted).ConfigureAwait(false);
+
+            // Return the assistant response
+            context.Response.ContentType = "application/json";
+            await using (var w = new Utf8JsonWriter(context.Response.Body, s_compactWriterOptions))
+            {
+                w.WriteStartObject();
+                w.WriteStartObject("userMessage");
+                w.WriteNumber("id", userMsg.Key);
+                w.WriteString("role", "user");
+                w.WriteString("content", content);
+                w.WriteString("timestampUtc", userMsg.TimestampUtc);
+                w.WriteEndObject();
+
+                w.WriteStartObject("assistantMessage");
+                w.WriteNumber("id", assistantMsg.Key);
+                w.WriteString("role", "assistant");
+                w.WriteString("content", aiResponse.Message);
+                w.WriteString("timestampUtc", assistantMsg.TimestampUtc);
+                w.WriteNumber("latencyMs", assistantMsg.LatencyMs);
+                w.WriteString("resolvedIntent", aiResponse.ResolvedIntent);
+                w.WriteNumber("confidence", assistantMsg.Confidence);
+                w.WriteEndObject();
+                w.WriteEndObject();
+            }
+        }));
+
+        // ── GET /api/chat/sessions/{id}/messages — paginated history ─────────
+        host.RegisterRoute("GET /api/chat/sessions/{id}/messages", new RouteHandlerData(raw, async context =>
+        {
+            var user = await UserAuth.GetRequestUserAsync(context, context.RequestAborted).ConfigureAwait(false);
+            if (user == null) { context.Response.StatusCode = 401; return; }
+
+            var idStr = GetRouteParam(context, "id");
+            if (!uint.TryParse(idStr, out var sessionId))
+            { context.Response.StatusCode = 400; return; }
+
+            var session = await DataStoreProvider.Current.LoadAsync<Runtime.ChatSession>(sessionId, context.RequestAborted).ConfigureAwait(false);
+            if (session == null || !string.Equals(session.UserName, user.UserName, StringComparison.OrdinalIgnoreCase))
+            { context.Response.StatusCode = 404; return; }
+
+            int skip = 0, top = 50;
+            if (context.HttpRequest.Query.TryGetValue("skip", out var skipVal) && int.TryParse(skipVal.FirstOrDefault(), out var s)) skip = s;
+            if (context.HttpRequest.Query.TryGetValue("top", out var topVal) && int.TryParse(topVal.FirstOrDefault(), out var t)) top = Math.Min(t, 200);
+
+            var msgQuery = new QueryDefinition
+            {
+                Clauses = new List<QueryClause>
+                {
+                    new() { Field = "SessionId", Operator = QueryOperator.Equals, Value = sessionId }
+                },
+                Sorts = new List<SortClause>
+                {
+                    new() { Field = "TimestampUtc", Direction = SortDirection.Asc }
+                },
+                Skip = skip,
+                Top = top
+            };
+            var messages = DataStoreProvider.Current.Query<Runtime.ChatMessage>(msgQuery).ToList();
+
+            context.Response.ContentType = "application/json";
+            var payload = new Dictionary<string, object?>[messages.Count];
+            for (int i = 0; i < messages.Count; i++)
+            {
+                var m = messages[i];
+                payload[i] = new Dictionary<string, object?>
+                {
+                    ["id"] = m.Key,
+                    ["role"] = m.Role,
+                    ["content"] = m.Content,
+                    ["timestampUtc"] = m.TimestampUtc,
+                    ["tokenCount"] = m.TokenCount,
+                    ["latencyMs"] = m.LatencyMs,
+                    ["resolvedIntent"] = m.ResolvedIntent,
+                    ["confidence"] = m.Confidence
+                };
+            }
+            await using (var w = new Utf8JsonWriter(context.Response.Body, s_compactWriterOptions))
+            {
+                JsonWriterHelper.WriteValue(w, payload);
+            }
+        }));
+    }
+
+    /// <summary>Rough token estimate: ~4 chars per token.</summary>
+    private static int EstimateTokens(string text) => (text.Length + 3) / 4;
+
     // ── View Engine Routes ────────────────────────────────────────────────────
 
     /// <summary>

--- a/BareMetalWeb.Runtime/ChatMessage.cs
+++ b/BareMetalWeb.Runtime/ChatMessage.cs
@@ -1,0 +1,47 @@
+using BareMetalWeb.Data;
+using BareMetalWeb.Rendering.Models;
+
+namespace BareMetalWeb.Runtime;
+
+/// <summary>
+/// Persisted chat message within a <see cref="ChatSession"/>.
+/// Each record is a single turn (user prompt or assistant response).
+/// </summary>
+[DataEntity("Chat Messages", ShowOnNav = false, NavGroup = "Admin", NavOrder = 1011)]
+public class ChatMessage : BaseDataObject
+{
+    /// <summary>Foreign key to the owning ChatSession.</summary>
+    [DataField(Label = "Session", Order = 1, Required = true, List = true, View = true)]
+    [DataIndex]
+    public uint SessionId { get; set; }
+
+    /// <summary>Message role: user, assistant, or system.</summary>
+    [DataField(Label = "Role", Order = 2, Required = true, List = true, View = true, FieldType = FormFieldType.Enum)]
+    public string Role { get; set; } = "user";
+
+    /// <summary>Message content (plain text).</summary>
+    [DataField(Label = "Content", Order = 3, Required = true, View = true, FieldType = FormFieldType.TextArea)]
+    public string Content { get; set; } = string.Empty;
+
+    /// <summary>UTC timestamp when the message was created.</summary>
+    [DataField(Label = "Timestamp", Order = 4, List = true, View = true, ReadOnly = true, FieldType = FormFieldType.DateTime)]
+    public DateTime TimestampUtc { get; set; }
+
+    /// <summary>Approximate token count for this message.</summary>
+    [DataField(Label = "Tokens", Order = 5, View = true, ReadOnly = true, FieldType = FormFieldType.Integer)]
+    public int TokenCount { get; set; }
+
+    /// <summary>Inference latency in milliseconds (assistant messages only).</summary>
+    [DataField(Label = "Latency (ms)", Order = 6, View = true, ReadOnly = true, FieldType = FormFieldType.Integer)]
+    public int LatencyMs { get; set; }
+
+    /// <summary>Resolved intent from the orchestrator (for diagnostics).</summary>
+    [DataField(Label = "Intent", Order = 7, View = true, ReadOnly = true)]
+    public string ResolvedIntent { get; set; } = string.Empty;
+
+    /// <summary>Confidence score from intent classification.</summary>
+    [DataField(Label = "Confidence", Order = 8, View = true, ReadOnly = true, FieldType = FormFieldType.Decimal)]
+    public decimal Confidence { get; set; }
+
+    public override string ToString() => $"[{Role}] {Content[..Math.Min(Content.Length, 50)]}";
+}

--- a/BareMetalWeb.Runtime/ChatSession.cs
+++ b/BareMetalWeb.Runtime/ChatSession.cs
@@ -1,0 +1,39 @@
+using BareMetalWeb.Data;
+using BareMetalWeb.Rendering.Models;
+
+namespace BareMetalWeb.Runtime;
+
+/// <summary>
+/// Persisted chat session. Groups a conversation between a user and the
+/// BitNet inference engine, maintaining context across multiple turns.
+/// </summary>
+[DataEntity("Chat Sessions", ShowOnNav = false, NavGroup = "Admin", NavOrder = 1010)]
+public class ChatSession : BaseDataObject
+{
+    /// <summary>Username of the session owner.</summary>
+    [DataField(Label = "User", Order = 1, Required = true, List = true, View = true)]
+    [DataIndex]
+    public string UserName { get; set; } = string.Empty;
+
+    /// <summary>Short title summarising the conversation.</summary>
+    [DataField(Label = "Title", Order = 2, Required = true, List = true, View = true, Edit = true)]
+    public string Title { get; set; } = string.Empty;
+
+    /// <summary>UTC timestamp when the session was created.</summary>
+    [DataField(Label = "Created", Order = 3, List = true, View = true, ReadOnly = true, FieldType = FormFieldType.DateTime)]
+    public DateTime CreatedAtUtc { get; set; }
+
+    /// <summary>UTC timestamp of the last message in the session.</summary>
+    [DataField(Label = "Last Message", Order = 4, List = true, View = true, ReadOnly = true, FieldType = FormFieldType.DateTime)]
+    public DateTime UpdatedAtUtc { get; set; }
+
+    /// <summary>Number of messages in the session (user + assistant).</summary>
+    [DataField(Label = "Messages", Order = 5, List = true, View = true, ReadOnly = true, FieldType = FormFieldType.Integer)]
+    public int MessageCount { get; set; }
+
+    /// <summary>Session status: active, archived.</summary>
+    [DataField(Label = "Status", Order = 6, List = true, View = true, FieldType = FormFieldType.Enum)]
+    public string Status { get; set; } = "active";
+
+    public override string ToString() => Title;
+}


### PR DESCRIPTION
Closes #1405

Adds ChatSession/ChatMessage entities with full CRUD API and VNext SPA chat interface wired to the IntelligenceOrchestrator.

**Backend:**
- ChatSession + ChatMessage entity classes with WAL persistence
- System schemas added to SystemEntitySchemas.cs
- 6 API endpoints: list/create/get/delete sessions, send messages, get history
- Messages invoke IntelligenceOrchestrator (keyword+BitNet pipeline)
- Tracks latency, token counts, resolved intents per message

**Frontend:**
- Chat icon in top nav bar
- Full-height split layout: session sidebar + message thread
- Chat bubbles with typing indicator and latency metadata
- Enter to send, Shift+Enter for newlines
- Auto-title sessions from first message