### PR TITLE
feat: hyper-limited service principals with role-scoped authorization (#1393)

### DIFF
--- a/BareMetalWeb.Data.Tests/PrincipalAuthorizationPolicyTests.cs
+++ b/BareMetalWeb.Data.Tests/PrincipalAuthorizationPolicyTests.cs
@@ -1,0 +1,320 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using BareMetalWeb.Data;
+using BareMetalWeb.Data.Interfaces;
+using Xunit;
+
+namespace BareMetalWeb.Data.Tests;
+
+[Collection("SharedState")]
+public sealed class PrincipalAuthorizationPolicyTests : IDisposable
+{
+    private readonly string _testFolder;
+    private readonly IDataObjectStore _store;
+    private readonly AuditService _auditService;
+
+    public PrincipalAuthorizationPolicyTests()
+    {
+        _testFolder = Path.Combine(Path.GetTempPath(), $"principal-auth-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_testFolder);
+
+        var provider = new WalDataProvider(_testFolder);
+        _store = new DataObjectStore();
+        _store.RegisterProvider(provider);
+        DataStoreProvider.Current = _store;
+
+        _auditService = new AuditService(_store) { RunSynchronously = true };
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_testFolder))
+                Directory.Delete(_testFolder, true);
+        }
+        catch { }
+    }
+
+    // ── AsRestrictedPrincipal ──────────────────────────────────────────
+
+    [Fact]
+    public void AsRestrictedPrincipal_RegularUser_ReturnsNull()
+    {
+        var user = new User { UserName = "alice" };
+        Assert.Null(PrincipalAuthorizationPolicy.AsRestrictedPrincipal(user));
+    }
+
+    [Fact]
+    public void AsRestrictedPrincipal_FullAccessPrincipal_ReturnsNull()
+    {
+        var sp = new SystemPrincipal { UserName = "deploy-full", Role = PrincipalRole.FullAccess };
+        Assert.Null(PrincipalAuthorizationPolicy.AsRestrictedPrincipal(sp));
+    }
+
+    [Theory]
+    [InlineData(PrincipalRole.DeploymentProcess)]
+    [InlineData(PrincipalRole.DeploymentAgent)]
+    [InlineData(PrincipalRole.TenantCallback)]
+    public void AsRestrictedPrincipal_RestrictedRole_ReturnsPrincipal(PrincipalRole role)
+    {
+        var sp = new SystemPrincipal { UserName = "sp-test", Role = role };
+        var result = PrincipalAuthorizationPolicy.AsRestrictedPrincipal(sp);
+        Assert.NotNull(result);
+        Assert.Same(sp, result);
+    }
+
+    [Fact]
+    public void AsRestrictedPrincipal_NullUser_ReturnsNull()
+    {
+        Assert.Null(PrincipalAuthorizationPolicy.AsRestrictedPrincipal(null));
+    }
+
+    // ── DeploymentProcess role ─────────────────────────────────────────
+
+    [Theory]
+    [InlineData("orders", "Read")]
+    [InlineData("orders", "Create")]
+    [InlineData("orders", "Update")]
+    public void CheckEntityAction_DeploymentProcess_AllowsReadCreateUpdate(string entity, string action)
+    {
+        var sp = new SystemPrincipal { Role = PrincipalRole.DeploymentProcess };
+        Assert.Null(PrincipalAuthorizationPolicy.CheckEntityAction(sp, entity, action));
+    }
+
+    [Fact]
+    public void CheckEntityAction_DeploymentProcess_DeniesDelete()
+    {
+        var sp = new SystemPrincipal { Role = PrincipalRole.DeploymentProcess };
+        var result = PrincipalAuthorizationPolicy.CheckEntityAction(sp, "orders", "Delete");
+        Assert.NotNull(result);
+        Assert.Contains("cannot delete", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("Create")]
+    [InlineData("Update")]
+    public void CheckEntityAction_DeploymentProcess_DeniesSpKeyOperations(string action)
+    {
+        var sp = new SystemPrincipal { Role = PrincipalRole.DeploymentProcess };
+        var result = PrincipalAuthorizationPolicy.CheckEntityAction(sp, "system-principals", action);
+        Assert.NotNull(result);
+        Assert.Contains("API keys", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ── DeploymentAgent role ───────────────────────────────────────────
+
+    [Theory]
+    [InlineData("orders", "Read")]
+    [InlineData("orders", "Create")]
+    public void CheckEntityAction_DeploymentAgent_AllowsReadCreate(string entity, string action)
+    {
+        var sp = new SystemPrincipal { Role = PrincipalRole.DeploymentAgent };
+        Assert.Null(PrincipalAuthorizationPolicy.CheckEntityAction(sp, entity, action));
+    }
+
+    [Theory]
+    [InlineData("Update")]
+    [InlineData("Delete")]
+    public void CheckEntityAction_DeploymentAgent_DeniesUpdateDelete(string action)
+    {
+        var sp = new SystemPrincipal { Role = PrincipalRole.DeploymentAgent };
+        var result = PrincipalAuthorizationPolicy.CheckEntityAction(sp, "orders", action);
+        Assert.NotNull(result);
+    }
+
+    [Theory]
+    [InlineData("Create")]
+    [InlineData("Update")]
+    public void CheckEntityAction_DeploymentAgent_DeniesSpKeyOperations(string action)
+    {
+        var sp = new SystemPrincipal { Role = PrincipalRole.DeploymentAgent };
+        var result = PrincipalAuthorizationPolicy.CheckEntityAction(sp, "system-principals", action);
+        Assert.NotNull(result);
+        Assert.Contains("API keys", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ── TenantCallback role ────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("orders", "Read")]
+    [InlineData("orders", "Update")]
+    public void CheckEntityAction_TenantCallback_AllowsReadUpdate(string entity, string action)
+    {
+        var sp = new SystemPrincipal { Role = PrincipalRole.TenantCallback };
+        Assert.Null(PrincipalAuthorizationPolicy.CheckEntityAction(sp, entity, action));
+    }
+
+    [Theory]
+    [InlineData("Create")]
+    [InlineData("Delete")]
+    public void CheckEntityAction_TenantCallback_DeniesCreateDelete(string action)
+    {
+        var sp = new SystemPrincipal { Role = PrincipalRole.TenantCallback };
+        var result = PrincipalAuthorizationPolicy.CheckEntityAction(sp, "orders", action);
+        Assert.NotNull(result);
+    }
+
+    [Theory]
+    [InlineData("Create")]
+    [InlineData("Update")]
+    public void CheckEntityAction_TenantCallback_DeniesSpKeyOperations(string action)
+    {
+        var sp = new SystemPrincipal { Role = PrincipalRole.TenantCallback };
+        var result = PrincipalAuthorizationPolicy.CheckEntityAction(sp, "system-principals", action);
+        Assert.NotNull(result);
+        Assert.Contains("API keys", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ── FullAccess (unrestricted) ──────────────────────────────────────
+
+    [Theory]
+    [InlineData("orders", "Read")]
+    [InlineData("orders", "Create")]
+    [InlineData("orders", "Update")]
+    [InlineData("orders", "Delete")]
+    [InlineData("system-principals", "Create")]
+    [InlineData("system-principals", "Update")]
+    public void CheckEntityAction_FullAccess_AllowsEverything(string entity, string action)
+    {
+        var sp = new SystemPrincipal { Role = PrincipalRole.FullAccess };
+        Assert.Null(PrincipalAuthorizationPolicy.CheckEntityAction(sp, entity, action));
+    }
+
+    // ── CanManageApiKeys ───────────────────────────────────────────────
+
+    [Fact]
+    public void CanManageApiKeys_FullAccess_ReturnsTrue()
+    {
+        var sp = new SystemPrincipal { Role = PrincipalRole.FullAccess };
+        Assert.True(PrincipalAuthorizationPolicy.CanManageApiKeys(sp));
+    }
+
+    [Theory]
+    [InlineData(PrincipalRole.DeploymentProcess)]
+    [InlineData(PrincipalRole.DeploymentAgent)]
+    [InlineData(PrincipalRole.TenantCallback)]
+    public void CanManageApiKeys_RestrictedRole_ReturnsFalse(PrincipalRole role)
+    {
+        var sp = new SystemPrincipal { Role = role };
+        Assert.False(PrincipalAuthorizationPolicy.CanManageApiKeys(sp));
+    }
+
+    [Fact]
+    public void CanManageApiKeys_RegularUser_ReturnsTrue()
+    {
+        var user = new User { UserName = "admin" };
+        Assert.True(PrincipalAuthorizationPolicy.CanManageApiKeys(user));
+    }
+
+    [Fact]
+    public void CanManageApiKeys_NullUser_ReturnsTrue()
+    {
+        Assert.True(PrincipalAuthorizationPolicy.CanManageApiKeys(null));
+    }
+
+    // ── IsRecordOwner ──────────────────────────────────────────────────
+
+    [Fact]
+    public void IsRecordOwner_MatchingCreatedBy_ReturnsTrue()
+    {
+        var sp = new SystemPrincipal { UserName = "tenant-agent" };
+        var record = new User { CreatedBy = "tenant-agent" };
+        Assert.True(PrincipalAuthorizationPolicy.IsRecordOwner(sp, record));
+    }
+
+    [Fact]
+    public void IsRecordOwner_CaseInsensitiveMatch_ReturnsTrue()
+    {
+        var sp = new SystemPrincipal { UserName = "Tenant-Agent" };
+        var record = new User { CreatedBy = "tenant-agent" };
+        Assert.True(PrincipalAuthorizationPolicy.IsRecordOwner(sp, record));
+    }
+
+    [Fact]
+    public void IsRecordOwner_DifferentCreatedBy_ReturnsFalse()
+    {
+        var sp = new SystemPrincipal { UserName = "tenant-a" };
+        var record = new User { CreatedBy = "tenant-b" };
+        Assert.False(PrincipalAuthorizationPolicy.IsRecordOwner(sp, record));
+    }
+
+    [Fact]
+    public void IsRecordOwner_SelfAccess_SystemPrincipal_ReturnsTrue()
+    {
+        var sp = new SystemPrincipal { Key = 42, UserName = "sp-self" };
+        Assert.True(PrincipalAuthorizationPolicy.IsRecordOwner(sp, sp));
+    }
+
+    [Fact]
+    public void IsRecordOwner_OtherPrincipal_ReturnsFalse()
+    {
+        var sp = new SystemPrincipal { Key = 42, UserName = "sp-a" };
+        var other = new SystemPrincipal { Key = 99, UserName = "sp-b", CreatedBy = "admin" };
+        Assert.False(PrincipalAuthorizationPolicy.IsRecordOwner(sp, other));
+    }
+
+    // ── FilterOwnedRecords ─────────────────────────────────────────────
+
+    [Fact]
+    public void FilterOwnedRecords_ReturnsOnlyOwned()
+    {
+        var sp = new SystemPrincipal { UserName = "my-agent" };
+        var records = new List<User>
+        {
+            new() { Key = 1, CreatedBy = "my-agent" },
+            new() { Key = 2, CreatedBy = "other-agent" },
+            new() { Key = 3, CreatedBy = "my-agent" },
+        };
+
+        var filtered = PrincipalAuthorizationPolicy.FilterOwnedRecords(sp, records);
+        Assert.Equal(2, filtered.Count);
+        Assert.All(filtered, r => Assert.Equal("my-agent", r.CreatedBy));
+    }
+
+    [Fact]
+    public void FilterOwnedRecords_EmptyInput_ReturnsEmpty()
+    {
+        var sp = new SystemPrincipal { UserName = "my-agent" };
+        var filtered = PrincipalAuthorizationPolicy.FilterOwnedRecords(sp, Array.Empty<User>());
+        Assert.Empty(filtered);
+    }
+
+    // ── Default role for new SystemPrincipal ───────────────────────────
+
+    [Fact]
+    public void NewSystemPrincipal_DefaultRole_IsFullAccess()
+    {
+        var sp = new SystemPrincipal();
+        Assert.Equal(PrincipalRole.FullAccess, sp.Role);
+    }
+
+    [Fact]
+    public void NewSystemPrincipal_DefaultOwnerFields_AreEmpty()
+    {
+        var sp = new SystemPrincipal();
+        Assert.Equal(string.Empty, sp.OwnerTenantId);
+        Assert.Equal(string.Empty, sp.OwnerInstanceId);
+    }
+
+    // ── AuditService.AuditDeniedAsync ──────────────────────────────────
+
+    [Fact]
+    public async Task AuditDeniedAsync_CreatesAccessDeniedEntry()
+    {
+        await _auditService.AuditDeniedAsync(
+            "orders", 42, "Update", "deploy-agent",
+            "DeploymentAgent principals cannot update records.");
+
+        var entries = await _store.QueryAsync<AuditEntry>();
+        var denied = entries.FirstOrDefault(e => e.Operation == AuditOperation.AccessDenied);
+        Assert.NotNull(denied);
+        Assert.Equal("orders", denied.EntityType);
+        Assert.Equal(42u, denied.EntityKey);
+        Assert.Equal("deploy-agent", denied.UserName);
+        Assert.Contains("Update", denied.Notes);
+        Assert.Contains("cannot update", denied.Notes, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/BareMetalWeb.Data/AuditOperation.cs
+++ b/BareMetalWeb.Data/AuditOperation.cs
@@ -8,5 +8,8 @@ public enum AuditOperation
     Create,
     Update,
     Delete,
-    RemoteCommand
+    RemoteCommand,
+
+    /// <summary>An operation was denied by the authorization policy.</summary>
+    AccessDenied,
 }

--- a/BareMetalWeb.Data/AuditService.cs
+++ b/BareMetalWeb.Data/AuditService.cs
@@ -359,6 +359,37 @@ public sealed class AuditService
         }
     }
 
+    /// <summary>
+    /// Captures an audit record for a denied operation (authorization failure).
+    /// </summary>
+    public async ValueTask AuditDeniedAsync(
+        string entityType,
+        uint entityKey,
+        string attemptedAction,
+        string userName,
+        string reason,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var auditEntry = new AuditEntry(userName)
+            {
+                EntityType = entityType,
+                EntityKey = entityKey,
+                Operation = AuditOperation.AccessDenied,
+                TimestampUtc = DateTime.UtcNow,
+                UserName = userName,
+                Notes = $"Denied {attemptedAction}: {reason}",
+            };
+
+            await SaveAuditEntryAsync(auditEntry, "access denied", cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError($"Failed to create audit entry for denied operation: {ex.Message}", ex);
+        }
+    }
+
     private async ValueTask SaveAuditEntryAsync(AuditEntry entry, string operationName, CancellationToken cancellationToken)
     {
         // Auto-assign a sequential key if not already set

--- a/BareMetalWeb.Data/BmwDataJsonContext.cs
+++ b/BareMetalWeb.Data/BmwDataJsonContext.cs
@@ -43,5 +43,6 @@ namespace BareMetalWeb.Data;
 [JsonSerializable(typeof(long))]
 [JsonSerializable(typeof(bool))]
 [JsonSerializable(typeof(double))]
+[JsonSerializable(typeof(PrincipalRole))]
 [JsonSourceGenerationOptions(DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
 internal partial class BmwDataJsonContext : JsonSerializerContext { }

--- a/BareMetalWeb.Data/PrincipalAuthorizationPolicy.cs
+++ b/BareMetalWeb.Data/PrincipalAuthorizationPolicy.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+
+namespace BareMetalWeb.Data;
+
+/// <summary>
+/// Enforces principal-role-scoped authorization for <see cref="SystemPrincipal"/> entities.
+/// All methods are static to match the no-DI, no-middleware architecture.
+/// </summary>
+public static class PrincipalAuthorizationPolicy
+{
+    /// <summary>Entity slug for <see cref="SystemPrincipal"/>.</summary>
+    private const string SystemPrincipalSlug = "system-principals";
+
+    /// <summary>
+    /// Determines whether <paramref name="user"/> is a role-restricted <see cref="SystemPrincipal"/>.
+    /// Returns null for regular web users (session-based), which are not subject to principal-role checks.
+    /// </summary>
+    public static SystemPrincipal? AsRestrictedPrincipal(User? user)
+    {
+        if (user is SystemPrincipal sp && sp.Role != PrincipalRole.FullAccess)
+            return sp;
+        return null;
+    }
+
+    /// <summary>
+    /// Checks whether a restricted principal may perform <paramref name="action"/> on
+    /// the entity identified by <paramref name="entitySlug"/>.
+    /// Returns null when the action is permitted, or a denial reason string otherwise.
+    /// </summary>
+    public static string? CheckEntityAction(SystemPrincipal principal, string entitySlug, string action)
+    {
+        return principal.Role switch
+        {
+            PrincipalRole.DeploymentProcess => CheckDeploymentProcess(entitySlug, action),
+            PrincipalRole.DeploymentAgent => CheckDeploymentAgent(entitySlug, action),
+            PrincipalRole.TenantCallback => CheckTenantCallback(entitySlug, action),
+            _ => null, // FullAccess — unrestricted
+        };
+    }
+
+    /// <summary>
+    /// Returns true when <paramref name="principal"/> is allowed to manage API keys
+    /// (create, rotate, or revoke keys on SystemPrincipal records).
+    /// Only FullAccess principals may modify API keys.
+    /// </summary>
+    public static bool CanManageApiKeys(User? user)
+    {
+        if (user is not SystemPrincipal sp)
+            return true; // regular session user — governed by entity permission, not role policy
+        return sp.Role == PrincipalRole.FullAccess;
+    }
+
+    /// <summary>
+    /// Checks whether a <see cref="PrincipalRole.TenantCallback"/> principal owns
+    /// the specified record, based on matching <see cref="BaseDataObject.CreatedBy"/>
+    /// against the principal's <see cref="User.UserName"/>, or matching the record's
+    /// owner tenant/instance metadata when available.
+    /// </summary>
+    public static bool IsRecordOwner(SystemPrincipal principal, BaseDataObject record)
+    {
+        // Match by username (CreatedBy is set from the authenticated user's UserName)
+        if (!string.IsNullOrEmpty(principal.UserName) &&
+            string.Equals(record.CreatedBy, principal.UserName, StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        // If the record itself is a SystemPrincipal, allow only self-access
+        if (record is SystemPrincipal targetSp)
+            return targetSp.Key == principal.Key;
+
+        return false;
+    }
+
+    /// <summary>
+    /// Filters a sequence of records to only those owned by the specified
+    /// <see cref="PrincipalRole.TenantCallback"/> principal.
+    /// </summary>
+    public static List<T> FilterOwnedRecords<T>(SystemPrincipal principal, IEnumerable<T> records)
+        where T : BaseDataObject
+    {
+        var result = new List<T>();
+        foreach (var record in records)
+        {
+            if (IsRecordOwner(principal, record))
+                result.Add(record);
+        }
+        return result;
+    }
+
+    // ── Role-specific action checks ──────────────────────────────────────
+
+    private static string? CheckDeploymentProcess(string entitySlug, string action)
+    {
+        // Can create records and read, but cannot manage SP keys
+        if (IsSpKeyOperation(entitySlug, action))
+            return "DeploymentProcess principals cannot manage service principal API keys.";
+
+        // Allow Read, Create, Update for non-SP-key operations
+        if (string.Equals(action, "Delete", StringComparison.OrdinalIgnoreCase))
+            return "DeploymentProcess principals cannot delete records.";
+
+        return null;
+    }
+
+    private static string? CheckDeploymentAgent(string entitySlug, string action)
+    {
+        // Can query (read) and create, but cannot update/delete or manage SP keys
+        if (IsSpKeyOperation(entitySlug, action))
+            return "DeploymentAgent principals cannot manage service principal API keys.";
+
+        if (string.Equals(action, "Update", StringComparison.OrdinalIgnoreCase))
+            return "DeploymentAgent principals cannot update records.";
+
+        if (string.Equals(action, "Delete", StringComparison.OrdinalIgnoreCase))
+            return "DeploymentAgent principals cannot delete records.";
+
+        return null;
+    }
+
+    private static string? CheckTenantCallback(string entitySlug, string action)
+    {
+        // Can only read and update own records — ownership check is handled separately
+        if (IsSpKeyOperation(entitySlug, action))
+            return "TenantCallback principals cannot manage service principal API keys.";
+
+        if (string.Equals(action, "Create", StringComparison.OrdinalIgnoreCase))
+            return "TenantCallback principals cannot create new records.";
+
+        if (string.Equals(action, "Delete", StringComparison.OrdinalIgnoreCase))
+            return "TenantCallback principals cannot delete records.";
+
+        return null;
+    }
+
+    /// <summary>
+    /// Returns true when the operation targets the SystemPrincipal entity for
+    /// a write action (which could mutate API keys).
+    /// </summary>
+    private static bool IsSpKeyOperation(string entitySlug, string action)
+    {
+        if (!string.Equals(entitySlug, SystemPrincipalSlug, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        return string.Equals(action, "Create", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(action, "Update", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/BareMetalWeb.Data/PrincipalRole.cs
+++ b/BareMetalWeb.Data/PrincipalRole.cs
@@ -1,0 +1,29 @@
+namespace BareMetalWeb.Data;
+
+/// <summary>
+/// Defines the access scope for a <see cref="SystemPrincipal"/>.
+/// Default is <see cref="FullAccess"/> for backward compatibility with existing principals.
+/// </summary>
+public enum PrincipalRole
+{
+    /// <summary>Unrestricted access — backward-compatible default for existing principals.</summary>
+    FullAccess = 0,
+
+    /// <summary>
+    /// Deployment process principal: can create registry records and assign deployment
+    /// metadata, but cannot set or rotate service principal API keys.
+    /// </summary>
+    DeploymentProcess = 1,
+
+    /// <summary>
+    /// Deployment agent principal: can query and create records needed for
+    /// registration/bootstrap, but cannot set service principal API keys.
+    /// </summary>
+    DeploymentAgent = 2,
+
+    /// <summary>
+    /// Tenant-scoped callback principal: can only read and update records
+    /// belonging to its own tenant/instance. No broad registry mutation rights.
+    /// </summary>
+    TenantCallback = 3,
+}

--- a/BareMetalWeb.Data/SystemPrincipal.cs
+++ b/BareMetalWeb.Data/SystemPrincipal.cs
@@ -10,6 +10,15 @@ public sealed class SystemPrincipal : User
     [DataField(Label = "API Keys", Order = 10, Required = false, List = false, View = false, Edit = true, Create = true, Placeholder = "one key per line")]
     public List<string> ApiKeyHashes { get; set; } = new();
 
+    [DataField(Label = "Principal Role", Order = 11, Required = false, List = true, View = true, Edit = true, Create = true)]
+    public PrincipalRole Role { get; set; } = PrincipalRole.FullAccess;
+
+    [DataField(Label = "Owner Tenant ID", Order = 12, Required = false, List = true, View = true, Edit = true, Create = true, Placeholder = "tenant scope (TenantCallback only)")]
+    public string OwnerTenantId { get; set; } = string.Empty;
+
+    [DataField(Label = "Owner Instance ID", Order = 13, Required = false, List = true, View = true, Edit = true, Create = true, Placeholder = "instance scope (TenantCallback only)")]
+    public string OwnerInstanceId { get; set; } = string.Empty;
+
     public static async ValueTask<SystemPrincipal?> FindByApiKeyAsync(string apiKey, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(apiKey))

--- a/BareMetalWeb.Host/RouteHandlers.cs
+++ b/BareMetalWeb.Host/RouteHandlers.cs
@@ -2065,6 +2065,9 @@ public sealed class RouteHandlers : IRouteHandlers
             return;
         }
 
+        if (!await CheckPrincipalRolePolicyAsync(context, meta, "Read", context.RequestAborted).ConfigureAwait(false))
+            return;
+
         var queryDict = ToQueryDictionary(context.HttpRequest.Query);
         var query = DataScaffold.BuildQueryDefinition(queryDict, meta);
 
@@ -2175,6 +2178,9 @@ public sealed class RouteHandlers : IRouteHandlers
             await context.Response.WriteAsync("{\"error\":\"Access denied.\"}");
             return;
         }
+
+        if (!await CheckPrincipalRolePolicyAsync(context, meta, "Create", context.RequestAborted).ConfigureAwait(false))
+            return;
 
         if (!await UserAuth.HasValidApiKeyAsync(context, context.RequestAborted).ConfigureAwait(false) &&
             (!ValidateApiCsrfHeader(context) || !CsrfProtection.ValidateApiToken(context)))
@@ -2362,6 +2368,9 @@ public sealed class RouteHandlers : IRouteHandlers
             return;
         }
 
+        if (!await CheckPrincipalRolePolicyAsync(context, meta, "Read", context.RequestAborted).ConfigureAwait(false))
+            return;
+
         if (!uint.TryParse(id, out var parsedId))
         {
             context.Response.StatusCode = StatusCodes.Status400BadRequest;
@@ -2374,6 +2383,20 @@ public sealed class RouteHandlers : IRouteHandlers
         {
             context.Response.StatusCode = StatusCodes.Status404NotFound;
             await context.Response.WriteAsync("Item not found.");
+            return;
+        }
+
+        // TenantCallback principals can only read their own records
+        var getUser = await UserAuth.GetRequestUserAsync(context, context.RequestAborted).ConfigureAwait(false);
+        var getRestricted = PrincipalAuthorizationPolicy.AsRestrictedPrincipal(getUser);
+        if (getRestricted is { Role: PrincipalRole.TenantCallback } && instance is BaseDataObject getBdo &&
+            !PrincipalAuthorizationPolicy.IsRecordOwner(getRestricted, getBdo))
+        {
+            context.Response.StatusCode = StatusCodes.Status403Forbidden;
+            await context.Response.WriteAsync("Access denied: record not owned by this principal.");
+            await _auditService.AuditDeniedAsync(
+                meta.Slug, parsedId, "Read", getRestricted.UserName ?? getRestricted.Key.ToString(),
+                "TenantCallback principal attempted to read non-owned record", context.RequestAborted).ConfigureAwait(false);
             return;
         }
 
@@ -2396,6 +2419,9 @@ public sealed class RouteHandlers : IRouteHandlers
             await context.Response.WriteAsync("Access denied.");
             return;
         }
+
+        if (!await CheckPrincipalRolePolicyAsync(context, meta, "Create", context.RequestAborted).ConfigureAwait(false))
+            return;
 
         if (!await UserAuth.HasValidApiKeyAsync(context, context.RequestAborted).ConfigureAwait(false) &&
             (!ValidateApiCsrfHeader(context) || !CsrfProtection.ValidateApiToken(context)))
@@ -2487,6 +2513,9 @@ public sealed class RouteHandlers : IRouteHandlers
             return;
         }
 
+        if (!await CheckPrincipalRolePolicyAsync(context, meta, "Update", context.RequestAborted).ConfigureAwait(false))
+            return;
+
         if (!await UserAuth.HasValidApiKeyAsync(context, context.RequestAborted).ConfigureAwait(false) &&
             (!ValidateApiCsrfHeader(context) || !CsrfProtection.ValidateApiToken(context)))
         {
@@ -2507,6 +2536,20 @@ public sealed class RouteHandlers : IRouteHandlers
         {
             context.Response.StatusCode = StatusCodes.Status404NotFound;
             await context.Response.WriteAsync("Item not found.");
+            return;
+        }
+
+        // TenantCallback principals can only update their own records
+        var putUser = await UserAuth.GetRequestUserAsync(context, context.RequestAborted).ConfigureAwait(false);
+        var putRestricted = PrincipalAuthorizationPolicy.AsRestrictedPrincipal(putUser);
+        if (putRestricted is { Role: PrincipalRole.TenantCallback } && instance is BaseDataObject putBdo &&
+            !PrincipalAuthorizationPolicy.IsRecordOwner(putRestricted, putBdo))
+        {
+            context.Response.StatusCode = StatusCodes.Status403Forbidden;
+            await context.Response.WriteAsync("Access denied: record not owned by this principal.");
+            await _auditService.AuditDeniedAsync(
+                meta.Slug, parsedId, "Update", putRestricted.UserName ?? putRestricted.Key.ToString(),
+                "TenantCallback principal attempted to update non-owned record", context.RequestAborted).ConfigureAwait(false);
             return;
         }
 
@@ -2586,6 +2629,9 @@ public sealed class RouteHandlers : IRouteHandlers
             return;
         }
 
+        if (!await CheckPrincipalRolePolicyAsync(context, meta, "Update", context.RequestAborted).ConfigureAwait(false))
+            return;
+
         if (!await UserAuth.HasValidApiKeyAsync(context, context.RequestAborted).ConfigureAwait(false) &&
             (!ValidateApiCsrfHeader(context) || !CsrfProtection.ValidateApiToken(context)))
         {
@@ -2606,6 +2652,20 @@ public sealed class RouteHandlers : IRouteHandlers
         {
             context.Response.StatusCode = StatusCodes.Status404NotFound;
             await context.Response.WriteAsync("Item not found.");
+            return;
+        }
+
+        // TenantCallback principals can only update their own records
+        var patchUser = await UserAuth.GetRequestUserAsync(context, context.RequestAborted).ConfigureAwait(false);
+        var patchRestricted = PrincipalAuthorizationPolicy.AsRestrictedPrincipal(patchUser);
+        if (patchRestricted is { Role: PrincipalRole.TenantCallback } && instance is BaseDataObject patchBdo &&
+            !PrincipalAuthorizationPolicy.IsRecordOwner(patchRestricted, patchBdo))
+        {
+            context.Response.StatusCode = StatusCodes.Status403Forbidden;
+            await context.Response.WriteAsync("Access denied: record not owned by this principal.");
+            await _auditService.AuditDeniedAsync(
+                meta.Slug, parsedId, "Update", patchRestricted.UserName ?? patchRestricted.Key.ToString(),
+                "TenantCallback principal attempted to update non-owned record", context.RequestAborted).ConfigureAwait(false);
             return;
         }
 
@@ -2672,6 +2732,9 @@ public sealed class RouteHandlers : IRouteHandlers
             await context.Response.WriteAsync("Access denied.");
             return;
         }
+
+        if (!await CheckPrincipalRolePolicyAsync(context, meta, "Delete", context.RequestAborted).ConfigureAwait(false))
+            return;
 
         if (!await UserAuth.HasValidApiKeyAsync(context, context.RequestAborted).ConfigureAwait(false) &&
             (!ValidateApiCsrfHeader(context) || !CsrfProtection.ValidateApiToken(context)))
@@ -5546,6 +5609,32 @@ public sealed class RouteHandlers : IRouteHandlers
         return true;
         }
         finally { ReturnPermissionSet(userPermissions); }
+    }
+
+    /// <summary>
+    /// Checks whether the current user (if a role-restricted <see cref="SystemPrincipal"/>)
+    /// is allowed to perform <paramref name="action"/> on the entity identified by <paramref name="meta"/>.
+    /// Returns true when the action is permitted (or the user is not a restricted principal).
+    /// On denial, sets 403 status, writes the reason, and fires an audit entry.
+    /// </summary>
+    private async ValueTask<bool> CheckPrincipalRolePolicyAsync(
+        BmwContext context, DataEntityMetadata meta, string action, CancellationToken cancellationToken)
+    {
+        var user = await UserAuth.GetRequestUserAsync(context, cancellationToken).ConfigureAwait(false);
+        var restricted = PrincipalAuthorizationPolicy.AsRestrictedPrincipal(user);
+        if (restricted == null)
+            return true; // not a restricted principal
+
+        var denial = PrincipalAuthorizationPolicy.CheckEntityAction(restricted, meta.Slug, action);
+        if (denial == null)
+            return true;
+
+        context.Response.StatusCode = StatusCodes.Status403Forbidden;
+        await context.Response.WriteAsync(denial);
+        await _auditService.AuditDeniedAsync(
+            meta.Slug, 0, action, restricted.UserName ?? restricted.Key.ToString(),
+            denial, cancellationToken).ConfigureAwait(false);
+        return false;
     }
 
     private static List<string[]> ParseCsvRows(string content)

--- a/docs/architecture/auth.md
+++ b/docs/architecture/auth.md
@@ -161,6 +161,62 @@ API keys are issued via `/account/apikey` (admin only) and stored as PBKDF2 hash
 
 ---
 
+## Principal Role Model (Least-Privilege)
+
+Each `SystemPrincipal` has a `Role` field that restricts what operations the principal can perform. This enforces least-privilege access for machine-to-machine scenarios such as deployment automation and tenant callbacks.
+
+### Roles
+
+| Role | Enum value | Read | Create | Update | Delete | Manage SP Keys |
+|------|-----------|------|--------|--------|--------|----------------|
+| **FullAccess** | 0 (default) | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **DeploymentProcess** | 1 | ✅ | ✅ | ✅ | ❌ | ❌ |
+| **DeploymentAgent** | 2 | ✅ | ✅ | ❌ | ❌ | ❌ |
+| **TenantCallback** | 3 | own | ❌ | own | ❌ | ❌ |
+
+- **FullAccess**: Backward-compatible default — no additional restrictions beyond entity-level permissions.
+- **DeploymentProcess**: Intended for CI/CD pipelines. Can create registry records and assign metadata but cannot delete records or manage API keys on other principals.
+- **DeploymentAgent**: Intended for bootstrap/registration agents. Can query and create records but cannot update, delete, or manage API keys.
+- **TenantCallback**: Scoped to records owned by the principal. Can only read and update records where `CreatedBy` matches the principal's `UserName`. Cannot create, delete, or manage API keys.
+
+### Ownership Scoping (TenantCallback)
+
+`TenantCallback` principals include two optional scope fields:
+
+- `OwnerTenantId` — the tenant this principal is scoped to
+- `OwnerInstanceId` — the specific instance within the tenant
+
+Record ownership is determined by matching `BaseDataObject.CreatedBy` against the principal's `UserName`. For `SystemPrincipal` records, access is limited to the principal's own record (key match).
+
+### Enforcement Points
+
+Principal role checks are enforced in all data API handlers (`DataApiListHandler`, `DataApiGetHandler`, `DataApiPostHandler`, `DataApiPutHandler`, `DataApiPatchHandler`, `DataApiDeleteHandler`, `DataApiImportHandler`) immediately after the entity-level permission check (`HasEntityPermissionAsync`).
+
+```
+Request → HasEntityPermissionAsync → CheckPrincipalRolePolicyAsync → CSRF → Handler logic
+```
+
+### Denied Operation Auditing
+
+When a principal role policy denies an operation, an `AuditEntry` is created with:
+
+- `Operation = AccessDenied`
+- `EntityType` — the target entity slug
+- `UserName` — the denied principal's identity
+- `Notes` — includes the attempted action and denial reason
+
+### Key Files
+
+| File | Description |
+|------|-------------|
+| `BareMetalWeb.Data/PrincipalRole.cs` | `PrincipalRole` enum definition |
+| `BareMetalWeb.Data/PrincipalAuthorizationPolicy.cs` | Static policy enforcement methods |
+| `BareMetalWeb.Data/SystemPrincipal.cs` | `Role`, `OwnerTenantId`, `OwnerInstanceId` fields |
+| `BareMetalWeb.Data/AuditOperation.cs` | `AccessDenied` enum value |
+| `BareMetalWeb.Host/RouteHandlers.cs` | `CheckPrincipalRolePolicyAsync` helper and handler hooks |
+
+---
+
 ## Security Headers
 
 Every response includes the following security headers:


### PR DESCRIPTION
## Summary
Add a least-privilege service principal model for tenant self-registration where principals are hyper-limited to their own records and callback scope.

Closes #1393

## Changes
- **PrincipalRole enum** (FullAccess, DeploymentProcess, DeploymentAgent, TenantCallback)
- **SystemPrincipal** extended with Role, OwnerTenantId, OwnerInstanceId fields
- **PrincipalAuthorizationPolicy** — static enforcement for entity actions, record ownership, API key guards
- **RouteHandlers** — CheckPrincipalRolePolicyAsync hook in all 7 data API handlers
- **AuditOperation.AccessDenied** + AuditService.AuditDeniedAsync for denied operation logging
- **46 unit tests** covering all role/action/ownership scenarios
- **docs/architecture/auth.md** updated with principal role model

## Backward Compatibility
Existing principals default to FullAccess — zero disruption. No migration needed.