### PR TITLE
security: comprehensive deep-scan audit fixes (issue #1386)

### DIFF
--- a/BareMetalWeb.Data/ColumnQueryExecutor.cs
+++ b/BareMetalWeb.Data/ColumnQueryExecutor.cs
@@ -488,7 +488,7 @@ internal static class ColumnQueryExecutor
                     && DataScaffold.GetEnumLookup(targetType).TryGetValue(s, out var cached)
                     ? cached
                     : value;
-                result = (int)Convert.ChangeType(enumVal, typeof(int));
+                result = ((IConvertible)enumVal).ToInt32(null);
                 return true;
             }
             if (value is bool b) { result = b ? 1 : 0; return true; }

--- a/BareMetalWeb.Data/WalSegmentWriter.cs
+++ b/BareMetalWeb.Data/WalSegmentWriter.cs
@@ -30,11 +30,10 @@ internal sealed class WalSegmentWriter : IDisposable
     public WalSegmentWriter(string filePath, uint segmentId)
     {
         SegmentId = segmentId;
-        bool isNew = !File.Exists(filePath);
         _file = new FileStream(filePath, FileMode.OpenOrCreate, FileAccess.ReadWrite,
             FileShare.Read, 65536, FileOptions.None);
 
-        if (isNew)
+        if (_file.Length == 0)
             WriteSegmentHeader();
         else
         {

--- a/BareMetalWeb.Intelligence/ModelSnapshot.cs
+++ b/BareMetalWeb.Intelligence/ModelSnapshot.cs
@@ -266,6 +266,12 @@ public static class ModelSnapshot
             if (matrixCount != layerCount * 2 + 2)
                 throw new InvalidDataException("Matrix count mismatch");
 
+            // Bounds: ensure descriptor region fits within file
+            long descEnd = HeaderSize + (long)matrixCount * DescriptorSize;
+            if (descEnd < HeaderSize || descEnd > fileSize)
+                throw new InvalidDataException(
+                    $"Descriptor region out of bounds (need {descEnd}, file is {fileSize})");
+
             // ── Descriptors ─────────────────────────────────────────
             var descSpan = new ReadOnlySpan<byte>(
                 basePtr + HeaderSize, matrixCount * DescriptorSize);
@@ -284,10 +290,19 @@ public static class ModelSnapshot
             }
 
             // ── Token table ─────────────────────────────────────────
+            // Bounds: validate tokenTableOffset and token table region
+            if (tokenTableOffset < 0 || tokenTableOffset > fileSize)
+                throw new InvalidDataException(
+                    $"Token table offset out of bounds ({tokenTableOffset}, file is {fileSize})");
+            long tokenTableEnd = descriptors[0].Offset;
+            if (tokenTableEnd < tokenTableOffset || tokenTableEnd > fileSize)
+                throw new InvalidDataException(
+                    $"Token table region out of bounds (offset={tokenTableOffset}, end={tokenTableEnd}, file={fileSize})");
+
             string[] tokens;
             using (var tokenStream = new UnmanagedMemoryStream(
                 basePtr + tokenTableOffset,
-                descriptors[0].Offset - tokenTableOffset))
+                tokenTableEnd - tokenTableOffset))
             using (var tbr = new BinaryReader(tokenStream, Encoding.UTF8))
             {
                 tokens = DecodeTokenTable(tbr, tokenCount);
@@ -298,6 +313,10 @@ public static class ModelSnapshot
             for (int i = 0; i < matrixCount; i++)
             {
                 var (rows, cols, _, offset, length) = descriptors[i];
+                if (offset < 0 || length < 0 || length > int.MaxValue ||
+                    offset + length < offset || offset + length > fileSize)
+                    throw new InvalidDataException(
+                        $"Matrix descriptor {i} out of bounds (offset={offset}, length={length}, file={fileSize})");
                 var dataSpan = new ReadOnlySpan<byte>(
                     basePtr + offset, (int)length);
                 matrices[i] = NativeTernaryMatrix.FromPackedData(dataSpan, rows, cols);
@@ -394,16 +413,34 @@ public static class ModelSnapshot
             }
 
             // ── Token table ─────────────────────────────────────────────
+            // Bounds: validate tokenTableOffset and token table region
+            if (tokenTableOffset < 0 || tokenTableOffset > fs.Length)
+                throw new InvalidDataException(
+                    $"Token table offset out of bounds ({tokenTableOffset}, file is {fs.Length})");
+            long lazyTokenEnd = descriptors[0].Offset;
+            if (lazyTokenEnd < tokenTableOffset || lazyTokenEnd > fs.Length)
+                throw new InvalidDataException(
+                    $"Token table region out of bounds (offset={tokenTableOffset}, end={lazyTokenEnd}, file={fs.Length})");
+
             string[] tokens;
             using (var tokenStream = new UnmanagedMemoryStream(
                 basePtr + tokenTableOffset,
-                descriptors[0].Offset - tokenTableOffset))
+                lazyTokenEnd - tokenTableOffset))
             using (var tbr = new BinaryReader(tokenStream, Encoding.UTF8))
             {
                 tokens = DecodeTokenTable(tbr, tokenCount);
             }
 
             // ── Zero-copy matrices from mapped memory ───────────────────
+            // Bounds: validate all descriptor offsets/lengths against file size
+            for (int i = 0; i < matrixCount; i++)
+            {
+                var (_, _, _, doff, dlen) = descriptors[i];
+                if (doff < 0 || dlen < 0 || doff + dlen < doff || doff + dlen > fs.Length)
+                    throw new InvalidDataException(
+                        $"Matrix descriptor {i} out of bounds (offset={doff}, length={dlen}, file={fs.Length})");
+            }
+
             var attn = new NativeTernaryMatrix[layerCount];
             var ffn = new NativeTernaryMatrix[layerCount];
             for (int i = 0; i < layerCount; i++)


### PR DESCRIPTION
## Security Deep Scan — Issue #1386

### Changes

**CRITICAL — Buffer overruns (ModelSnapshot.cs)**
- Bounds validation for descriptor regions, token table offsets, and matrix data spans in both LoadMapped and LoadLazy
- Prevents OOB reads from malformed BMWM snapshot files

**CRITICAL — Decompression bomb (WalPayloadCodec.cs)**
- 256 MiB hard cap on WAL Brotli decompression payload size
- 64 KB cap on cookie deflate decompression

**HIGH — TOCTOU fixes**
- WalSegmentWriter: replaced File.Exists with post-open _file.Length == 0
- RouteHandlers.RenderLogFile: replaced File.Exists → File.ReadLines with direct try-catch for FileNotFoundException

**HIGH — MFA dictionary DoS**
- 100K key hard cap on MfaAttempts ConcurrentDictionary
- Force-scavenge when over cap (bypasses 60s cooldown)
- Oldest-first eviction when time-based cleanup insufficient

**HIGH — Exception disclosure**
- SetupRegistrationResult: replaced x.Message with generic `"Callback request failed."`

**MEDIUM — Session sliding-window race**
- Added SemaphoreSlim locking to GetSessionAsync (matching existing GetSession pattern)

**Other**
- Random.Shared replacing 
ew Random() in SearchIndexing and RouteHandlers
- 512-byte max-length on API key header paths
- DPAPI/AES-256-GCM envelope encryption for key files
- Stack trace redaction in DiskBufferedLogger
- AOT-safe enum conversion in ColumnQueryExecutor

Closes #1386