### PR TITLE
fix: align CD1 image selection and persist AKS logs

### DIFF
--- a/.github/workflows/cd-canary.yml
+++ b/.github/workflows/cd-canary.yml
@@ -23,8 +23,8 @@ on:
   workflow_dispatch:
     inputs:
       image_tag:
-        description: 'Image tag to deploy (e.g. 1.20260309.42-linux-arm64). Leave empty to use latest CI2 build.'
-        required: false
+        description: 'Image tag to deploy manually (e.g. 1.20260309.42-linux-arm64). Required for workflow_dispatch.'
+        required: true
         type: string
 
 concurrency:
@@ -37,6 +37,7 @@ permissions:
   actions: read
 
 env:
+  ACR_NAME: metalclusterregistry
   ACR_LOGIN_SERVER: metalclusterregistry.azurecr.io
   ACR_IMAGE: baremetalweb
   AKS_CLUSTER: metalcluster
@@ -68,14 +69,39 @@ jobs:
         run: |
           if [[ -n "${{ inputs.image_tag }}" ]]; then
             TAG="${{ inputs.image_tag }}"
-          else
+            IMAGE="${{ env.ACR_LOGIN_SERVER }}/${{ env.ACR_IMAGE }}:${TAG}"
+          elif [[ "${{ github.event_name }}" == "workflow_run" ]]; then
             MAJOR="${{ vars.MAJOR_VERSION || '1' }}"
-            DATE="$(date +%Y%m%d)"
-            BUILD="${{ github.run_number }}"
+            BUILD="${{ github.event.workflow_run.run_number }}"
+            CREATED_AT="${{ github.event.workflow_run.created_at }}"
+            DATE="${CREATED_AT%%T*}"
+            DATE="${DATE//-/}"
             TAG="${MAJOR}.${DATE}.${BUILD}-linux-arm64"
+            IMAGE="${{ env.ACR_LOGIN_SERVER }}/${{ env.ACR_IMAGE }}:${TAG}"
+          else
+            echo "::error::workflow_dispatch requires inputs.image_tag"
+            exit 1
           fi
           echo "image_tag=${TAG}" >> $GITHUB_OUTPUT
-          echo "image=${{ env.ACR_LOGIN_SERVER }}/${{ env.ACR_IMAGE }}:${TAG}" >> $GITHUB_OUTPUT
+          echo "image=${IMAGE}" >> $GITHUB_OUTPUT
+
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Verify resolved image exists in ACR
+        env:
+          RESOLVED_TAG: ${{ steps.resolve.outputs.image_tag }}
+        run: |
+          az acr repository show-tags \
+            --name ${{ env.ACR_NAME }} \
+            --repository ${{ env.ACR_IMAGE }} \
+            --query "[?@=='${RESOLVED_TAG}']" \
+            -o tsv | grep -q "${RESOLVED_TAG}" \
+            || { echo "::error::Resolved tag '${RESOLVED_TAG}' not found in ACR"; exit 1; }
 
   # ── Deploy to AKS ──────────────────────────────────────────────────────
   deploy:

--- a/docs/CI-CD-PIPELINE.md
+++ b/docs/CI-CD-PIPELINE.md
@@ -112,11 +112,11 @@ The container image is tagged `{version}-linux-arm64` and pushed to:
 
 | Property    | Value |
 |-------------|-------|
-| **Trigger** | CI2 success on main, workflow_dispatch (optional image_tag) |
+| **Trigger** | CI2 success on main, workflow_dispatch (explicit `image_tag`) |
 | **Environment** | AKS canary (same namespace) |
 | **Duration** | ~15–30 minutes |
 
-Deploys the newly built container to the AKS StatefulSet using `kubectl set image`, then runs three extended test stages:
+When triggered automatically by CI2, CD1 derives the container tag from the triggering CI2 run metadata, so it deploys the exact image CI2 just built and pushed. When run manually, `image_tag` must be supplied explicitly. After deployment it runs three extended test stages:
 
 | Test | Purpose | Method |
 |------|---------|--------|

--- a/kubectl/statefulset.yaml
+++ b/kubectl/statefulset.yaml
@@ -27,6 +27,20 @@ spec:
         fsGroup: 1654
         seccompProfile:
           type: RuntimeDefault
+      initContainers:
+        - name: prepare-logs
+          image: busybox:1.36.1
+          command:
+            - /bin/sh
+            - -c
+            - mkdir -p /mnt/data/Logs && chown 1654:1654 /mnt/data/Logs
+          volumeMounts:
+            - name: data
+              mountPath: /mnt/data
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+            allowPrivilegeEscalation: false
       containers:
         - name: baremetalweb
           image: metalclusterregistry.azurecr.io/baremetalweb:1.20260308.1-linux-arm64
@@ -78,6 +92,9 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /app/Data
+            - name: data
+              mountPath: /app/Logs
+              subPath: Logs
             - name: config
               mountPath: /app/Metal.config
               subPath: Metal.config


### PR DESCRIPTION
## Summary
- derive CD1 workflow-run deployments from the triggering CI2 run number/date instead of CD1's own run number
- require explicit image_tag for manual CD1 runs and verify the tag exists in ACR
- persist /app/Logs on the existing StatefulSet PVC via subPath: Logs
- add an init container to create the log directory while keeping the main container root filesystem read-only

## Why
- fixes CD1 deploying the wrong tag (70 instead of CI2 149)
- fixes AKS runtime logging failures caused by /app/Logs living on a read-only root filesystem
