### PR TITLE
fix: stabilize vnext routing and account path (#1447 #1449 #1451 #1454)

### DIFF
--- a/BareMetalWeb.Core/Interfaces/IRouteHandlers.cs
+++ b/BareMetalWeb.Core/Interfaces/IRouteHandlers.cs
@@ -22,6 +22,7 @@ public interface IRouteHandlers
     ValueTask SsoLoginHandler(BmwContext context);
     ValueTask SsoCallbackHandler(BmwContext context);
     ValueTask SsoLogoutHandler(BmwContext context);
+    ValueTask AccountRedirectHandler(BmwContext context);
     ValueTask AccountHandler(BmwContext context);
     ValueTask MfaStatusHandler(BmwContext context);
     ValueTask MfaSetupHandler(BmwContext context);

--- a/BareMetalWeb.Core/wwwroot/static/js/vnext-app.js
+++ b/BareMetalWeb.Core/wwwroot/static/js/vnext-app.js
@@ -248,7 +248,7 @@
     var content = null;
 
     function getContent() {
-        return content || (content = document.getElementById('vnext-content'));
+        return content || (content = document.getElementById('vnext-content') || document.getElementById('vnext-root'));
     }
 
     function setContent(html) {
@@ -4869,6 +4869,9 @@
 
     // ── App init / routing ────────────────────────────────────────────────────
     function init() {
+        var legacyRoot = document.getElementById('vnext-content');
+        if (!legacyRoot) return;
+
         // Build nav from metadata (async, non-blocking)
         fetchMetaObjects().then(buildNav).catch(function () {});
 
@@ -5009,13 +5012,21 @@
   const R   = document.getElementById('vnext-root') || document.getElementById('vnext-content');
   if (!R) return;
 
+  let _routeAbortController = null;
+
+  function cancelNavigation() {
+    if (_routeAbortController) {
+      _routeAbortController.abort();
+      _routeAbortController = null;
+    }
+  }
+
   // ── SPA Activation: hide server-rendered content, take over navigation ──
   // Use class-based hiding (not display:none) to avoid CLS — the .bm-ssr-hidden
   // class uses visibility:hidden + position:absolute so the element is removed
   // from visual flow without triggering a layout shift.
   const ssrContent = document.querySelector('.bm-ssr-content');
   if (ssrContent) ssrContent.classList.add('bm-ssr-hidden');
-  R.style.display = '';
 
   // Intercept ALL internal link clicks for SPA navigation (not just [data-go])
   document.addEventListener('click', function (e) {
@@ -5029,7 +5040,8 @@
     }
     // Skip non-SPA paths
     if (href.startsWith('/api/') || href.startsWith('/auth/') || href.startsWith('/admin/') ||
-        href.startsWith('/login') || href.startsWith('/logout') || href.startsWith('/meta/') ||
+        href.startsWith('/login') || href.startsWith('/logout') || href.startsWith('/account') ||
+        href === '/system/me' || href.startsWith('/system/me?') || href.startsWith('/meta/') ||
         href.startsWith('/static/') || href.startsWith('/bmw/') ||
         href === '/status' || href === '/metrics') return;
     e.preventDefault();
@@ -5154,6 +5166,16 @@
     chatA.innerHTML = '<i class="bi bi-chat-dots"></i>';
     chatLi.appendChild(chatA);
     rightUl.appendChild(chatLi);
+
+    const accountLi = el('li', { className: 'nav-item' });
+    const accountA = el('a', {
+      className: 'nav-link',
+      href: '/system/me',
+      title: 'My Account'
+    });
+    accountA.innerHTML = '<i class="bi bi-person-circle"></i>';
+    accountLi.appendChild(accountA);
+    rightUl.appendChild(accountLi);
 
     // Bell icon linking to inbox page
     const jobsLi  = el('li', { className: 'nav-item' });

--- a/BareMetalWeb.Host.Tests/RouteRegistrationExtensionsTests.cs
+++ b/BareMetalWeb.Host.Tests/RouteRegistrationExtensionsTests.cs
@@ -195,6 +195,7 @@ public class RouteRegistrationExtensionsTests : IDisposable
 
         // Assert
         Assert.True(_server.routes.ContainsKey("GET /account"));
+        Assert.True(_server.routes.ContainsKey("GET /system/me"));
     }
 
     [Fact]
@@ -295,7 +296,7 @@ public class RouteRegistrationExtensionsTests : IDisposable
         _server.RegisterAuthRoutes(_routeHandlers, _pageInfoFactory, _mainTemplate, allowAccountCreation: false);
 
         // Assert — 14 routes without register
-        Assert.Equal(17, _server.routes.Count);
+        Assert.Equal(18, _server.routes.Count);
     }
 
     [Fact]
@@ -305,7 +306,7 @@ public class RouteRegistrationExtensionsTests : IDisposable
         _server.RegisterAuthRoutes(_routeHandlers, _pageInfoFactory, _mainTemplate, allowAccountCreation: true);
 
         // Assert — 16 routes with register
-        Assert.Equal(19, _server.routes.Count);
+        Assert.Equal(20, _server.routes.Count);
     }
 
     // ──────────────────────────────────────────────────────────────
@@ -682,7 +683,7 @@ public class RouteRegistrationExtensionsTests : IDisposable
         _server.RegisterAuthRoutes(_routeHandlers, _pageInfoFactory, _mainTemplate, allowAccountCreation: false);
 
         // Assert
-        var route = _server.routes["GET /account"];
+        var route = _server.routes["GET /system/me"];
         Assert.Equal("Authenticated", route.PageInfo!.PageMetaData.PermissionsNeeded);
     }
 
@@ -708,7 +709,7 @@ public class RouteRegistrationExtensionsTests : IDisposable
         _server.RegisterAuthRoutes(_routeHandlers, _pageInfoFactory, _mainTemplate, allowAccountCreation: false);
 
         // Assert
-        var route = _server.routes["GET /account"];
+        var route = _server.routes["GET /system/me"];
         Assert.True(route.PageInfo!.PageMetaData.ShowOnNavBar);
     }
 
@@ -719,7 +720,7 @@ public class RouteRegistrationExtensionsTests : IDisposable
         _server.RegisterAuthRoutes(_routeHandlers, _pageInfoFactory, _mainTemplate, allowAccountCreation: false);
 
         // Assert
-        var route = _server.routes["GET /account"];
+        var route = _server.routes["GET /system/me"];
         Assert.Equal(NavAlignment.Right, route.PageInfo!.PageContext.NavAlignment);
     }
 
@@ -796,7 +797,7 @@ public class RouteRegistrationExtensionsTests : IDisposable
         Assert.True(afterAdmin > afterMonitoring);
         Assert.True(afterLookup > afterAdmin);
         Assert.True(total > afterLookup);
-        Assert.Equal(staticCount + 20 + 4 + 13 + 5 + 26, total);
+        Assert.Equal(staticCount + 21 + 4 + 13 + 5 + 26, total);
     }
 
     [Fact]
@@ -930,6 +931,7 @@ public class RouteRegistrationExtensionsTests : IDisposable
         public ValueTask SsoLoginHandler(BmwContext context) => ValueTask.CompletedTask;
         public ValueTask SsoCallbackHandler(BmwContext context) => ValueTask.CompletedTask;
         public ValueTask SsoLogoutHandler(BmwContext context) => ValueTask.CompletedTask;
+        public ValueTask AccountRedirectHandler(BmwContext context) => ValueTask.CompletedTask;
         public ValueTask AccountHandler(BmwContext context) => ValueTask.CompletedTask;
         public ValueTask MfaStatusHandler(BmwContext context) => ValueTask.CompletedTask;
         public ValueTask MfaSetupHandler(BmwContext context) => ValueTask.CompletedTask;
@@ -1141,13 +1143,13 @@ public class RouteRegistrationExtensionsTests : IDisposable
     // ──────────────────────────────────────────────────────────────
 
     [Fact]
-    public void TryBuildMetaObjectsScript_WithAccessibleEntity_ReturnsScriptWithSlug()
+    public async Task TryBuildMetaObjectsScript_WithAccessibleEntity_ReturnsScriptWithSlug()
     {
         // Arrange
         _ = HostGalleryTestFixture.State;
 
         var method = typeof(RouteRegistrationExtensions).GetMethod(
-            "TryBuildMetaObjectsScript",
+            "TryBuildMetaObjectsScriptAsync",
             BindingFlags.NonPublic | BindingFlags.Static);
         Assert.NotNull(method);
 
@@ -1155,7 +1157,9 @@ public class RouteRegistrationExtensionsTests : IDisposable
         var user = new User { Key = 1, UserName = "test", IsActive = true, Permissions = new[] { "Customers" } };
 
         // Act
-        var script = (string?)method.Invoke(null, new object?[] { user, user.Permissions, "testnonce" });
+        var task = (Task<string?>?)method.Invoke(null, new object?[] { user, user.Permissions, "testnonce" });
+        Assert.NotNull(task);
+        var script = await task.ConfigureAwait(false);
 
         // Assert
         Assert.NotNull(script);
@@ -1165,18 +1169,20 @@ public class RouteRegistrationExtensionsTests : IDisposable
     }
 
     [Fact]
-    public void TryBuildMetaObjectsScript_NullUser_ReturnsScriptExcludingPermissionedEntities()
+    public async Task TryBuildMetaObjectsScript_NullUser_ReturnsScriptExcludingPermissionedEntities()
     {
         // Arrange — register a permission-restricted entity
         _ = HostGalleryTestFixture.State;
 
         var method = typeof(RouteRegistrationExtensions).GetMethod(
-            "TryBuildMetaObjectsScript",
+            "TryBuildMetaObjectsScriptAsync",
             BindingFlags.NonPublic | BindingFlags.Static);
         Assert.NotNull(method);
 
         // Act — null user, no permissions
-        var script = (string?)method.Invoke(null, new object?[] { null, Array.Empty<string>(), "nonce" });
+        var task = (Task<string?>?)method.Invoke(null, new object?[] { null, Array.Empty<string>(), "nonce" });
+        Assert.NotNull(task);
+        var script = await task.ConfigureAwait(false);
 
         // Assert — script is still returned (may be empty list), but Customer is filtered out
         Assert.NotNull(script);

--- a/BareMetalWeb.Host/RouteHandlers.cs
+++ b/BareMetalWeb.Host/RouteHandlers.cs
@@ -598,7 +598,7 @@ public sealed class RouteHandlers : IRouteHandlers
         user.SetPassword(password);
         await Users.SaveAsync(user);
         await UserAuth.SignInAsync(context, user, rememberMe: true);
-        context.Response.Redirect("/account");
+        context.Response.Redirect("/system/me");
     }
 
     public async ValueTask LogoutHandler(BmwContext context)
@@ -793,6 +793,12 @@ public sealed class RouteHandlers : IRouteHandlers
         {
             context.Response.Redirect("/login");
         }
+    }
+
+    public ValueTask AccountRedirectHandler(BmwContext context)
+    {
+        context.Response.Redirect("/system/me");
+        return ValueTask.CompletedTask;
     }
 
     public async ValueTask AccountHandler(BmwContext context)
@@ -1021,7 +1027,7 @@ public sealed class RouteHandlers : IRouteHandlers
             var backupHtml = string.IsNullOrWhiteSpace(backupList)
                 ? string.Empty
                 : $"<div class=\"mt-3\"><p><strong>Backup codes (save these now):</strong></p><ul>{backupList}</ul><p class=\"text-warning\">These codes are shown once.</p></div>";
-            context.SetStringValue("html_message", "<p>MFA enabled successfully.</p>" + backupHtml + "<p><a href=\"/account\">Back to account</a></p>");
+            context.SetStringValue("html_message", "<p>MFA enabled successfully.</p>" + backupHtml + "<p><a href=\"/system/me\">Back to account</a></p>");
             await _renderer.RenderPage(context);
             return;
         }
@@ -1046,7 +1052,7 @@ public sealed class RouteHandlers : IRouteHandlers
             ctx.SetStringValue("title", "Reset MFA");
             if (!user.MfaEnabled)
             {
-                ctx.SetStringValue("html_message", "<p>MFA is not enabled for your account.</p><p><a href=\"/account\">Back to account</a></p>");
+                ctx.SetStringValue("html_message", "<p>MFA is not enabled for your account.</p><p><a href=\"/system/me\">Back to account</a></p>");
                 return true;
             }
 
@@ -1092,7 +1098,7 @@ public sealed class RouteHandlers : IRouteHandlers
         await Users.SaveAsync(user);
 
         context.SetStringValue("title", "Reset MFA");
-        context.SetStringValue("html_message", "<p>MFA has been reset.</p><p><a href=\"/account\">Back to account</a></p>");
+        context.SetStringValue("html_message", "<p>MFA has been reset.</p><p><a href=\"/system/me\">Back to account</a></p>");
         await _renderer.RenderPage(context);
     }
 

--- a/BareMetalWeb.Host/RouteRegistrationExtensions.cs
+++ b/BareMetalWeb.Host/RouteRegistrationExtensions.cs
@@ -167,6 +167,10 @@ public static class RouteRegistrationExtensions
 
         // Account management
         host.RegisterRoute("GET /account", new RouteHandlerData(
+            pageInfoFactory.TemplatedPage(mainTemplate, 302, Array.Empty<string>(), Array.Empty<string>(), "Authenticated", false, 1, navAlignment: NavAlignment.Right),
+            routeHandlers.AccountRedirectHandler));
+
+        host.RegisterRoute("GET /system/me", new RouteHandlerData(
             pageInfoFactory.TemplatedPage(mainTemplate, 200, new[] { "title", "html_message" }, new[] { "Account", "" }, "Authenticated", true, 1, navGroup: "Account", navAlignment: NavAlignment.Right),
             routeHandlers.AccountHandler));
 


### PR DESCRIPTION
## Summary
Fixes #1447
Fixes #1449
Fixes #1451
Fixes #1454

This batches the four related SPA regressions together because they all sit in the same vNext routing/account surface.

## What changed
- stopped the legacy router from booting on vNext-root pages, which removes the null setContent(...).innerHTML crash behind the metrics/navigation regressions
- gave the vNext router its own cancelNavigation() helper so /settings-style pages no longer throw ReferenceError: cancelNavigation is not defined
- removed the direct inline R.style.display = '' mutation during vNext bootstrap
- added a right-side vNext account link pointing to /system/me
- taught the SPA click interceptor to leave /account* and /system/me to the server-side account routes
- added GET /system/me as the canonical authenticated account page
- changed GET /account into a compatibility redirect to /system/me
- updated post-sign-in and “Back to account” links to use /system/me
- updated route-registration tests for the new canonical account route

## Validation
- dotnet build BareMetalWeb.sln ✅
- dotnet test BareMetalWeb.Host.Tests/BareMetalWeb.Host.Tests.csproj --filter RouteRegistrationExtensionsTests -v quiet ✅
- dotnet test BareMetalWeb.sln --no-build -v quiet ❌ still fails in unrelated existing suites on current main/branch (for example multiple BmwContext.TryLogFirstWriteLatency() null-reference failures in StaticAssetCacheTests / JsBundleServiceCompressionTests and other pre-existing failures outside the changed files)