### PR TITLE
fix: ensure AOT binary has execute permission in container

### DIFF
--- a/Dockerfile.prebuilt
+++ b/Dockerfile.prebuilt
@@ -21,6 +21,9 @@ WORKDIR /app
 ARG PUBLISH_DIR=./publish
 COPY --chown=app:app ${PUBLISH_DIR} .
 
+# Ensure AOT binary is executable (upload-artifact strips Unix permissions)
+RUN chmod +x ./BareMetalWeb.Host
+
 # Persistent data directory — mount a volume here in production
 VOLUME /app/Data
 


### PR DESCRIPTION
## Problem
`actions/upload-artifact` strips Unix file permissions. The native AOT binary `BareMetalWeb.Host` loses its `+x` execute bit during CI2 artifact transfer between the AOT publish job and the container build job.

This causes `permission denied` on container startup:
```
exec: "./BareMetalWeb.Host": permission denied
```

Both `baremetalweb` and `bmwrollout` AKS pods have been affected — baremetalweb has been in CrashLoopBackOff for 21+ hours.

## Fix
Add `RUN chmod +x ./BareMetalWeb.Host` in `Dockerfile.prebuilt` after the COPY step.

## Impact
All CI2 builds since run #173 produce broken container images. This fix will unblock the CI2 → CD pipeline.