### PR TITLE
fix: provide NoOpBufferedLogger in test host to fix StaticAssetCache NullRef (#1490)

### DIFF
--- a/BareMetalWeb.Host.Tests/BmwContextTestExtensions.cs
+++ b/BareMetalWeb.Host.Tests/BmwContextTestExtensions.cs
@@ -33,7 +33,7 @@ internal sealed class NullBareWebHost : IBareWebHost
     public static string[] appMetaDataKeys { get; set; } = Array.Empty<string>();
 
     public WebApplication app { get; set; } = null!;
-    public IBufferedLogger BufferedLogger => null!;
+    public IBufferedLogger BufferedLogger { get; } = new NoOpBufferedLogger();
     public IMetricsTracker Metrics { get; set; } = null!;
     public IClientRequestTracker ClientRequests => null!;
     public IHtmlRenderer HtmlRenderer => null!;
@@ -68,4 +68,17 @@ internal sealed class NullBareWebHost : IBareWebHost
     public Task RenderForbidden(BmwContext context) => Task.CompletedTask;
     public Task RequestHandler(BmwContext context) => Task.CompletedTask;
     public Task WireUpRequestHandlingAndLoggerAsyncLifetime() => Task.CompletedTask;
+}
+
+/// <summary>
+/// No-op logger for unit tests — avoids NullReferenceException in
+/// BmwContext.TryLogFirstWriteLatency when WriteResponseAsync is called.
+/// </summary>
+internal sealed class NoOpBufferedLogger : IBufferedLogger
+{
+    public void LogInfo(string message) { }
+    public void LogError(string message, Exception ex) { }
+    public Task RunAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    public void OnApplicationStopping(CancellationTokenSource cts, Task loggerTask) { }
+    public bool IsEnabled(BmwLogLevel level) => false;
 }


### PR DESCRIPTION
## Summary

Fixes #1490 — all 8 `ServeAsync_*` tests in `StaticAssetCacheTests` were failing with `NullReferenceException` in `BmwContext.TryLogFirstWriteLatency()`.

## Root Cause


## Fix

- Added `NoOpBufferedLogger` implementing `IBufferedLogger` with empty method bodies and `IsEnabled` returning `false` (short-circuits debug logging path)

## Verification

All 28 `StaticAssetCacheTests` pass (including the 8 previously-failing `ServeAsync` tests). No regressions in the remaining Host.Tests.