### PR TITLE
fix: forwarded headers, HTTP/2 keep-alive, and Ajax error tests (#1492)

### DIFF
--- a/BareMetalWeb.Core/BmwContext.cs
+++ b/BareMetalWeb.Core/BmwContext.cs
@@ -66,6 +66,9 @@ public sealed class BmwContext
     /// <summary>Request scheme (http or https).</summary>
     public string RequestScheme => _requestFeature.Scheme;
 
+    /// <summary>HTTP protocol version string (e.g. "HTTP/1.1", "HTTP/2").</summary>
+    public string RequestProtocol => _requestFeature.Protocol;
+
     /// <summary>True when the request arrived over HTTPS (or was forwarded as such).</summary>
     public bool IsHttps => string.Equals(RequestScheme, "https", StringComparison.OrdinalIgnoreCase);
 

--- a/BareMetalWeb.Host.Tests/BareMetalWebServerTests.cs
+++ b/BareMetalWeb.Host.Tests/BareMetalWebServerTests.cs
@@ -523,8 +523,7 @@ public class BareMetalWebServerTests : IDisposable
         // Act
         await _server.RequestHandler(context.ToBmw());
 
-        // Assert
-        Assert.Equal("true", context.Response.Headers["X-BareMetal-IsHttps"].ToString());
+        // Assert — forwarded HTTPS detected, so no HTTPS redirect (301) occurs
         Assert.NotEqual(301, context.Response.StatusCode);
     }
 
@@ -548,8 +547,7 @@ public class BareMetalWebServerTests : IDisposable
         // Act
         await _server.RequestHandler(context.ToBmw());
 
-        // Assert
-        Assert.Equal("true", context.Response.Headers["X-BareMetal-IsHttps"].ToString());
+        // Assert — Forwarded header proto=https detected, so no HTTPS redirect (301) occurs
         Assert.NotEqual(301, context.Response.StatusCode);
     }
 
@@ -569,8 +567,7 @@ public class BareMetalWebServerTests : IDisposable
         // Act
         await _server.RequestHandler(context.ToBmw());
 
-        // Assert
-        Assert.Equal("false", context.Response.Headers["X-BareMetal-IsHttps"].ToString());
+        // Assert — headers not trusted, so forwarded proto is ignored and redirect occurs
         Assert.Equal(301, context.Response.StatusCode);
     }
 

--- a/BareMetalWeb.Host/ApiErrorWriter.cs
+++ b/BareMetalWeb.Host/ApiErrorWriter.cs
@@ -85,6 +85,8 @@ internal static class ApiErrorWriter
         await using var writer = new Utf8JsonWriter(context.ResponseBody, WriterOptions);
         WriteErrorBody(writer, error);
         await writer.FlushAsync(ct);
+        // Flush the PipeWriter to push buffered bytes to the underlying transport/stream
+        await context.ResponseBody.FlushAsync(ct);
     }
 
     /// <summary>

--- a/BareMetalWeb.Host/BareMetalWebServer.cs
+++ b/BareMetalWeb.Host/BareMetalWebServer.cs
@@ -1178,9 +1178,9 @@ public class BareMetalWebServer : IBareWebHost
         context.ResponseHeaders["Permissions-Policy"] = "camera=(), microphone=(), geolocation=()";
         if (isHttps)
             context.ResponseHeaders["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains; preload";
-        // HTTP/1.x keep-alive hint — check protocol from request feature
-        var protocol = context.RequestHeaders[":protocol"];
-        if (protocol.Count == 0)
+        // HTTP/1.x keep-alive hint — skip for HTTP/2+ (connection multiplexing makes it unnecessary)
+        if (!context.RequestProtocol.StartsWith("HTTP/2", StringComparison.OrdinalIgnoreCase)
+            && !context.RequestProtocol.StartsWith("HTTP/3", StringComparison.OrdinalIgnoreCase))
             context.ResponseHeaders["Keep-Alive"] = "timeout=60, max=1000";
     }
 


### PR DESCRIPTION
## Summary

Fixes #1492 — 5 failing tests in `BareMetalWebServerTests`.

## Changes

### Production code (3 files)

**`BmwContext.cs`** — Added `RequestProtocol` property exposing `IHttpRequestFeature.Protocol` (e.g. "HTTP/1.1", "HTTP/2").

**`BareMetalWebServer.cs`** — Fixed HTTP/2 Keep-Alive detection in `ApplySecurityHeaders`. Was checking `:protocol` pseudo-header (unreliable in test/non-Kestrel contexts); now checks `RequestProtocol` string, skipping Keep-Alive for HTTP/2+.

**`ApiErrorWriter.cs`** — Added `PipeWriter.FlushAsync()` after `Utf8JsonWriter.FlushAsync()`. The `Utf8JsonWriter` only advances the `IBufferWriter` buffer; the PipeWriter itself must be flushed to push bytes to the underlying stream/transport.

### Test code (1 file)

**`BareMetalWebServerTests.cs`** — Updated 3 forwarded header tests to remove assertions on `X-BareMetal-IsHttps` diagnostic header (intentionally removed for security per code comment). Tests now verify no HTTPS redirect (301) occurs instead.

## Verification

All 5 previously-failing tests pass. 895 total Host.Tests: 24 failures (down from 29), all remaining are pre-existing (#1494, DeviceIdentity permissions, etc.).