### PR TITLE
fix: register DataScaffold entity metadata in PrincipalAuthorizationPolicyTests (#1495)

### DIFF
--- a/BareMetalWeb.Data.Tests/PrincipalAuthorizationPolicyTests.cs
+++ b/BareMetalWeb.Data.Tests/PrincipalAuthorizationPolicyTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using BareMetalWeb.Core;
 using BareMetalWeb.Data;
 using BareMetalWeb.Data.Interfaces;
 using Xunit;
@@ -24,6 +25,12 @@ public sealed class PrincipalAuthorizationPolicyTests : IDisposable
         _store = new DataObjectStore();
         _store.RegisterProvider(provider);
         DataStoreProvider.Current = _store;
+
+        // Register entity metadata so PrincipalAuthorizationPolicy helpers can
+        // resolve roles, usernames, and entity types via DataScaffold lookups.
+        DataScaffold.RegisterEntity<User>();
+        DataScaffold.RegisterEntity<SystemPrincipal>();
+        DataScaffold.RegisterEntity<AuditEntry>();
 
         _auditService = new AuditService(_store) { RunSynchronously = true };
     }


### PR DESCRIPTION
## Summary

Fixes #1495 — 17 failing PrincipalAuthorizationPolicy tests.

### Root Cause

Same pattern as #1494: the test fixture didn't register entity metadata with `DataScaffold`, so all metadata-driven helpers (`GetPrincipalRole`, `GetUserName`, `IsSystemPrincipal`) returned null/false.

### Fix

Added `DataScaffold.RegisterEntity<T>()` calls for `User`, `SystemPrincipal`, and `AuditEntry` in the test constructor.

### Testing

All 46 tests in `PrincipalAuthorizationPolicyTests` pass (previously 17 failing).