### PR TITLE
fix: MetadataExtractor lookup support and gallery package count (#1499)

### DIFF
--- a/BareMetalWeb.Runtime.Tests/SampleGalleryServiceTests.cs
+++ b/BareMetalWeb.Runtime.Tests/SampleGalleryServiceTests.cs
@@ -10,10 +10,10 @@ namespace BareMetalWeb.Runtime.Tests;
 public class SampleGalleryServiceTests
 {
     [Fact]
-    public void GetAllPackages_Returns_FourPackages()
+    public void GetAllPackages_Returns_FivePackages()
     {
         var packages = SampleGalleryService.GetAllPackages();
-        Assert.Equal(4, packages.Count);
+        Assert.Equal(5, packages.Count);
     }
 
     [Theory]
@@ -21,6 +21,7 @@ public class SampleGalleryServiceTests
     [InlineData("todo")]
     [InlineData("employee")]
     [InlineData("school")]
+    [InlineData("deployment-rings")]
     public void GetAllPackages_ContainsExpectedSlug(string slug)
     {
         var packages = SampleGalleryService.GetAllPackages();
@@ -32,6 +33,7 @@ public class SampleGalleryServiceTests
     [InlineData("todo")]
     [InlineData("employee")]
     [InlineData("school")]
+    [InlineData("deployment-rings")]
     public void GetPackage_BySlug_ReturnsPackage(string slug)
     {
         var pkg = SampleGalleryService.GetPackage(slug);
@@ -51,6 +53,7 @@ public class SampleGalleryServiceTests
     [InlineData("todo")]
     [InlineData("employee")]
     [InlineData("school")]
+    [InlineData("deployment-rings")]
     public void GetPackage_HasEntitiesAndFields(string slug)
     {
         var pkg = SampleGalleryService.GetPackage(slug)!;
@@ -106,6 +109,7 @@ public class SampleGalleryServiceTests
     [InlineData("todo")]
     [InlineData("employee")]
     [InlineData("school")]
+    [InlineData("deployment-rings")]
     public void GetPackage_HasNonEmptyNameAndDescription(string slug)
     {
         var pkg = SampleGalleryService.GetPackage(slug)!;

--- a/BareMetalWeb.Runtime/MetadataExtractor.cs
+++ b/BareMetalWeb.Runtime/MetadataExtractor.cs
@@ -152,14 +152,18 @@ public static class MetadataExtractor
         foreach (var (prop, attr) in properties)
         {
             var dataIndex = prop.GetCustomAttribute<DataIndexAttribute>();
+            var lookupAttr = prop.GetCustomAttribute<DataLookupAttribute>();
+            bool hasLookup = lookupAttr != null;
+            string? lookupSlug = hasLookup ? ResolveEntitySlug(lookupAttr!.TargetType) : null;
+
             FormFieldType? explicitType = attr!.FieldType != FormFieldType.Unknown
                 ? attr.FieldType
                 : null;
-            string fieldTypeStr = MapFieldTypeString(prop.PropertyType, explicitType, hasLookup: false);
+            string fieldTypeStr = MapFieldTypeString(prop.PropertyType, explicitType, hasLookup);
 
             string? enumValues = null;
             var effectivePropType = Nullable.GetUnderlyingType(prop.PropertyType) ?? prop.PropertyType;
-            if (effectivePropType.IsEnum)
+            if (effectivePropType.IsEnum && !hasLookup)
                 enumValues = string.Join("|", Enum.GetNames(effectivePropType));
 
             bool isNullable = Nullable.GetUnderlyingType(prop.PropertyType) != null
@@ -181,7 +185,10 @@ public static class MetadataExtractor
                 Create = attr.Create,
                 ReadOnly = attr.ReadOnly,
                 Placeholder = attr.Placeholder,
-                EnumValues = enumValues
+                EnumValues = enumValues,
+                LookupEntitySlug = lookupSlug,
+                LookupValueField = hasLookup ? lookupAttr!.ValueField : null,
+                LookupDisplayField = hasLookup ? lookupAttr!.DisplayField : null
             });
 
             if (dataIndex != null)


### PR DESCRIPTION
## Summary

Fixes #1499 — 2 failing Runtime.Tests.

### Changes

**MetadataExtractor.ExtractFromType — lookup attribute support**
- The `ExtractFromType` path was missing `DataLookupAttribute` handling (hardcoded `hasLookup: false`), so lookup fields like `DomainEventSubscription.SourceEntity` had no `LookupEntitySlug`
- Now reads `DataLookupAttribute` and populates `LookupEntitySlug`, `LookupValueField`, and `LookupDisplayField` — matching the existing `BuildFromMetadata` path

**SampleGalleryServiceTests — package count**
- Updated from 4 → 5 packages (deployment-rings was added)
- Added `deployment-rings` to all slug theory tests

### Testing
All 140 Runtime.Tests pass (0 failures).