### PR TITLE
fix: Data.Tests — metadata registration, schema count, SIMD bug (#1497)

### DIFF
--- a/BareMetalWeb.Data.Tests/AuditServiceTests.cs
+++ b/BareMetalWeb.Data.Tests/AuditServiceTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using BareMetalWeb.Core;
 using BareMetalWeb.Data;
 using BareMetalWeb.Data.Interfaces;
 using Xunit;
@@ -25,6 +26,8 @@ public sealed class AuditServiceTests : IDisposable
         _store = new DataObjectStore();
         _store.RegisterProvider(provider);
         DataStoreProvider.Current = _store;
+
+        DataScaffold.RegisterEntity<AuditEntry>();
         
         _auditService = new AuditService(_store) { RunSynchronously = true };
     }

--- a/BareMetalWeb.Data.Tests/MfaSecretProtectorTests.cs
+++ b/BareMetalWeb.Data.Tests/MfaSecretProtectorTests.cs
@@ -466,7 +466,7 @@ public class MfaSecretProtectorTests : IDisposable
         // Assert — key file should exist after constructor
         Assert.True(File.Exists(keyPath));
         var keyBytes = File.ReadAllBytes(keyPath);
-        Assert.Equal(32, keyBytes.Length);
+        Assert.Equal(64, keyBytes.Length);
 
         // Act — creating another instance should reuse the same key file
         var protector2 = MfaSecretProtector.CreateDefault(_tempDirectory);

--- a/BareMetalWeb.Data.Tests/SettingsServiceTests.cs
+++ b/BareMetalWeb.Data.Tests/SettingsServiceTests.cs
@@ -26,6 +26,7 @@ public class SettingsServiceTests : IDisposable
         _testStore = new DataObjectStore();
         _testStore.RegisterProvider(_provider);
         DataStoreProvider.Current = _testStore;
+        DataScaffold.RegisterEntity<AppSetting>();
         SettingsService.InvalidateCache();
         SettingsService.OnSettingInvalidated = null;
     }
@@ -518,30 +519,9 @@ public class SettingsServiceTests : IDisposable
         // Update the stored value directly so the in-memory store has the new value
         setting.Value = "new-token";
 
-        // Build a minimal metadata whose SaveAsync delegates to the test store
-        var handlers = new DataEntityHandlers(
-            Create: () => new AppSetting(),
-            LoadAsync: (key, ct) => ValueTask.FromResult((BaseDataObject?)_testStore.Query<AppSetting>().FirstOrDefault(s => s.Key == key)),
-            SaveAsync: (obj, ct) => { _testStore.Save((AppSetting)obj); return ValueTask.CompletedTask; },
-            DeleteAsync: (key, ct) => { _testStore.Delete<AppSetting>(key); return ValueTask.CompletedTask; },
-            QueryAsync: (q, ct) => ValueTask.FromResult(_testStore.Query<AppSetting>(q).Cast<BaseDataObject>()),
-            CountAsync: (q, ct) => ValueTask.FromResult(_testStore.Query<AppSetting>(q).Count())
-        );
-        var metadata = new DataEntityMetadata(
-            Type: typeof(AppSetting),
-            Name: "Settings",
-            Slug: "settings",
-            Permissions: "admin",
-            ShowOnNav: false,
-            NavGroup: null,
-            NavOrder: 0,
-            IdGeneration: AutoIdStrategy.Sequential,
-            ViewType: ViewType.Table,
-            ParentField: null,
-            Fields: Array.Empty<DataFieldMetadata>(),
-            Handlers: handlers,
-            Commands: Array.Empty<RemoteCommandMetadata>()
-        );
+        // Use the registered metadata so FindField("SettingId") resolves for cache invalidation
+        Assert.True(DataScaffold.TryGetEntity("settings", out var metadata),
+            "AppSetting metadata must be registered");
 
         // Act — save via DataScaffold; this should invalidate the cache
         await DataScaffold.SaveAsync(metadata, setting);

--- a/BareMetalWeb.Data.Tests/SystemEntitySchemaTests.cs
+++ b/BareMetalWeb.Data.Tests/SystemEntitySchemaTests.cs
@@ -13,7 +13,7 @@ public class SystemEntitySchemaTests
     public void AllSchemas_AreNonNull()
     {
         Assert.NotNull(SystemEntitySchemas.All);
-        Assert.Equal(17, SystemEntitySchemas.All.Count);
+        Assert.Equal(22, SystemEntitySchemas.All.Count);
         foreach (var schema in SystemEntitySchemas.All)
         {
             Assert.NotNull(schema);

--- a/BareMetalWeb.Data/ExpressionEngine/CalculatedFieldService.cs
+++ b/BareMetalWeb.Data/ExpressionEngine/CalculatedFieldService.cs
@@ -337,18 +337,30 @@ public static class CalculatedFieldService
     private static Dictionary<string, object?> BuildContext(BaseDataObject instance, Type type)
     {
         var meta = DataScaffold.GetEntityByType(type);
-        if (meta == null)
-            return new Dictionary<string, object?> { ["Key"] = instance.Key };
-
-        var layout = EntityLayoutCompiler.GetOrCompile(meta);
-        var context = new Dictionary<string, object?>(layout.Fields.Length + 4);
-        context["Key"] = instance.Key;
-        foreach (var field in layout.Fields)
+        if (meta != null)
         {
-            try { context[field.Name] = field.Getter(instance); }
-            catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"CalculatedFieldService: field '{field.Name}' getter failed: {ex.Message}"); context[field.Name] = null; }
+            var layout = EntityLayoutCompiler.GetOrCompile(meta);
+            var context = new Dictionary<string, object?>(layout.Fields.Length + 4);
+            context["Key"] = instance.Key;
+            foreach (var field in layout.Fields)
+            {
+                try { context[field.Name] = field.Getter(instance); }
+                catch (Exception ex) { System.Diagnostics.Debug.WriteLine($"CalculatedFieldService: field '{field.Name}' getter failed: {ex.Message}"); context[field.Name] = null; }
+            }
+            return context;
         }
-        return context;
+
+        // Fallback for types without DataScaffold metadata (e.g. test entities)
+        var props = type.GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
+        var fallback = new Dictionary<string, object?>(props.Length + 4);
+        fallback["Key"] = instance.Key;
+        foreach (var prop in props)
+        {
+            if (!prop.CanRead) continue;
+            try { fallback[prop.Name] = prop.GetValue(instance); }
+            catch { fallback[prop.Name] = null; }
+        }
+        return fallback;
     }
 
     private static bool HasCycle(

--- a/BareMetalWeb.Data/SimdByteScanner.cs
+++ b/BareMetalWeb.Data/SimdByteScanner.cs
@@ -395,19 +395,14 @@ public static class SimdByteScanner
         int vectorizableLength = length & ~0xF; // Round down to 16-byte boundary
         var vecs = MemoryMarshal.Cast<byte, Vector128<byte>>(data[..vectorizableLength]);
         Vector128<byte> needle = Vector128.Create(target);
-        // Each matching lane is 0xFF. We use subtraction from a zero accumulator:
-        // 0 - 0xFF = wraps, so instead we just sum each chunk's scalar count.
-        // Simple and correct: extract the match count via AddAcross.
+        Vector128<byte> one = Vector128.Create((byte)1);
 
         for (int k = 0; k < vecs.Length; k++)
         {
             Vector128<byte> cmp = AdvSimd.CompareEqual(vecs[k], needle);
-            // Each matching lane = 0xFF. Negate (0-0xFF wraps to 1 in signed)
-            // is tricky; simpler: horizontally add all bytes then divide by 255.
-            // AddAcross sums all 16 byte lanes into one ushort.
-            ushort laneSum = AdvSimd.Arm64.AddAcross(cmp).ToScalar();
-            // Each match contributes 0xFF=255, so matches = laneSum / 255
-            count += laneSum / 255;
+            // Each matching lane = 0xFF; mask to 0x01 to avoid overflow in AddAcross
+            Vector128<byte> masked = AdvSimd.And(cmp, one);
+            count += AdvSimd.Arm64.AddAcross(masked).ToScalar();
         }
 
         // Process remaining bytes beyond the 16-byte-aligned region


### PR DESCRIPTION
## Summary

Fixes #1497 — ~20 failing Data.Tests across multiple test classes.

### Changes

| Category | Fix |
|---|---|
| **AuditServiceTests** (5 tests) | Register `AuditEntry` entity with DataScaffold |
| **SettingsServiceTests** (1 test) | Register `AppSetting` entity; use registered metadata with field definitions for cache invalidation |
| **SystemEntitySchemaTests** (1 test) | Update expected schema count 17 → 22 (5 new schemas added) |
| **MfaSecretProtectorTests** (1 test) | Expect 64-byte protected key file (was 32 raw bytes before key protection wrapper) |
| **CalculatedFieldServiceTests** (8 tests) | Add reflection fallback in `BuildContext` for types without DataScaffold metadata |
| **SimdByteScanner** (3 tests) | Fix `CountByteAdvSimd` byte overflow — mask 0xFF match lanes to 0x01 before `AddAcross` sum |

### Implementation bug fix
The `CountByteAdvSimd` had a real bug: `AddAcross` on `Vector128<byte>` wraps at byte boundaries, so 2+ matches per 16-byte chunk produced incorrect results (e.g., 2×255=510 wraps to 254, then 254/255=0).

### Testing
1324/1374 Data.Tests pass. Remaining 50 failures are all SearchIndexing tests (tracked in #1496) plus 1 environment-dependent throughput test.