### PR TITLE
fix: SearchIndexManager reflection fallback for unregistered entity types (#1496)

### DIFF
--- a/BareMetalWeb.Data/SearchIndexing.cs
+++ b/BareMetalWeb.Data/SearchIndexing.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Numerics;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
@@ -384,23 +385,43 @@ public sealed class SearchIndexManager
         return _typeMetadata.GetOrAdd(type, t =>
         {
             var entityMeta = BareMetalWeb.Core.DataScaffold.GetEntityByType(t);
-            if (entityMeta == null)
-                return new TypeMetadata { IndexedFields = Array.Empty<IndexedFieldAccessor>(), IndexKinds = new HashSet<IndexKind>(0) };
-
-            var indexed = new List<IndexedFieldAccessor>();
-            var kinds = new HashSet<IndexKind>(4);
-            foreach (var f in entityMeta.Fields)
+            if (entityMeta != null)
             {
-                if (f.DataIndex != null)
+                var indexed = new List<IndexedFieldAccessor>();
+                var kinds = new HashSet<IndexKind>(4);
+                foreach (var f in entityMeta.Fields)
                 {
-                    indexed.Add(new IndexedFieldAccessor(f.Name, f.ClrType, f.GetValueFn, f.DataIndex));
-                    kinds.Add(f.DataIndex.Kind);
+                    if (f.DataIndex != null)
+                    {
+                        indexed.Add(new IndexedFieldAccessor(f.Name, f.ClrType, f.GetValueFn, f.DataIndex));
+                        kinds.Add(f.DataIndex.Kind);
+                    }
+                }
+                return new TypeMetadata
+                {
+                    IndexedFields = indexed.ToArray(),
+                    IndexKinds = kinds
+                };
+            }
+
+            // Fallback: scan properties for [DataIndex] attributes when DataScaffold metadata is unavailable
+            var props = t.GetProperties(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
+            var fallbackFields = new List<IndexedFieldAccessor>();
+            var fallbackKinds = new HashSet<IndexKind>(4);
+            foreach (var prop in props)
+            {
+                var attr = prop.GetCustomAttribute<DataIndexAttribute>();
+                if (attr != null && prop.CanRead)
+                {
+                    var getter = new Func<object, object?>(obj => prop.GetValue(obj));
+                    fallbackFields.Add(new IndexedFieldAccessor(prop.Name, prop.PropertyType, getter, attr));
+                    fallbackKinds.Add(attr.Kind);
                 }
             }
             return new TypeMetadata
             {
-                IndexedFields = indexed.ToArray(),
-                IndexKinds = kinds
+                IndexedFields = fallbackFields.ToArray(),
+                IndexKinds = fallbackKinds
             };
         });
     }


### PR DESCRIPTION
## Summary

Fixes #1496 — ~50 failing SearchIndexing tests.

### Root Cause

`SearchIndexManager.GetOrCreateTypeMetadata` relied solely on `DataScaffold.GetEntityByType()` to find indexed fields. When the entity type wasn't registered (e.g. test entities without `[DataEntity]`), it returned empty metadata — no indexed fields, no tokens, empty search results.

### Fix

Added a reflection fallback that scans properties for `[DataIndex]` attributes when DataScaffold metadata is unavailable. This is the same pattern applied to `CalculatedFieldService.BuildContext` in #1497.

### Testing

**All 1374 Data.Tests pass — 0 failures** (was 50 failing before this fix + #1497).