### PR TITLE
Metadata-driven GET ingress endpoint

### DIFF
--- a/BareMetalWeb.Data/DataScaffold.cs
+++ b/BareMetalWeb.Data/DataScaffold.cs
@@ -90,7 +90,8 @@ public sealed record DataEntityMetadata(
     IReadOnlyList<RemoteCommandMetadata> Commands,
     string? DefaultSortField = null,
     SortDirection DefaultSortDirection = SortDirection.Asc,
-    IReadOnlyList<DataFieldMetadata>? DocumentRelationFields = null
+    IReadOnlyList<DataFieldMetadata>? DocumentRelationFields = null,
+    bool EnableGetIngress = false
 )
 {
     private DataFieldMetadata[]? _listFields;

--- a/BareMetalWeb.Host/RouteRegistrationExtensions.cs
+++ b/BareMetalWeb.Host/RouteRegistrationExtensions.cs
@@ -146,6 +146,11 @@ public static class RouteRegistrationExtensions
                     await context.Response.WriteAsync("{\"status\":\"not_ready\",\"reason\":\"Server is still initializing\"}");
                 }
             }));
+
+        // GET ingress HTML form — user-facing page for entities with EnableGetIngress
+        host.RegisterRoute("GET /queryinput/{type}", new RouteHandlerData(
+            pageInfoFactory.RawPage("Public", false),
+            async context => await HandleGetIngest(context, json: false)));
     }
 
     /// <summary>
@@ -929,6 +934,11 @@ public static class RouteRegistrationExtensions
                     JsonWriterHelper.WriteValue(w, new Dictionary<string, object?> { ["nodes"] = nodes, ["links"] = links });
                 }
             }));
+
+        // GET ingress — must precede /api/{type}/{id} to avoid '_ingest' matching {id}
+        host.RegisterRoute("GET /api/{type}/_ingest", new RouteHandlerData(
+            pageInfoFactory.RawPage("Authenticated", false),
+            async context => await HandleGetIngest(context, json: true)));
 
         // List and create
         host.RegisterRoute("GET /api/{type}", new RouteHandlerData(
@@ -4338,5 +4348,131 @@ public static class RouteRegistrationExtensions
                 }
                 await context.Response.Body.WriteAsync(ms.ToArray()).ConfigureAwait(false);
             }));
+    }
+
+    // ── GET ingress handler ────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Shared handler for <c>GET /api/{type}/_ingest?text=…</c> (JSON response)
+    /// and <c>GET /queryinput/{type}?text=…</c> (HTML form response).
+    /// Creates a record on the target entity using the metadata-flagged ingress field.
+    /// </summary>
+    private static async Task HandleGetIngest(BmwContext context, bool json)
+    {
+        var slug = GetRouteParam(context, "type") ?? string.Empty;
+        var registry = RuntimeEntityRegistry.Current;
+        var walProvider = DataStoreProvider.PrimaryProvider as WalDataProvider;
+
+        if (walProvider == null)
+        {
+            context.Response.StatusCode = 503;
+            if (json) await context.Response.WriteAsync("{\"ok\":false,\"error\":\"Storage unavailable\"}");
+            else      await context.Response.WriteAsync("Storage unavailable.");
+            return;
+        }
+
+        if (!registry.TryGet(slug, out var model) || !model.EnableGetIngress)
+        {
+            context.Response.StatusCode = 404;
+            if (json) await context.Response.WriteAsync("{\"ok\":false,\"error\":\"Entity not found or ingress not enabled\"}");
+            else      await context.Response.WriteAsync("Entity not found or GET ingress not enabled.");
+            return;
+        }
+
+        // Find the ingress-target field
+        int targetOrd = -1;
+        string targetName = "";
+        foreach (var f in model.Fields)
+        {
+            if (f.IsIngressTarget)
+            {
+                targetOrd = f.Ordinal;
+                targetName = f.Name;
+                break;
+            }
+        }
+
+        if (targetOrd < 0)
+        {
+            context.Response.StatusCode = 400;
+            if (json) await context.Response.WriteAsync("{\"ok\":false,\"error\":\"No ingress target field configured\"}");
+            else      await context.Response.WriteAsync("No ingress target field is configured for this entity.");
+            return;
+        }
+
+        var text = context.HttpRequest.Query.ContainsKey("text")
+            ? context.HttpRequest.Query["text"].ToString()
+            : null;
+
+        // If text was provided, create the record
+        uint recordKey = 0;
+        if (!string.IsNullOrWhiteSpace(text))
+        {
+            var schema = EntitySchemaFactory.FromModel(model);
+            var record = schema.CreateRecord();
+            record.EntityTypeName = model.Name;
+            record.SetValue(targetOrd, text);
+            walProvider.SaveRecord(record, schema);
+            recordKey = record.Key;
+        }
+
+        if (json)
+        {
+            context.Response.ContentType = "application/json";
+            await using var w = new Utf8JsonWriter(context.Response.Body, s_compactWriterOptions);
+            w.WriteStartObject();
+
+            if (!string.IsNullOrWhiteSpace(text))
+            {
+                w.WriteBoolean("ok", true);
+                w.WriteNumber("id", recordKey);
+            }
+            else
+            {
+                w.WriteBoolean("ok", false);
+                w.WriteString("error", "Query parameter 'text' is required");
+            }
+
+            w.WriteEndObject();
+        }
+        else
+        {
+            var entityLabel = WebUtility.HtmlEncode(model.Name);
+            var fieldLabel = WebUtility.HtmlEncode(targetName);
+            var sb = new StringBuilder(1024);
+            sb.Append("<!DOCTYPE html><html><head><meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">");
+            sb.Append("<title>").Append(entityLabel).Append(" — Quick Input</title><style>");
+            sb.Append("*{margin:0;padding:0;box-sizing:border-box}");
+            sb.Append("body{font-family:system-ui,-apple-system,sans-serif;background:#f4f6f9;color:#333}");
+            sb.Append("header{background:#1a1a2e;color:#fff;padding:16px 24px;font-size:1.4em;font-weight:600}");
+            sb.Append(".container{max-width:600px;margin:24px auto;padding:0 16px}");
+            sb.Append("form{display:flex;gap:8px;margin-bottom:24px}");
+            sb.Append("input[type=text]{flex:1;padding:10px 14px;border:1px solid #ccc;border-radius:6px;font-size:1em}");
+            sb.Append("button{padding:10px 20px;background:#4361ee;color:#fff;border:none;border-radius:6px;font-size:1em;cursor:pointer}");
+            sb.Append("button:hover{background:#3a56d4}");
+            sb.Append(".msg{padding:12px 16px;border-radius:6px;margin-bottom:16px;font-size:.95em}");
+            sb.Append(".msg-ok{background:#e8f5e9;color:#2e7d32}.msg-err{background:#fce4ec;color:#c62828}");
+            sb.Append("footer{text-align:center;padding:24px;color:#999;font-size:.85em}");
+            sb.Append("</style></head><body>");
+            sb.Append("<header>&#9998; ").Append(entityLabel).Append(" — Quick Input</header>");
+            sb.Append("<div class=\"container\">");
+
+            if (!string.IsNullOrWhiteSpace(text))
+            {
+                sb.Append("<div class=\"msg msg-ok\">&#10003; Saved to <b>")
+                  .Append(fieldLabel).Append("</b> (id ").Append(recordKey).Append(")</div>");
+            }
+
+            sb.Append("<form method=\"get\" action=\"/queryinput/")
+              .Append(WebUtility.HtmlEncode(slug)).Append("\">");
+            sb.Append("<input type=\"text\" name=\"text\" placeholder=\"Enter ").Append(fieldLabel).Append("...\" value=\"\" autofocus>");
+            sb.Append("<button type=\"submit\">Submit</button>");
+            sb.Append("</form>");
+
+            sb.Append("</div><footer>BareMetalWeb &middot; ").Append(entityLabel).Append("</footer></body></html>");
+
+            context.Response.ContentType = "text/html";
+            await context.Response.WriteAsync(sb.ToString());
+        }
     }
 }

--- a/BareMetalWeb.Runtime/EntityDefinition.cs
+++ b/BareMetalWeb.Runtime/EntityDefinition.cs
@@ -56,5 +56,13 @@ public class EntityDefinition : BaseDataObject
     [DataField(Label = "Form Layout", Order = 11, Placeholder = "Standard | Wizard")]
     public string FormLayout { get; set; } = "Standard";
 
+    /// <summary>
+    /// When true, registers a GET-based ingress route (<c>/api/{slug}/_ingest?text=…</c>
+    /// and <c>/queryinput/{slug}?text=…</c>) that creates a record by populating
+    /// the field marked <see cref="FieldDefinition.IsIngressTarget"/>.
+    /// </summary>
+    [DataField(Label = "Enable GET Ingress", Order = 12)]
+    public bool EnableGetIngress { get; set; } = false;
+
     public override string ToString() => Name;
 }

--- a/BareMetalWeb.Runtime/FieldDefinition.cs
+++ b/BareMetalWeb.Runtime/FieldDefinition.cs
@@ -171,5 +171,14 @@ public class FieldDefinition : BaseDataObject
     [DataField(Label = "Column Span", Order = 38)]
     public int ColumnSpan { get; set; } = 12;
 
+    /// <summary>
+    /// Marks this field as the target for the GET ingress endpoint.
+    /// When the parent entity has <see cref="EntityDefinition.EnableGetIngress"/> = true,
+    /// the <c>text</c> query-string parameter is written to this field.
+    /// Only one field per entity should have this set.
+    /// </summary>
+    [DataField(Label = "Is Ingress Target", Order = 39)]
+    public bool IsIngressTarget { get; set; } = false;
+
     public override string ToString() => $"{Name} ({Type})";
 }

--- a/BareMetalWeb.Runtime/RuntimeEntityCompiler.cs
+++ b/BareMetalWeb.Runtime/RuntimeEntityCompiler.cs
@@ -118,7 +118,8 @@ public sealed class RuntimeEntityCompiler : IRuntimeEntityCompiler
                 CascadeFromField: f.CascadeFromField,
                 CascadeFilterField: f.CascadeFilterField,
                 FieldGroup: f.FieldGroup,
-                ColumnSpan: f.ColumnSpan
+                ColumnSpan: f.ColumnSpan,
+                IsIngressTarget: f.IsIngressTarget
             ));
         }
 
@@ -186,6 +187,7 @@ public sealed class RuntimeEntityCompiler : IRuntimeEntityCompiler
             version: entity.Version,
             schemaHash: schemaHash,
             formLayout: entity.FormLayout ?? "Standard",
+            enableGetIngress: entity.EnableGetIngress,
             fields: compiledFields.AsReadOnly(),
             indexes: compiledIndexes.AsReadOnly(),
             actions: compiledActions.AsReadOnly()

--- a/BareMetalWeb.Runtime/RuntimeEntityModel.cs
+++ b/BareMetalWeb.Runtime/RuntimeEntityModel.cs
@@ -37,6 +37,7 @@ public sealed class RuntimeEntityModel
         int version,
         string schemaHash,
         string formLayout,
+        bool enableGetIngress,
         IReadOnlyList<RuntimeFieldModel> fields,
         IReadOnlyList<RuntimeIndexModel> indexes,
         IReadOnlyList<RuntimeActionModel> actions)
@@ -52,6 +53,7 @@ public sealed class RuntimeEntityModel
         Version = version;
         SchemaHash = schemaHash;
         FormLayout = formLayout;
+        EnableGetIngress = enableGetIngress;
         Fields = fields;
         Indexes = indexes;
         Actions = actions;
@@ -72,6 +74,9 @@ public sealed class RuntimeEntityModel
 
     /// <summary>Form layout: "Standard" or "Wizard".</summary>
     public string FormLayout { get; }
+
+    /// <summary>When true, a GET ingress route is registered for this entity.</summary>
+    public bool EnableGetIngress { get; }
 
     public IReadOnlyList<RuntimeFieldModel> Fields { get; }
     public IReadOnlyList<RuntimeIndexModel> Indexes { get; }
@@ -240,7 +245,8 @@ public sealed class RuntimeEntityModel
             Fields: fields,
             Handlers: handlers,
             Commands: commands,
-            DocumentRelationFields: docRelFields
+            DocumentRelationFields: docRelFields,
+            EnableGetIngress: EnableGetIngress
         );
     }
 }

--- a/BareMetalWeb.Runtime/RuntimeFieldModel.cs
+++ b/BareMetalWeb.Runtime/RuntimeFieldModel.cs
@@ -66,5 +66,6 @@ public sealed record RuntimeFieldModel(
     string? CascadeFromField = null,
     string? CascadeFilterField = null,
     string? FieldGroup = null,
-    int ColumnSpan = 12
+    int ColumnSpan = 12,
+    bool IsIngressTarget = false
 );


### PR DESCRIPTION
## Summary

Adds a metadata-driven GET ingress feature that lets any runtime entity accept text via query string — generalizing the hardcoded `/ideas/search` pattern.

### New metadata flags
| Flag | On | Purpose |
|------|------|---------|
| `EnableGetIngress` | `EntityDefinition` | Opts an entity into GET ingress routes |
| `IsIngressTarget` | `FieldDefinition` | Marks which field receives the `?text=` value |

### New routes (active only when flags are set)
| Route | Response | Auth |
|-------|----------|------|
| `GET /api/{slug}/_ingest?text=…` | JSON `{"ok":true,"id":123}` | Authenticated |
| `GET /queryinput/{slug}?text=…` | HTML form page | Public |

### Files changed (7)
- `EntityDefinition.cs` — `EnableGetIngress` property (Order=12)
- `FieldDefinition.cs` — `IsIngressTarget` property (Order=39)
- `RuntimeFieldModel.cs` — plumb `IsIngressTarget`
- `RuntimeEntityModel.cs` — plumb `EnableGetIngress`, pass to `DataEntityMetadata`
- `RuntimeEntityCompiler.cs` — wire both flags through compilation
- `DataScaffold.cs` — `EnableGetIngress` on `DataEntityMetadata` record
- `RouteRegistrationExtensions.cs` — `HandleGetIngest()` handler + route registration

### Testing
- ✅ Build: 0 errors
- ✅ Runtime tests: 140/140 pass
- ✅ Host tests: no regressions (353 pre-existing failures unchanged)

Fixes #1518